### PR TITLE
Fix: TokenResponse grantType 삭제

### DIFF
--- a/src/main/java/com/dnd/runus/domain/oauth/dto/response/TokenResponse.java
+++ b/src/main/java/com/dnd/runus/domain/oauth/dto/response/TokenResponse.java
@@ -10,15 +10,10 @@ public record TokenResponse(
     String accessToken,
     //todo refresh token 구현 되면
     @Schema(description = "리프레시토큰(아직 리프레시 토큰 구현이 아직 안되어서 발급하면 'refreshToken'으로 리턴될 거에요.")
-    String refreshToken,
-    @Schema(
-        description = "토큰 타입",
-        example = "Bearer "
-    )
-    String grantType
+    String refreshToken
 ) {
 
     public static TokenResponse from(AuthTokenDto tokenDto) {
-        return new TokenResponse(tokenDto.accessToken(), "refreshToken", tokenDto.type());
+        return new TokenResponse(tokenDto.accessToken(), "refreshToken");
     }
 }


### PR DESCRIPTION
- 로그인 후 grantType 반환 안함

## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #3 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- TokenResponse의 grantType 삭제합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
