### PR TITLE
Fix: member_level table member_id fk 오류 수정

### DIFF
--- a/src/main/resources/db/migration/V4__fix_member_level_fk.sql
+++ b/src/main/resources/db/migration/V4__fix_member_level_fk.sql
@@ -1,0 +1,4 @@
+-- 기존 member_level 테이블의 잘못된 FK constraint (member_id) 제거
+ALTER TABLE member_level DROP CONSTRAINT fk_member_level_level;
+-- 올바른 FK constraint 추가
+ALTER TABLE member_level ADD CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member (id);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #53 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에는 `references member_level references member`로 적혀 있습니다.
- references는 한 번만 적어야 하므로, `member_level` 테이블의 FK를 올바르게 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
