### PR TITLE
Fix: Duration 직렬화/역직렬화 HH:mm:ss 포맷 추가

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/config/ObjectMapperConfig.java
+++ b/src/main/java/com/dnd/runus/presentation/config/ObjectMapperConfig.java
@@ -1,14 +1,17 @@
 package com.dnd.runus.presentation.config;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.time.*;
 
@@ -40,8 +43,39 @@ public class ObjectMapperConfig {
                                 false,
                                 false,
                                 dateTimeFormatter.withZone(SERVER_TIMEZONE_ID)) {})
-                .addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(dateTimeFormatter));
+                .addSerializer(Duration.class, new CustomDurationSerializer())
+                .addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(dateTimeFormatter))
+                .addDeserializer(Duration.class, new CustomDurationDeserializer());
         objectMapper.registerModule(dateTimeModule);
         return objectMapper;
+    }
+
+    public static class CustomDurationSerializer extends JsonSerializer<Duration> {
+        @Override
+        public void serialize(Duration duration, JsonGenerator generator, SerializerProvider provider)
+                throws IOException {
+            long totalSeconds = duration.getSeconds();
+            long hours = totalSeconds / 3600;
+            long minutes = (totalSeconds % 3600) / 60;
+            long seconds = totalSeconds % 60;
+            // HH:mm:ss or HHH:mm:ss
+            String formattedDuration =
+                    String.format("%s:%02d:%02d", (hours < 10 ? "0" + hours : hours), minutes, seconds);
+            generator.writeString(formattedDuration);
+        }
+    }
+
+    public static class CustomDurationDeserializer extends JsonDeserializer<Duration> {
+        @Override
+        public Duration deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            String[] parts = parser.getText().split(":");
+            if (parts.length != 3) {
+                throw new JsonMappingException(parser, "Invalid duration format, expected HH:mm:ss");
+            }
+            long hours = Long.parseLong(parts[0]);
+            long minutes = Long.parseLong(parts[1]);
+            long seconds = Long.parseLong(parts[2]);
+            return Duration.ofHours(hours).plusMinutes(minutes).plusSeconds(seconds);
+        }
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #26 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Duration 직렬화, 역 직렬화를 ObjectMapperConfig에 추가합니다.
- `HH:mm:ss` 형식입니다.
  - `12:34:56` -> `Duration(12 hours, 34 minutes, 56 seconds)`
  - `123:34:45` -> `Duration(123 hours, 34 minutes, 45 seconds)`

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- `LocalTime` 형식과 같은데, `LocalTime`은 24시간 밖에 저장하지 못하고, 초로 변환하는 기능이 없어요
- 그래서 초로 변환하는 기능을 지원하는 `Duration` 타입 포맷터를 추가해요
