### PR TITLE
Feat: API 공통 핸들러 추가

### DIFF
--- a/src/main/java/com/dnd/runus/global/exception/BaseException.java
+++ b/src/main/java/com/dnd/runus/global/exception/BaseException.java
@@ -1,0 +1,21 @@
+package com.dnd.runus.global.exception;
+
+import com.dnd.runus.global.exception.type.ErrorType;
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+    private final ErrorType type;
+    private final String message;
+
+    public BaseException(ErrorType type, String message) {
+        super(message);
+        this.type = type;
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return "에러 타입: " + type + ", 사유: " + message;
+    }
+}

--- a/src/main/java/com/dnd/runus/global/exception/BusinessException.java
+++ b/src/main/java/com/dnd/runus/global/exception/BusinessException.java
@@ -1,0 +1,9 @@
+package com.dnd.runus.global.exception;
+
+import com.dnd.runus.global.exception.type.ErrorType;
+
+public class BusinessException extends BaseException {
+    public BusinessException(ErrorType type, String message) {
+        super(type, message);
+    }
+}

--- a/src/main/java/com/dnd/runus/global/exception/NotFoundException.java
+++ b/src/main/java/com/dnd/runus/global/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.dnd.runus.global.exception;
+
+import com.dnd.runus.global.exception.type.PersistenceErrorType;
+
+public class NotFoundException extends BaseException {
+    public NotFoundException(String message) {
+        super(PersistenceErrorType.ENTITY_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -1,0 +1,11 @@
+package com.dnd.runus.global.exception.type;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorType {
+    String name();
+
+    HttpStatus httpStatus();
+
+    String message();
+}

--- a/src/main/java/com/dnd/runus/global/exception/type/PersistenceErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/PersistenceErrorType.java
@@ -1,0 +1,21 @@
+package com.dnd.runus.global.exception.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.springframework.http.HttpStatus;
+
+import static lombok.AccessLevel.PACKAGE;
+import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@Accessors(fluent = true)
+@RequiredArgsConstructor(access = PACKAGE)
+public enum PersistenceErrorType implements ErrorType {
+    ENTITY_NOT_FOUND(NOT_FOUND, "해당 엔티티를 찾을 수 없습니다"),
+    CONSTRAINT_VIOLATION(NOT_ACCEPTABLE, "제약 조건에 어긋나는 값은 저장할 수 없습니다"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/dnd/runus/global/exception/type/WebErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/WebErrorType.java
@@ -1,0 +1,24 @@
+package com.dnd.runus.global.exception.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.springframework.http.HttpStatus;
+
+import static lombok.AccessLevel.PACKAGE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Getter
+@Accessors(fluent = true)
+@RequiredArgsConstructor(access = PACKAGE)
+public enum WebErrorType implements ErrorType {
+    UNHANDLED_EXCEPTION(INTERNAL_SERVER_ERROR, "직접적으로 처리되지 않은 예외, 문의해주세요"),
+    FAILED_VALIDATION(BAD_REQUEST, "Request 요청에서 올바르지 않은 값이 있습니다"),
+    FAILED_PARSING(BAD_REQUEST, "Request JSON body를 파싱하지 못했습니다"),
+    UNSUPPORTED_API(BAD_REQUEST, "지원하지 않는 API입니다"),
+    COOKIE_NOT_FOND(BAD_REQUEST, "요청에 쿠키가 필요합니다"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/dnd/runus/presentation/dto/response/ApiErrorResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/dto/response/ApiErrorResponse.java
@@ -1,0 +1,61 @@
+package com.dnd.runus.presentation.dto.response;
+
+import com.dnd.runus.global.exception.type.ErrorType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.ResponseEntity;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Schema(description = "API 애러 응답 형식")
+@Getter
+@ToString
+@Builder(access = PRIVATE)
+public class ApiErrorResponse {
+    @Schema(description = "요청 경로", example = "/api/v1/auth/login")
+    private final String path;
+    @Schema(description = "응답 상태 코드", example = "400")
+    private final int statusCode;
+    @Schema(description = "응답 상태 코드 이름", example = "BAD_REQUEST")
+    private final String statusName;
+    @Schema(description = "응답 코드 이름", example = "FAILED_AUTHENTICATION")
+    private final String codeName;
+    @Schema(description = "응답 메시지", example = "인증에 실패했습니다")
+    private final String message;
+
+    public static ResponseEntity<ApiErrorResponse> toResponseEntity(
+            @NotNull ErrorType errorCode,
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        return ResponseEntity.status(errorCode.httpStatus().value())
+                .body(of(errorCode, exception.getMessage(), request));
+    }
+
+    public static ResponseEntity<ApiErrorResponse> toResponseEntity(
+            @NotNull ErrorType errorCode,
+            String message,
+            HttpServletRequest request
+    ) {
+        return ResponseEntity.status(errorCode.httpStatus().value())
+                .body(of(errorCode, message, request));
+    }
+
+    private static ApiErrorResponse of(
+            @NotNull ErrorType errorCode,
+            String message,
+            HttpServletRequest request
+    ) {
+        return ApiErrorResponse.builder()
+                .path(request.getServletPath())
+                .statusCode(errorCode.httpStatus().value())
+                .statusName(errorCode.httpStatus().name())
+                .codeName(errorCode.name())
+                .message(errorCode.message() + ", " + message)
+                .build();
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/dto/response/ApiSuccessResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/dto/response/ApiSuccessResponse.java
@@ -1,0 +1,18 @@
+package com.dnd.runus.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNullElse;
+
+@Schema(description = "API 성공 응답 형식")
+public record ApiSuccessResponse<T>(
+        @Schema(description = "응답 상태 코드", example = "200")
+        int statusCode,
+        @Schema(description = "응답 데이터")
+        T data
+) {
+    public static <T> ApiSuccessResponse<?> of(int statusCode, T data) {
+        return new ApiSuccessResponse<>(statusCode, requireNonNullElse(data, emptyMap()));
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/handler/ExceptionRestHandler.java
+++ b/src/main/java/com/dnd/runus/presentation/handler/ExceptionRestHandler.java
@@ -1,0 +1,45 @@
+package com.dnd.runus.presentation.handler;
+
+import com.dnd.runus.global.exception.BaseException;
+import com.dnd.runus.global.exception.type.WebErrorType;
+import com.dnd.runus.presentation.dto.response.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionRestHandler {
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiErrorResponse> handleBaseException(BaseException e, HttpServletRequest request) {
+        log.warn(e.getMessage(), e);
+        return ApiErrorResponse.toResponseEntity(e.getType(), e.getMessage(), request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        log.error(e.getMessage(), e);
+        return ApiErrorResponse.toResponseEntity(WebErrorType.UNHANDLED_EXCEPTION, e.getMessage(), request);
+    }
+
+    ////////////////// 직렬화 / 역직렬화 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
+        log.warn(ex.getBindingResult().getAllErrors().toString());
+        return ApiErrorResponse.toResponseEntity(
+                WebErrorType.FAILED_VALIDATION,
+                ex.getBindingResult().getAllErrors().toString(),
+                request);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(WebErrorType.FAILED_PARSING, ex, request);
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/handler/SuccessResponseHandlerAdvise.java
+++ b/src/main/java/com/dnd/runus/presentation/handler/SuccessResponseHandlerAdvise.java
@@ -1,0 +1,40 @@
+package com.dnd.runus.presentation.handler;
+
+import com.dnd.runus.presentation.dto.response.ApiSuccessResponse;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "com.dnd.runus")
+public class SuccessResponseHandlerAdvise implements ResponseBodyAdvice<Object> {
+    @Override
+    public boolean supports(@Nonnull MethodParameter returnType, @Nonnull Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, @Nonnull MethodParameter returnType,
+                                  @Nonnull MediaType selectedContentType, @Nonnull Class selectedConverterType,
+                                  @Nonnull ServerHttpRequest request, @Nonnull ServerHttpResponse response) {
+        HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+
+        int status = servletResponse.getStatus();
+        HttpStatus resolve = HttpStatus.resolve(status);
+        if (resolve == null || !resolve.is2xxSuccessful()) {
+            return body;
+        }
+
+        if (body instanceof String str) {
+            // FIXME: body가 String일 경우, ApiSuccessResponse.of()로 감싸면 에러 발생
+            return str;
+        }
+        return ApiSuccessResponse.of(status, body);
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #15 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- API 공통 형식 핸들러를 추가합니다.
- 아직 iOS팀과 상의하진 않아서 필드는 추후 회의하고 변경하면 좋을 것 같아요

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- `ResponseBodyAdvice<Object>`를 사용했는데, Controller에서 String을 반환하면 에러가 발생해요. 그런데 찾아봐도 못 찾겠어서 일단 `ApiSuccessResponse`로 감싸지 않고 그대로 반환하도록 했습니다.
