### PR TITLE
Fix: Pace json format 형식에서 "대신 ''을 사용하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -19,13 +19,13 @@ public record Pace(int minute, int second) {
     @JsonCreator
     public static Pace from(String pace) {
         // e.g. 5'30"
-        String[] paceArr = pace.split("'\"");
+        String[] paceArr = pace.split("'|''");
         return new Pace(Integer.parseInt(paceArr[0]), Integer.parseInt(paceArr[1]));
     }
 
     @JsonValue
     public String getPace() {
-        return minute + "'" + second + "\"";
+        return minute + "'" + second + "''";
     }
 
     public int toSeconds() {

--- a/src/test/java/com/dnd/runus/domain/common/PaceTest.java
+++ b/src/test/java/com/dnd/runus/domain/common/PaceTest.java
@@ -1,0 +1,40 @@
+package com.dnd.runus.domain.common;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PaceTest {
+    private Pace pace;
+
+    @BeforeEach
+    void setUp() {
+        pace = new Pace(5, 30);
+    }
+
+    @Test
+    @DisplayName("초를 입력받아 Pace 객체를 생성한다.")
+    void ofSeconds() {
+        assertEquals(Pace.ofSeconds(330), pace);
+    }
+
+    @Test
+    @DisplayName("올바른 형태의 문자열을 입력받아 Pace 객체를 생성한다.")
+    void from() {
+        assertEquals(Pace.from("5'30''"), pace);
+    }
+
+    @Test
+    @DisplayName("Pace 객체를 올바른 형태의 문자열로 변환한다.")
+    void getPace() {
+        assertEquals("5'30''", pace.getPace());
+    }
+
+    @Test
+    @DisplayName("Pace 객체를 초(60 * 분 + 초)로 변환한다.")
+    void toSeconds() {
+        assertEquals(330, pace.toSeconds());
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #30

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `"` 대신 `''`을 사용해요
  - json body에 `"`을 사용하지 못해요
  - `\"`으로 보내니 \도 같이 그대로 인식해요
  - 그래서 `"` 대신 `'` 2개를 사용하도록 변경해요

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 관련 테스트도 추가했으니 확인 부탁드려요!
