### PR TITLE
Fix: imageName에서 version을 가져오도록 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 }
 
 group = "com.dnd"
-version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
@@ -53,15 +52,13 @@ tasks.withType<Test> {
 
 tasks.bootBuildImage {
     createdDate = "now"
-}
-
-springBoot {
-    buildInfo {
-        properties {
-            setVersion(System.getProperty("WAS_TAG") ?: "Unknown")
-        }
+    doFirst {
+        version = imageName.get().substringAfterLast(":", "Unknown")
+        println("Setting version to: $version")
     }
 }
+
+springBoot.buildInfo { properties {} }
 
 spotless {
     encoding = Charsets.UTF_8


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #9 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- WAS 버전은 docker image tag에서 가져오도록 수정합니다.
- 스웨거 접속시, image tag를 version 항목에서 확인할 수 있습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
