### PR TITLE
Fix: member level repository의 updateMemberLevel 메서드 반환값을 void로 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/member/MemberLevel.java
+++ b/src/main/java/com/dnd/runus/domain/member/MemberLevel.java
@@ -1,9 +1,3 @@
 package com.dnd.runus.domain.member;
 
-public record MemberLevel(long memberLevelId, Member member, long levelId, int exp) {
-    public record Summary(long memberLevelId, long levelId, int exp) {
-        public MemberLevel toMemberLevel(Member member) {
-            return new MemberLevel(memberLevelId, member, levelId, exp);
-        }
-    }
-}
+public record MemberLevel(long memberLevelId, Member member, long levelId, int exp) {}

--- a/src/main/java/com/dnd/runus/domain/member/MemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/domain/member/MemberLevelRepository.java
@@ -6,9 +6,9 @@ public interface MemberLevelRepository {
 
     MemberLevel save(MemberLevel memberLevel);
 
-    Optional<MemberLevel> findByMemberId(long memberLevelId);
+    Optional<MemberLevel> findByMemberId(long memberId);
 
     void deleteByMemberId(long memberId);
 
-    MemberLevel.Summary updateMemberLevel(long memberId, int exp);
+    void updateMemberLevel(long memberId, int plusExp);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.infrastructure.persistence.jooq.member.JooqMemberLevelRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.member.JpaMemberLevelRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberLevelEntity;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,6 +18,8 @@ public class MemberLevelRepositoryImpl implements MemberLevelRepository {
     private final JpaMemberLevelRepository jpaMemberLevelRepository;
     private final JooqMemberLevelRepository jooqMemberLevelRepository;
 
+    private final EntityManager entityManager;
+
     @Override
     public MemberLevel save(MemberLevel memberLevel) {
         return jpaMemberLevelRepository
@@ -25,8 +28,8 @@ public class MemberLevelRepositoryImpl implements MemberLevelRepository {
     }
 
     @Override
-    public Optional<MemberLevel> findByMemberId(long memberLevelId) {
-        return jpaMemberLevelRepository.findByMemberId(memberLevelId).map(MemberLevelEntity::toDomain);
+    public Optional<MemberLevel> findByMemberId(long memberId) {
+        return jpaMemberLevelRepository.findByMemberId(memberId).map(MemberLevelEntity::toDomain);
     }
 
     @Override
@@ -35,7 +38,9 @@ public class MemberLevelRepositoryImpl implements MemberLevelRepository {
     }
 
     @Override
-    public MemberLevel.Summary updateMemberLevel(long memberId, int exp) {
-        return jooqMemberLevelRepository.updateMemberLevel(memberId, exp);
+    public void updateMemberLevel(long memberId, int plusExp) {
+        entityManager.flush();
+        entityManager.clear();
+        jooqMemberLevelRepository.updateMemberLevel(memberId, plusExp);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/member/JooqMemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/member/JooqMemberLevelRepository.java
@@ -1,11 +1,8 @@
 package com.dnd.runus.infrastructure.persistence.jooq.member;
 
-import com.dnd.runus.domain.member.MemberLevel;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.jooq.Field;
-import org.jooq.Record;
-import org.jooq.RecordMapper;
 import org.springframework.stereotype.Repository;
 
 import static com.dnd.runus.jooq.Tables.LEVEL;
@@ -16,10 +13,10 @@ import static com.dnd.runus.jooq.Tables.MEMBER_LEVEL;
 public class JooqMemberLevelRepository {
     private final DSLContext dsl;
 
-    public MemberLevel.Summary updateMemberLevel(long memberId, int exp) {
-        Field<Integer> newExp = MEMBER_LEVEL.EXP.add(exp);
+    public void updateMemberLevel(long memberId, int plusExp) {
+        Field<Integer> newExp = MEMBER_LEVEL.EXP.add(plusExp);
 
-        return dsl.update(MEMBER_LEVEL)
+        dsl.update(MEMBER_LEVEL)
                 .set(MEMBER_LEVEL.EXP, newExp)
                 .set(
                         MEMBER_LEVEL.LEVEL_ID,
@@ -28,17 +25,6 @@ public class JooqMemberLevelRepository {
                                 .where(newExp.between(LEVEL.EXP_RANGE_START, LEVEL.EXP_RANGE_END))
                                 .limit(1))
                 .where(MEMBER_LEVEL.MEMBER_ID.eq(memberId))
-                .returningResult(MEMBER_LEVEL.ID, MEMBER_LEVEL.MEMBER_ID, MEMBER_LEVEL.LEVEL_ID, MEMBER_LEVEL.EXP)
-                .fetchOne(new MemberLevelSummaryMapper());
-    }
-
-    private static class MemberLevelSummaryMapper implements RecordMapper<Record, MemberLevel.Summary> {
-        @Override
-        public MemberLevel.Summary map(Record record) {
-            return new MemberLevel.Summary(
-                    record.get(MEMBER_LEVEL.ID, long.class),
-                    record.get(MEMBER_LEVEL.LEVEL_ID, long.class),
-                    record.get(MEMBER_LEVEL.EXP, int.class));
-        }
+                .execute();
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImplTest.java
@@ -79,8 +79,10 @@ class MemberLevelRepositoryImplTest {
         @DisplayName("경험치가 주어지면, 경험치와 member level을 경험치와 맞는 level로 수정한다.")
         void updateMemberLevel(int plusExp, int expectedExp, long expectedLevelId) {
             // when
-            MemberLevel.Summary updatedMemberLevel =
-                    memberLevelRepository.updateMemberLevel(savedMember.memberId(), plusExp);
+            memberLevelRepository.updateMemberLevel(savedMember.memberId(), plusExp);
+
+            MemberLevel updatedMemberLevel =
+                    memberLevelRepository.findByMemberId(savedMember.memberId()).orElseThrow();
 
             // then
             assertEquals(expectedExp, updatedMemberLevel.exp());


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #65 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 레벨 업하고 나서 레벨 조회를 하지 않으므로, `UPDATE .. RETURNING` SQL 절을 삭제합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 전에 언급하신 사항인데, `memberLevelId`로 잘못 적은 파라미터 이름도 `memberId`로 수정해요
  - [`Optional<MemberLevel> findByMemberId(long memberId);`](https://github.com/dnd-side-project/dnd-11th-2-backend/compare/fix/%2365/level-up?expand=1#diff-eb5f4d1e3dbec8e1db125cdd66ce4f8c58db70cd2348f56de12d5ba1975f51eaL9)
