### PR TITLE
Feat: member id resolver 추가

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/annotation/MemberId.java
+++ b/src/main/java/com/dnd/runus/presentation/annotation/MemberId.java
@@ -1,0 +1,13 @@
+package com.dnd.runus.presentation.annotation;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Hidden
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {}

--- a/src/main/java/com/dnd/runus/presentation/config/WebConfig.java
+++ b/src/main/java/com/dnd/runus/presentation/config/WebConfig.java
@@ -1,10 +1,14 @@
 package com.dnd.runus.presentation.config;
 
 import com.dnd.runus.presentation.handler.NullResponseHandler;
+import com.dnd.runus.presentation.resolver.MemberIdResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -14,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(nullResponseHandler);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberIdResolver());
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/resolver/MemberIdResolver.java
+++ b/src/main/java/com/dnd/runus/presentation/resolver/MemberIdResolver.java
@@ -1,0 +1,47 @@
+package com.dnd.runus.presentation.resolver;
+
+import com.dnd.runus.auth.exception.AuthException;
+import com.dnd.runus.auth.userdetails.AuthUserDetails;
+import com.dnd.runus.global.exception.type.ErrorType;
+import com.dnd.runus.presentation.annotation.MemberId;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+public class MemberIdResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberId.class)
+                && (long.class == parameter.getParameterType() || Long.class == parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            @Nonnull MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            @Nonnull NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+        try {
+            HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+            assert httpServletRequest != null;
+
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication != null && authentication.getPrincipal() instanceof AuthUserDetails user) {
+                return user.getId();
+            }
+        } catch (NullPointerException ex) {
+            throw new AuthException(ErrorType.FAILED_AUTHENTICATION, "인증 토큰이 필요합니다");
+        }
+        log.error("Authentication is null or principal is not instance of AuthUserDetails");
+        throw new AuthException(ErrorType.FAILED_AUTHENTICATION, "인증 토큰이 필요합니다");
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #31 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `MemberIdResolver`를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- controller 계층에서 다음과 같이 사용할 수 있습니다.
- Security 계층에서 id 값을 가져와 memberId 변수에 넣으므로, 토큰을 사용하는(보호된) API 경로에서만 사용해야 합니다.

```java
@GetMapping
public void getMemberId(@MemberId long memberId) { ... }
```