### PR TITLE
Fix: member main badge 컬럼 삭제

### DIFF
--- a/src/main/java/com/dnd/runus/domain/member/Member.java
+++ b/src/main/java/com/dnd/runus/domain/member/Member.java
@@ -1,18 +1,12 @@
 package com.dnd.runus.domain.member;
 
-import com.dnd.runus.domain.badge.Badge;
 import com.dnd.runus.global.constant.MemberRole;
 
 import java.time.OffsetDateTime;
 
 public record Member(
-        long memberId,
-        OffsetDateTime createdAt,
-        OffsetDateTime updatedAt,
-        MemberRole role,
-        String nickname,
-        Badge mainBadge) {
+        long memberId, MemberRole role, String nickname, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
     public Member(MemberRole role, String nickname) {
-        this(0, null, null, role, nickname, null);
+        this(0, role, nickname, null, null);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeEntity.java
@@ -28,7 +28,8 @@ public class BadgeEntity {
     private String description;
 
     @NotNull
-    private String imagePath;
+    @Size(max = 500)
+    private String imageUrl;
 
     @NotNull
     @Enumerated(STRING)
@@ -42,13 +43,13 @@ public class BadgeEntity {
         badgeEntity.id = badge.badgeId();
         badgeEntity.name = badge.name();
         badgeEntity.description = badge.description();
-        badgeEntity.imagePath = badge.imageUrl();
+        badgeEntity.imageUrl = badge.imageUrl();
         badgeEntity.type = badge.type();
         badgeEntity.requiredValue = badge.requiredValue();
         return badgeEntity;
     }
 
     public Badge toDomain() {
-        return new Badge(id, name, description, imagePath, type, requiredValue);
+        return new Badge(id, name, description, imageUrl, type, requiredValue);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberEntity.java
@@ -1,6 +1,5 @@
 package com.dnd.runus.infrastructure.persistence.jpa.member.entity;
 
-import com.dnd.runus.domain.badge.Badge;
 import com.dnd.runus.domain.common.BaseTimeEntity;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.global.constant.MemberRole;
@@ -29,23 +28,15 @@ public class MemberEntity extends BaseTimeEntity {
     @Size(max = 20)
     private String nickname;
 
-    private Long mainBadgeId;
-
     public static MemberEntity from(Member member) {
         MemberEntity memberEntity = new MemberEntity();
         memberEntity.id = member.memberId();
         memberEntity.role = member.role();
         memberEntity.nickname = member.nickname();
-        memberEntity.mainBadgeId =
-                member.mainBadge() == null ? null : member.mainBadge().badgeId();
         return memberEntity;
     }
 
     public Member toDomain() {
-        return toDomain(null);
-    }
-
-    public Member toDomain(Badge mainBadge) {
-        return new Member(id, getCreatedAt(), getUpdatedAt(), role, nickname, mainBadge);
+        return new Member(id, role, nickname, getCreatedAt(), getUpdatedAt());
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordReportResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordReportResponse.java
@@ -15,8 +15,6 @@ public record RunningRecordReportResponse(
         LocalDateTime endAt,
         RunningEmoji emoji,
         String nickname,
-        @Schema(description = "프로필 이미지 URL")
-        String profileUrl,
         @Schema(description = "챌린지 정보")
         ChallengeDto challenge,
         @NotNull
@@ -29,7 +27,6 @@ public record RunningRecordReportResponse(
                 runningRecord.endAt().toLocalDateTime(),
                 runningRecord.emoji(),
                 runningRecord.member().nickname(),
-                runningRecord.member().mainBadge() == null ? null : runningRecord.member().mainBadge().imageUrl(),
                 new ChallengeDto(-1), // TODO: 챌린지 기능 추가 후 수정
                 new RunningRecordMetricsDto(
                         runningRecord.averagePace(),

--- a/src/main/resources/db/migration/V5.0.1__remove_main_badge_alter_badge_image_column.sql
+++ b/src/main/resources/db/migration/V5.0.1__remove_main_badge_alter_badge_image_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member DROP COLUMN main_badge_id;
+ALTER TABLE badge RENAME COLUMN image_path TO image_url;
+ALTER TABLE badge ALTER COLUMN image_url TYPE VARCHAR(500);

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberEntityTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberEntityTest.java
@@ -1,8 +1,6 @@
 package com.dnd.runus.infrastructure.persistence.jpa.member.entity;
 
-import com.dnd.runus.domain.badge.Badge;
 import com.dnd.runus.domain.member.Member;
-import com.dnd.runus.global.constant.BadgeType;
 import com.dnd.runus.global.constant.MemberRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,9 +15,7 @@ class MemberEntityTest {
 
     @BeforeEach
     void setUp() {
-        Badge badge =
-                new Badge(1L, "badge name", "badge description", "https://badge.com", BadgeType.DISTANCE_METER, 1000);
-        member = new Member(1L, OffsetDateTime.now(), OffsetDateTime.now(), MemberRole.USER, "nickname", badge);
+        member = new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now());
     }
 
     @Test


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #79

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- POST `api/v1/running-records`의 반환 필드에서 profileUrl 필드를 삭제합니다.
- member table의 main badge id 컬럼을 삭제합니다.
- badge table의 image_path 컬럼명을 image_url로 변경하고, 타입을 VARCHAR 500으로 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- X
