### PR TITLE
Chore: spotless 플러그인 추가

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,4 +30,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Test with Gradle
-        run: ./gradlew clean test --stacktrace --parallel
+        run: ./gradlew projectTest --stacktrace --parallel

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,3 +76,9 @@ tasks.register<Exec>("makeGitHooksExecutable") {
 tasks.compileJava {
     dependsOn("makeGitHooksExecutable")
 }
+
+tasks.register("projectTest") {
+    dependsOn("spotlessJavaCheck")
+    dependsOn("compileJava")
+    dependsOn("test")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "3.3.1"
     id("io.spring.dependency-management") version "1.1.5"
+    id("com.diffplug.spotless") version "6.25.0"
 }
 
 group = "com.dnd"
@@ -29,4 +30,34 @@ tasks.withType<Test> {
 
 tasks.bootBuildImage {
     createdDate = "now"
+}
+
+spotless {
+    encoding = Charsets.UTF_8
+
+    java {
+        target("**/*.java")
+        targetExclude("build/**", "**/*Request*.java", "**/*Response*.java", "**/*Dto*.java")
+        palantirJavaFormat("2.47.0")
+    }
+
+    java {
+        target("**/*.java")
+        endWithNewline()
+        indentWithSpaces(4)
+        trimTrailingWhitespace()
+        importOrder("", "java|javax", "\\#").wildcardsLast()
+        removeUnusedImports()
+        formatAnnotations()
+    }
+
+    format("misc") {
+        // define the files to apply `misc` to
+        target("*.gradle", "*.gradle.*", ".gitattributes", ".gitignore")
+
+        // define the steps to apply to those files
+        endWithNewline()
+        indentWithSpaces(4)
+        trimTrailingWhitespace()
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,3 +61,18 @@ spotless {
         trimTrailingWhitespace()
     }
 }
+
+tasks.register<Copy>("updateGitHooks") {
+    from("scripts/pre-commit.sh")
+    into(".git/hooks")
+    rename("pre-commit.sh", "pre-commit")
+}
+
+tasks.register<Exec>("makeGitHooksExecutable") {
+    commandLine("chmod", "+x", ".git/hooks/pre-commit")
+    dependsOn("updateGitHooks")
+}
+
+tasks.compileJava {
+    dependsOn("makeGitHooksExecutable")
+}

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+# Part 1
+stagedFiles=$(git diff --staged --name-only)
+
+# Part 2
+echo "Running spotlessApply. Formatting code..."
+cd "$PROJECT_ROOT" && ./gradlew spotlessApply
+
+# Checking the exit status
+if [ $? -ne 0 ]; then
+    echo "Spotless apply failed!"
+    exit 1
+fi
+
+# Part 3
+for file in $stagedFiles; do
+  if test -f "$file"; then
+    git add "$file"
+  fi
+done

--- a/src/test/java/com/dnd/runus/RunUsApplicationTests.java
+++ b/src/test/java/com/dnd/runus/RunUsApplicationTests.java
@@ -5,9 +5,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class RunUsApplicationTests {
-
     @Test
-    void contextLoads() {
-    }
-
+    void contextLoads() {}
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #4 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- spotless 플러그인을 추가합니다.
- 스프링 프로그램을 실행하거나, `./gradlew compileJava`를 실행하면 사용할 준비가 끝납니다.
- 이후에는 git에 staged된 파일들을 커밋할 경우, 자동으로 palantir 스타일을 적용합니다.
- palantir import순서보단 인텔리제이 import 순서와 동일하게 합니다.
  - 임의 import, java, static 순서
- 스타일을 체크하도록 테스트하는 `projectTest` gradle task를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 매번 `./gradlew spotlessApply`를 실행시키면 귀찮을 것 같아서,
   git pre commit 스크립트로 자동화하도록 했어요.
  
   그래서 커밋할때 살짝 버벅이는 것 같은데, 이 부분이 괜찮을까요?
