### PR TITLE
Fix: ddl-auto validate 속성으로 변경

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeAchievementEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeAchievementEntity.java
@@ -25,16 +25,16 @@ public class BadgeAchievementEntity extends BaseTimeEntity {
 
     @NotNull
     @ManyToOne(fetch = LAZY)
-    private MemberEntity memberEntity;
+    private MemberEntity member;
 
     public static BadgeAchievementEntity from(BadgeAchievement badgeAchievement) {
         BadgeAchievementEntity badgeAchievementEntity = new BadgeAchievementEntity();
         badgeAchievementEntity.badgeId = badgeAchievement.badge().badgeId();
-        badgeAchievementEntity.memberEntity = MemberEntity.from(badgeAchievement.member());
+        badgeAchievementEntity.member = MemberEntity.from(badgeAchievement.member());
         return badgeAchievementEntity;
     }
 
     public BadgeAchievement toDomain(Badge badge) {
-        return new BadgeAchievement(badge, memberEntity.toDomain(), getCreatedAt(), getUpdatedAt());
+        return new BadgeAchievement(badge, member.toDomain(), getCreatedAt(), getUpdatedAt());
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
@@ -39,7 +39,7 @@ public class RunningRecordEntity extends BaseTimeEntity {
 
     @NotNull
     @ManyToOne(fetch = LAZY)
-    private MemberEntity memberEntity;
+    private MemberEntity member;
 
     @NotNull
     private Integer distanceMeter;
@@ -80,7 +80,7 @@ public class RunningRecordEntity extends BaseTimeEntity {
 
         return RunningRecordEntity.builder()
                 .id(runningRecord.runningId())
-                .memberEntity(MemberEntity.from(runningRecord.member()))
+                .member(MemberEntity.from(runningRecord.member()))
                 .distanceMeter(runningRecord.distanceMeter())
                 .durationSeconds(runningRecord.durationSeconds())
                 .calorie(runningRecord.calorie())
@@ -100,7 +100,7 @@ public class RunningRecordEntity extends BaseTimeEntity {
 
         return RunningRecord.builder()
                 .runningId(id)
-                .member(memberEntity.toDomain())
+                .member(member.toDomain())
                 .distanceMeter(distanceMeter)
                 .durationSeconds(durationSeconds)
                 .calorie(calorie)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
     username: ${DATABASE_USER}
     password: ${DATABASE_PASSWORD}
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
 app:
   api:
     allow-origins: ${ALLOW_ORIGINS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring.profiles.active: local
 spring:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     show-sql: true
     open-in-view: false
     defer-datasource-initialization: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     show-sql: true
     open-in-view: false
     defer-datasource-initialization: false


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #41

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 컬럼명에서 `entity`를 제거합니다. (SQL말고 JPA 엔티티 컬럼명에 잘못 entity를 적은 컬럼을 수정합니다)
- `ddl-auto` 속성을 `none`에서 `validate`로 변경합니다.


## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

아래 글에 잘 설명되어 있으니 참고해주세요!

- https://stackoverflow.com/questions/42135114/how-does-spring-jpa-hibernate-ddl-auto-property-exactly-work-in-spring
> validate – Hibernate는 테이블과 칼럼이 존재하는지 여부만을 검증하고, 그렇지 않으면 예외를 발생시킨다
none – 이 값은 DDL 생성을 해제합니다.
