### PR TITLE
Fix: running record 테이블 pace 컬럼 타입을 정수형으로 변경

### DIFF
--- a/src/main/java/com/dnd/runus/domain/common/Coordinate.java
+++ b/src/main/java/com/dnd/runus/domain/common/Coordinate.java
@@ -6,9 +6,7 @@ package com.dnd.runus.domain.common;
  * @param altitude 고도
  */
 public record Coordinate(double longitude, double latitude, double altitude) {
-    public static final double NULL_ORDINATE = Double.NaN;
-
     public Coordinate(double longitude, double latitude) {
-        this(longitude, latitude, NULL_ORDINATE);
+        this(longitude, latitude, Double.NaN);
     }
 }

--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -1,0 +1,34 @@
+package com.dnd.runus.domain.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 러닝 페이스를 나타내는 클래스
+ *
+ * @param minute
+ * @param second
+ */
+public record Pace(int minute, int second) {
+    public static Pace ofSeconds(int seconds) {
+        int minute = seconds / 60;
+        int second = seconds % 60;
+        return new Pace(minute, second);
+    }
+
+    @JsonCreator
+    public static Pace from(String pace) {
+        // e.g. 5'30"
+        String[] paceArr = pace.split("'\"");
+        return new Pace(Integer.parseInt(paceArr[0]), Integer.parseInt(paceArr[1]));
+    }
+
+    @JsonValue
+    public String getPace() {
+        return minute + "'" + second + "\"";
+    }
+
+    public int toSeconds() {
+        return minute * 60 + second;
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecord.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecord.java
@@ -1,10 +1,12 @@
 package com.dnd.runus.domain.running;
 
 import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.global.constant.RunningEmoji;
 import lombok.Builder;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -13,9 +15,9 @@ public record RunningRecord(
         long runningId,
         Member member,
         int distanceMeter,
-        int durationSeconds,
+        Duration duration,
         double calorie,
-        double averagePace,
+        Pace averagePace,
         OffsetDateTime startAt,
         OffsetDateTime endAt,
         List<Coordinate> route,

--- a/src/main/java/com/dnd/runus/global/exception/NotFoundException.java
+++ b/src/main/java/com/dnd/runus/global/exception/NotFoundException.java
@@ -6,4 +6,8 @@ public class NotFoundException extends BaseException {
     public NotFoundException(String message) {
         super(ErrorType.ENTITY_NOT_FOUND, message);
     }
+
+    public <ID> NotFoundException(Class<?> clazz, ID id) {
+        super(ErrorType.ENTITY_NOT_FOUND, clazz.getSimpleName() + ": id (" + id + ") is not found");
+    }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/GeometryMapper.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/GeometryMapper.java
@@ -1,0 +1,38 @@
+package com.dnd.runus.infrastructure.persistence.domain;
+
+import com.dnd.runus.domain.common.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.PrecisionModel;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.dnd.runus.global.constant.GeometryConstant.SRID;
+import static org.locationtech.jts.geom.PrecisionModel.FLOATING;
+
+public final class GeometryMapper {
+    GeometryMapper() {}
+
+    public static Coordinate toDomain(org.locationtech.jts.geom.Coordinate coordinate) {
+        return new Coordinate(coordinate.getX(), coordinate.getY(), coordinate.getZ());
+    }
+
+    public static List<Coordinate> toDomain(LineString lineString) {
+        return Stream.of(lineString.getCoordinates())
+                .map(GeometryMapper::toDomain)
+                .toList();
+    }
+
+    public static LineString toLineString(List<Coordinate> coordinates) {
+        org.locationtech.jts.geom.Coordinate[] geoCoordinates = coordinates.stream()
+                .map(coordinate -> new org.locationtech.jts.geom.Coordinate(
+                        coordinate.longitude(), coordinate.latitude(), coordinate.altitude()))
+                .toArray(org.locationtech.jts.geom.Coordinate[]::new);
+        return GeometryFactoryHolder.INSTANCE.createLineString(geoCoordinates);
+    }
+
+    private static class GeometryFactoryHolder {
+        private static final GeometryFactory INSTANCE = new GeometryFactory(new PrecisionModel(FLOATING), SRID);
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
@@ -1,9 +1,10 @@
 package com.dnd.runus.infrastructure.persistence.jpa.running.entity;
 
 import com.dnd.runus.domain.common.BaseTimeEntity;
-import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.infrastructure.persistence.domain.GeometryMapper;
 import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -11,20 +12,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.PrecisionModel;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.List;
 
 import static com.dnd.runus.global.constant.GeometryConstant.SRID;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
-import static org.locationtech.jts.geom.PrecisionModel.FLOATING;
 
 @Getter
 @Entity(name = "running_record")
@@ -51,7 +48,7 @@ public class RunningRecordEntity extends BaseTimeEntity {
     private Double calorie;
 
     @NotNull
-    private Double averagePace;
+    private Integer averagePace;
 
     @NotNull
     private OffsetDateTime startAt;
@@ -70,44 +67,32 @@ public class RunningRecordEntity extends BaseTimeEntity {
     private RunningEmoji emoji;
 
     public static RunningRecordEntity from(RunningRecord runningRecord) {
-        org.locationtech.jts.geom.Coordinate[] coordinates = runningRecord.route().stream()
-                .map(coordinate ->
-                        new org.locationtech.jts.geom.Coordinate(coordinate.longitude(), coordinate.latitude()))
-                .toArray(org.locationtech.jts.geom.Coordinate[]::new);
-
-        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(FLOATING), SRID);
-        LineString route = geometryFactory.createLineString(coordinates);
-
         return RunningRecordEntity.builder()
                 .id(runningRecord.runningId())
                 .memberEntity(MemberEntity.from(runningRecord.member()))
                 .distanceMeter(runningRecord.distanceMeter())
-                .durationSeconds(runningRecord.durationSeconds())
+                .durationSeconds((int) runningRecord.duration().toSeconds())
                 .calorie(runningRecord.calorie())
-                .averagePace(runningRecord.averagePace())
+                .averagePace(runningRecord.averagePace().toSeconds())
                 .startAt(runningRecord.startAt())
                 .endAt(runningRecord.endAt())
-                .route(route)
+                .route(GeometryMapper.toLineString(runningRecord.route()))
                 .location(runningRecord.location())
                 .emoji(runningRecord.emoji())
                 .build();
     }
 
     public RunningRecord toDomain() {
-        List<Coordinate> coordinates = Arrays.stream(route.getCoordinates())
-                .map(coordinate -> new Coordinate(coordinate.x, coordinate.y, coordinate.z))
-                .toList();
-
         return RunningRecord.builder()
                 .runningId(id)
                 .member(memberEntity.toDomain())
                 .distanceMeter(distanceMeter)
-                .durationSeconds(durationSeconds)
+                .duration(Duration.ofSeconds(durationSeconds))
                 .calorie(calorie)
-                .averagePace(averagePace)
+                .averagePace(Pace.ofSeconds(averagePace))
                 .startAt(startAt)
                 .endAt(endAt)
-                .route(coordinates)
+                .route(GeometryMapper.toDomain(route))
                 .location(location)
                 .emoji(emoji)
                 .build();

--- a/src/main/resources/db/migration/V2__alter_running_record_avg_pace.sql
+++ b/src/main/resources/db/migration/V2__alter_running_record_avg_pace.sql
@@ -1,0 +1,2 @@
+ALTER TABLE running_record
+    ALTER COLUMN average_pace TYPE INTEGER USING average_pace::INTEGER;

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntityTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntityTest.java
@@ -1,6 +1,7 @@
 package com.dnd.runus.infrastructure.persistence.jpa.running.entity;
 
 import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.global.constant.MemberRole;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -23,9 +25,9 @@ class RunningRecordEntityTest {
                 .runningId(1L)
                 .member(new Member(MemberRole.USER, "nickname-1"))
                 .distanceMeter(500)
-                .durationSeconds(1)
+                .duration(Duration.ofSeconds(100))
                 .calorie(1.0)
-                .averagePace(1.0)
+                .averagePace(Pace.ofSeconds(100))
                 .startAt(OffsetDateTime.now())
                 .endAt(OffsetDateTime.now())
                 .route(List.of(new Coordinate(128.0, 36.0), new Coordinate(128.0, 37.0)))


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #30 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Pace 클래스를 추가합니다.
- `running_record` 테이블의 컬럼을 수정합니다.
  -  pace 컬럼을 double -> integer (minute * 60 + second)로 저장합니다.
- `RunningRecordEntity`의 pace 필드 타입을 Double -> Integer로 수정합니다.
- `RunningRecord`
  - pace를 double 대신 Pace 클래스를 사용합니다.
  - durationSeconds (integer)를 Duration 타입으로 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- Pace를 저장할때, double 대신 integer(분 * 60 + 초)로 저장하면 비교하기 더 편할 것 같은데 어떠신가요?
- 배지 부여를 할때, 평균 페이스도 일정 수치에 따라 기준을 정해야 하는데,
  badge 테이블의 requred_value 컬럼이 integer로 되어 있어서, pace 저장할 때도 integer 타입을 사용하면 좋을 것 같아요
