### PR TITLE
Feat: member 레벨업 기능 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -1,6 +1,7 @@
 package com.dnd.runus.application.running;
 
 import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
@@ -19,14 +20,17 @@ import java.time.ZoneOffset;
 public class RunningRecordService {
     private final RunningRecordRepository runningRecordRepository;
     private final MemberRepository memberRepository;
+    private final MemberLevelRepository memberLevelRepository;
     private final ZoneOffset defaultZoneOffset;
 
     public RunningRecordService(
             RunningRecordRepository runningRecordRepository,
             MemberRepository memberRepository,
+            MemberLevelRepository memberLevelRepository,
             @Value("${app.default-zone-offset}") ZoneOffset defaultZoneOffset) {
         this.runningRecordRepository = runningRecordRepository;
         this.memberRepository = memberRepository;
+        this.memberLevelRepository = memberLevelRepository;
         this.defaultZoneOffset = defaultZoneOffset;
     }
 
@@ -57,6 +61,8 @@ public class RunningRecordService {
                 .calorie(request.runningData().calorie())
                 .averagePace(request.runningData().averagePace())
                 .build());
+
+        memberLevelRepository.updateMemberLevel(memberId, request.runningData().distanceMeter());
 
         return RunningRecordReportResponse.from(record);
     }

--- a/src/main/java/com/dnd/runus/domain/level/LevelRepository.java
+++ b/src/main/java/com/dnd/runus/domain/level/LevelRepository.java
@@ -1,0 +1,9 @@
+package com.dnd.runus.domain.level;
+
+import java.util.Optional;
+
+public interface LevelRepository {
+    Optional<Level> findById(long id);
+
+    Level save(Level level);
+}

--- a/src/main/java/com/dnd/runus/domain/member/MemberLevel.java
+++ b/src/main/java/com/dnd/runus/domain/member/MemberLevel.java
@@ -1,3 +1,9 @@
 package com.dnd.runus.domain.member;
 
