### PR TITLE
Feat: member profile, badge 엔티티 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/badge/entity/Badge.java
+++ b/src/main/java/com/dnd/runus/domain/badge/entity/Badge.java
@@ -1,0 +1,48 @@
+package com.dnd.runus.domain.badge.entity;
+
+import com.dnd.runus.global.constant.BadgeType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Badge {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Size(max = 20)
+    private String name;
+
+    @NotNull
+    @Size(max = 100)
+    private String description;
+
+    @NotNull
+    private String imagePath;
+
+    @NotNull
+    @Enumerated(STRING)
+    private BadgeType type;
+
+    @NotNull
+    private Integer requiredValue;
+
+    public static Badge of(String name, String description, String imagePath, BadgeType type, Integer requiredValue) {
+        Badge badge = new Badge();
+        badge.name = name;
+        badge.description = description;
+        badge.imagePath = imagePath;
+        badge.type = type;
+        badge.requiredValue = requiredValue;
+        return badge;
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/badge/entity/BadgeAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/badge/entity/BadgeAchievement.java
@@ -1,0 +1,34 @@
+package com.dnd.runus.domain.badge.entity;
+
+import com.dnd.runus.domain.member.entity.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class BadgeAchievement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    private Badge badge;
+
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    private Member member;
+
+    public static BadgeAchievement of(Badge badge, Member member) {
+        BadgeAchievement badgeAchievement = new BadgeAchievement();
+        badgeAchievement.badge = badge;
+        badgeAchievement.member = member;
+        return badgeAchievement;
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/level/entity/Level.java
+++ b/src/main/java/com/dnd/runus/domain/level/entity/Level.java
@@ -1,0 +1,26 @@
+package com.dnd.runus.domain.level.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Level {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private Integer requiredMinExp;
+}

--- a/src/main/java/com/dnd/runus/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/runus/domain/member/entity/Member.java
@@ -2,12 +2,12 @@ package com.dnd.runus.domain.member.entity;
 
 import com.dnd.runus.domain.common.BaseTimeEntity;
 import com.dnd.runus.global.constant.MemberRole;
-import com.dnd.runus.global.constant.SocialType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
@@ -25,20 +25,25 @@ public class Member extends BaseTimeEntity {
     private MemberRole role;
 
     @NotNull
-    private String oauthId;
+    @Size(max = 20)
+    private String nickname;
 
-    @NotNull
-    @Enumerated(STRING)
-    private SocialType socialType;
+    private Long badgeId;
 
-    @NotNull
-    private String oauthEmail;
+    @Embedded
+    @Accessors(fluent = true)
+    private SocialProfile social;
 
-    @Builder
-    private Member(MemberRole role, String oauthId, SocialType socialType, String oauthEmail) {
-        this.role = role;
-        this.oauthId = oauthId;
-        this.socialType = socialType;
-        this.oauthEmail = oauthEmail;
+    @Embedded
+    @Accessors(fluent = true)
+    private PersonalProfile personal;
+
+    public static Member of(MemberRole role, String nickname, SocialProfile social, PersonalProfile personal) {
+        Member member = new Member();
+        member.role = role;
+        member.nickname = nickname;
+        member.social = social;
+        member.personal = personal;
+        return member;
     }
 }

--- a/src/main/java/com/dnd/runus/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/runus/domain/member/entity/Member.java
@@ -28,7 +28,7 @@ public class Member extends BaseTimeEntity {
     @Size(max = 20)
     private String nickname;
 
-    private Long badgeId;
+    private Long mainBadgeId;
 
     @NotNull
     private Integer exp;
@@ -47,6 +47,7 @@ public class Member extends BaseTimeEntity {
         member.nickname = nickname;
         member.social = social;
         member.personal = personal;
+        member.exp = 0;
         return member;
     }
 }

--- a/src/main/java/com/dnd/runus/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/runus/domain/member/entity/Member.java
@@ -30,6 +30,9 @@ public class Member extends BaseTimeEntity {
 
     private Long badgeId;
 
+    @NotNull
+    private Integer exp;
+
     @Embedded
     @Accessors(fluent = true)
     private SocialProfile social;

--- a/src/main/java/com/dnd/runus/domain/member/entity/PersonalProfile.java
+++ b/src/main/java/com/dnd/runus/domain/member/entity/PersonalProfile.java
@@ -1,0 +1,35 @@
+package com.dnd.runus.domain.member.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Embeddable
+public class PersonalProfile {
+    @Enumerated(STRING)
+    private Gender gender;
+
+    private Integer heightCm;
+
+    private Integer weightKg;
+
+    private LocalDate birthDay;
+
+    public enum Gender {
+        MALE,
+        FEMALE
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/member/entity/SocialProfile.java
+++ b/src/main/java/com/dnd/runus/domain/member/entity/SocialProfile.java
@@ -1,0 +1,31 @@
+package com.dnd.runus.domain.member.entity;
+
+import com.dnd.runus.global.constant.SocialType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Embeddable
+public class SocialProfile {
+    @NotNull
+    @Enumerated(STRING)
+    private SocialType socialType;
+
+    @NotNull
+    private String oauthId;
+
+    @NotNull
+    private String oauthEmail;
+}

--- a/src/main/java/com/dnd/runus/global/constant/BadgeType.java
+++ b/src/main/java/com/dnd/runus/global/constant/BadgeType.java
@@ -1,0 +1,6 @@
+package com.dnd.runus.global.constant;
+
+public enum BadgeType {
+    RUNNING_COUNT,
+    DISTANCE_METER,
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #14 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

아래 엔티티 클래스를 추가합니다.
- Badge
- BadgeAchievement: 멤버가 배지 달성 여부
- Level: 레벨 이름과 최소 경험치 요구량

기존 Member 엔티티 클래스를 수정합니다.
- Social, Personal profile 추가
  - member 생성시 인자를 줄이기 위해서 social, personal로 관련있는 컬럼끼리 `@Embeddable`로 구분해두었습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- `Level` id 키를 member에 저장하면 Level이 없어지면 사용자에게 보여줄 level이 없는게 이상해서 `exp` 경험치 컬럼을 member에 추가했습니다.
  - 외래키로 저장해도 되지만, 경험치를 늘릴 때마다 다음 레벨인지 확인하고 업데이트할 필요가 없을 것 같아서 exp 컬럼을 두었습니다.
  - 조회할 때는 exp에 맞는 level을 조회하면 어떨까요?
- `BadgeAchievement` 배지 달성 여부를 저장하는 테이블인데, badge, member는 둘다 외래키로 묶어 어느 하나가 삭제되면 해당 배재 달성 row로 삭제하면 좋을까요?
- apple 로그인 구현에 사용자 토큰 정보가 필요하다면, 이는 어디에 저장하면 좋을지 정하면 좋을 것 같아요