### PR TITLE
Fix: windows 환경에서도 포메팅 스크립트가 실행하도록 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,15 +93,14 @@ tasks.register<Copy>("updateGitHooks") {
     from("scripts/pre-commit.sh")
     into(".git/hooks")
     rename("pre-commit.sh", "pre-commit")
-}
-
-tasks.register<Exec>("makeGitHooksExecutable") {
-    commandLine("chmod", "+x", ".git/hooks/pre-commit")
-    dependsOn("updateGitHooks")
+    doLast {
+        val preCommitHook = file(".git/hooks/pre-commit")
+        preCommitHook.setExecutable(true, false)
+    }
 }
 
 tasks.compileJava {
-    dependsOn("makeGitHooksExecutable")
+    dependsOn("updateGitHooks")
 }
 
 tasks.register("projectTest") {

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -7,7 +7,12 @@ stagedFiles=$(git diff --staged --name-only)
 
 # Part 2
 echo "Running spotlessApply. Formatting code..."
-cd "$PROJECT_ROOT" && ./gradlew spotlessApply
+
+if [ "$OS" = "Windows_NT" ]; then
+    cd "$PROJECT_ROOT" && ./gradlew.bat spotlessApply
+else
+    cd "$PROJECT_ROOT" && ./gradlew spotlessApply
+fi
 
 # Checking the exit status
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #4

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `chmod` 대신 `file.setExecutable()`를 사용홥니다.
- `pre-commit.sh`에 OS에 따라 다르게 처리합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 안되면 말씀해주세요!