-public record MemberLevel(long levelId, int exp) {}
+public record MemberLevel(long memberLevelId, Member member, long levelId, int exp) {
+    public record Summary(long memberLevelId, long levelId, int exp) {
+        public MemberLevel toMemberLevel(Member member) {
+            return new MemberLevel(memberLevelId, member, levelId, exp);
+        }
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/member/MemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/domain/member/MemberLevelRepository.java
@@ -1,6 +1,14 @@
 package com.dnd.runus.domain.member;
 
+import java.util.Optional;
+
 public interface MemberLevelRepository {
 
+    MemberLevel save(MemberLevel memberLevel);
+
+    Optional<MemberLevel> findByMemberId(long memberLevelId);
+
     void deleteByMemberId(long memberId);
+
+    MemberLevel.Summary updateMemberLevel(long memberId, int exp);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/level/LevelRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/level/LevelRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.dnd.runus.infrastructure.persistence.domain.level;
+
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.domain.level.LevelRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.level.JpaLevelRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.level.entity.LevelEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LevelRepositoryImpl implements LevelRepository {
+    private final JpaLevelRepository jpaLevelRepository;
+
+    @Override
+    public Optional<Level> findById(long id) {
+        return jpaLevelRepository.findById(id).map(LevelEntity::toDomain);
+    }
+
+    @Override
+    public Level save(Level level) {
+        return jpaLevelRepository.save(LevelEntity.from(level)).toDomain();
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImpl.java
@@ -1,18 +1,41 @@
 package com.dnd.runus.infrastructure.persistence.domain.member;
 
+import com.dnd.runus.domain.member.MemberLevel;
 import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.infrastructure.persistence.jooq.member.JooqMemberLevelRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.member.JpaMemberLevelRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberLevelEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class MemberLevelRepositoryImpl implements MemberLevelRepository {
 
     private final JpaMemberLevelRepository jpaMemberLevelRepository;
+    private final JooqMemberLevelRepository jooqMemberLevelRepository;
+
+    @Override
+    public MemberLevel save(MemberLevel memberLevel) {
+        return jpaMemberLevelRepository
+                .save(MemberLevelEntity.from(memberLevel))
+                .toDomain();
+    }
+
+    @Override
+    public Optional<MemberLevel> findByMemberId(long memberLevelId) {
+        return jpaMemberLevelRepository.findByMemberId(memberLevelId).map(MemberLevelEntity::toDomain);
+    }
 
     @Override
     public void deleteByMemberId(long memberId) {
         jpaMemberLevelRepository.deleteByMemberId(memberId);
+    }
+
+    @Override
+    public MemberLevel.Summary updateMemberLevel(long memberId, int exp) {
+        return jooqMemberLevelRepository.updateMemberLevel(memberId, exp);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/member/JooqMemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/member/JooqMemberLevelRepository.java
@@ -1,0 +1,44 @@
+package com.dnd.runus.infrastructure.persistence.jooq.member;
+
+import com.dnd.runus.domain.member.MemberLevel;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+import org.springframework.stereotype.Repository;
+
+import static com.dnd.runus.jooq.Tables.LEVEL;
+import static com.dnd.runus.jooq.Tables.MEMBER_LEVEL;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqMemberLevelRepository {
+    private final DSLContext dsl;
+
+    public MemberLevel.Summary updateMemberLevel(long memberId, int exp) {
+        Field<Integer> newExp = MEMBER_LEVEL.EXP.add(exp);
+
+        return dsl.update(MEMBER_LEVEL)
+                .set(MEMBER_LEVEL.EXP, newExp)
+                .set(
+                        MEMBER_LEVEL.LEVEL_ID,
+                        dsl.select(LEVEL.ID)
+                                .from(LEVEL)
+                                .where(newExp.between(LEVEL.EXP_RANGE_START, LEVEL.EXP_RANGE_END))
+                                .limit(1))
+                .where(MEMBER_LEVEL.MEMBER_ID.eq(memberId))
+                .returningResult(MEMBER_LEVEL.ID, MEMBER_LEVEL.MEMBER_ID, MEMBER_LEVEL.LEVEL_ID, MEMBER_LEVEL.EXP)
+                .fetchOne(new MemberLevelSummaryMapper());
+    }
+
+    private static class MemberLevelSummaryMapper implements RecordMapper<Record, MemberLevel.Summary> {
+        @Override
+        public MemberLevel.Summary map(Record record) {
+            return new MemberLevel.Summary(
+                    record.get(MEMBER_LEVEL.ID, long.class),
+                    record.get(MEMBER_LEVEL.LEVEL_ID, long.class),
+                    record.get(MEMBER_LEVEL.EXP, int.class));
+        }
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/level/JpaLevelRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/level/JpaLevelRepository.java
@@ -1,0 +1,6 @@
+package com.dnd.runus.infrastructure.persistence.jpa.level;
+
+import com.dnd.runus.infrastructure.persistence.jpa.level.entity.LevelEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaLevelRepository extends JpaRepository<LevelEntity, Long> {}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/level/entity/LevelEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/level/entity/LevelEntity.java
@@ -1,5 +1,6 @@
 package com.dnd.runus.infrastructure.persistence.jpa.level.entity;
 
+import com.dnd.runus.domain.level.Level;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,4 +24,16 @@ public class LevelEntity {
 
     @NotNull
     private Integer expRangeEnd;
+
+    public static LevelEntity from(Level level) {
+        LevelEntity levelEntity = new LevelEntity();
+        levelEntity.id = level.levelId();
+        levelEntity.expRangeStart = level.expRangeStart();
+        levelEntity.expRangeEnd = level.expRangeEnd();
+        return levelEntity;
+    }
+
+    public Level toDomain() {
+        return new Level(id, expRangeStart, expRangeEnd);
+    }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/JpaMemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/JpaMemberLevelRepository.java
@@ -3,7 +3,11 @@ package com.dnd.runus.infrastructure.persistence.jpa.member;
 import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberLevelEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JpaMemberLevelRepository extends JpaRepository<MemberLevelEntity, Long> {
+
+    Optional<MemberLevelEntity> findByMemberId(long memberId);
 
     void deleteByMemberId(long memberId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberLevelEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberLevelEntity.java
@@ -1,7 +1,6 @@
 package com.dnd.runus.infrastructure.persistence.jpa.member.entity;
 
 import com.dnd.runus.domain.common.BaseTimeEntity;
-import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.member.MemberLevel;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -29,15 +28,16 @@ public class MemberLevelEntity extends BaseTimeEntity {
     @NotNull
     private Integer exp;
 
-    public static MemberLevelEntity of(Member member, long levelId, int exp) {
+    public static MemberLevelEntity from(MemberLevel memberLevel) {
         MemberLevelEntity memberLevelEntity = new MemberLevelEntity();
-        memberLevelEntity.member = MemberEntity.from(member);
-        memberLevelEntity.levelId = levelId;
-        memberLevelEntity.exp = exp;
+        memberLevelEntity.id = memberLevel.memberLevelId();
+        memberLevelEntity.member = MemberEntity.from(memberLevel.member());
+        memberLevelEntity.levelId = memberLevel.levelId();
+        memberLevelEntity.exp = memberLevel.exp();
         return memberLevelEntity;
     }
 
     public MemberLevel toDomain() {
-        return new MemberLevel(levelId, exp);
+        return new MemberLevel(id, member.toDomain(), levelId, exp);
     }
 }

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -3,6 +3,7 @@ package com.dnd.runus.application.running;
 import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
@@ -40,11 +41,15 @@ class RunningRecordServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private MemberLevelRepository memberLevelRepository;
+
     private final ZoneOffset defaultZoneOffset = ZoneOffset.of("+9");
 
     @BeforeEach
     void setUp() {
-        runningRecordService = new RunningRecordService(runningRecordRepository, memberRepository, defaultZoneOffset);
+        runningRecordService = new RunningRecordService(
+                runningRecordRepository, memberRepository, memberLevelRepository, defaultZoneOffset);
     }
 
     @Test

--- a/src/test/java/com/dnd/runus/config/TestJooqConfig.java
+++ b/src/test/java/com/dnd/runus/config/TestJooqConfig.java
@@ -1,19 +1,27 @@
 package com.dnd.runus.config;
 
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
 import org.jooq.impl.DataSourceConnectionProvider;
-import org.jooq.impl.DefaultConfiguration;
-import org.jooq.impl.DefaultDSLContext;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration;
+import org.springframework.boot.autoconfigure.jooq.JooqProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 
 import javax.sql.DataSource;
 
+@Import({
+    JooqAutoConfiguration.class,
+    JooqProperties.class,
+})
 @TestConfiguration
+@RequiredArgsConstructor
 public class TestJooqConfig {
-    @Autowired
-    private DataSource dataSource;
+    private final DataSource dataSource;
+    private final JooqProperties jooqProperties;
 
     @Bean
     DataSourceConnectionProvider connectionProvider() {
@@ -21,9 +29,7 @@ public class TestJooqConfig {
     }
 
     @Bean
-    DefaultDSLContext dsl() {
-        DefaultConfiguration jooqConfiguration = new DefaultConfiguration();
-        jooqConfiguration.set(connectionProvider());
-        return new DefaultDSLContext(jooqConfiguration);
+    DSLContext dsl() {
+        return DSL.using(connectionProvider(), jooqProperties.determineSqlDialect(dataSource));
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/annotation/RepositoryTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/annotation/RepositoryTest.java
@@ -5,7 +5,6 @@ import com.dnd.runus.config.TestcontainersConfig;
 import com.dnd.runus.global.config.JooqConfig;
 import com.dnd.runus.global.config.JpaConfig;
 import com.dnd.runus.infrastructure.persistence.InfrastructurePersistencePackage;
-import org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,6 +25,5 @@ import java.lang.annotation.*;
     JpaConfig.class,
     JooqConfig.class,
     TestJooqConfig.class,
-    JooqAutoConfiguration.class,
 })
 public @interface RepositoryTest {}

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImplTest.java
@@ -1,17 +1,22 @@
 package com.dnd.runus.infrastructure.persistence.domain.member;
 
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.domain.level.LevelRepository;
 import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevel;
 import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
-import com.dnd.runus.infrastructure.persistence.jpa.member.JpaMemberLevelRepository;
-import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberLevelEntity;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @RepositoryTest
@@ -19,9 +24,6 @@ class MemberLevelRepositoryImplTest {
 
     @Autowired
     private MemberLevelRepository memberLevelRepository;
-
-    @Autowired
-    private JpaMemberLevelRepository jpaMemberLevelRepository;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -39,12 +41,54 @@ class MemberLevelRepositoryImplTest {
     @Test
     void deleteByMemberId() {
         // given
-        MemberLevelEntity savedMemberLevel = jpaMemberLevelRepository.save(MemberLevelEntity.of(savedMember, 1L, 100));
+        memberLevelRepository.save(new MemberLevel(0, savedMember, 1, 100));
 
         // when
         memberLevelRepository.deleteByMemberId(savedMember.memberId());
 
         // then
-        assertFalse(jpaMemberLevelRepository.findById(savedMemberLevel.getId()).isPresent());
+        assertFalse(memberLevelRepository.findByMemberId(savedMember.memberId()).isPresent());
+    }
+
+    @Nested
+    @DisplayName("멤버 레벨 수정")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class MemberLevelUpdateTest {
+        @Autowired
+        private LevelRepository levelRepository;
+
+        @BeforeAll
+        void beforeAll() {
+            levelRepository.save(new Level(1, 0, 100));
+            levelRepository.save(new Level(2, 101, 200));
+            levelRepository.save(new Level(3, 201, Integer.MAX_VALUE));
+        }
+
+        @BeforeEach
+        void setUp() {
+            memberLevelRepository.save(new MemberLevel(0, savedMember, 1, 50));
+        }
+
+        @AfterEach
+        void tearDown() {
+            memberLevelRepository.deleteByMemberId(savedMember.memberId());
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideMemberLevelArgs")
+        @DisplayName("경험치가 주어지면, 경험치와 member level을 경험치와 맞는 level로 수정한다.")
+        void updateMemberLevel(int plusExp, int expectedExp, long expectedLevelId) {
+            // when
+            MemberLevel.Summary updatedMemberLevel =
+                    memberLevelRepository.updateMemberLevel(savedMember.memberId(), plusExp);
+
+            // then
+            assertEquals(expectedExp, updatedMemberLevel.exp());
+            assertEquals(expectedLevelId, updatedMemberLevel.levelId());
+        }
+
+        private static Stream<Arguments> provideMemberLevelArgs() {
+            return Stream.of(Arguments.of(10, 60, 1), Arguments.of(100, 150, 2));
+        }
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #65 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 러닝을 저장할때, 사용자의 레벨을 같이 업데이트합니다.
- 추가되는 경험치는 meter 단위로 추가해요

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 경험치에 해당하는 레벨이 없는 경우, level table에서 id를 찾지 못해서 NPE가 발생해요
  - 경험치가 int max를 넘어가지 않는지 확인해야 해요
  - 2,147,483km를 달려야 하는데(지구가 46,000km), 사용자가 조작하지 않는 이상 불가능해요
