### PR TITLE
Feat: member level 현재 경험치 조회 API 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/member/MemberService.java
+++ b/src/main/java/com/dnd/runus/application/member/MemberService.java
@@ -1,0 +1,29 @@
+package com.dnd.runus.application.member;
+
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.domain.member.MemberLevel;
+import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberLevelRepository memberLevelRepository;
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse getMyProfile(long memberId) {
+        MemberLevel.Current memberCurrentLevel = memberLevelRepository.findByMemberIdWithLevel(memberId);
+
+        long currentLevel = memberCurrentLevel.level().levelId();
+        long nextLevel = currentLevel + 1;
+
+        return new MyProfileResponse(
+                memberCurrentLevel.level().imageUrl(),
+                Level.formatExp(memberCurrentLevel.currentExp()),
+                Level.formatLevelName(nextLevel),
+                Level.formatExp(memberCurrentLevel.level().expRangeEnd() - memberCurrentLevel.currentExp()));
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/level/Level.java
+++ b/src/main/java/com/dnd/runus/domain/level/Level.java
@@ -1,3 +1,11 @@
 package com.dnd.runus.domain.level;
 
-public record Level(long levelId, int expRangeStart, int expRangeEnd, String imageUrl) {}
+public record Level(long levelId, int expRangeStart, int expRangeEnd, String imageUrl) {
+    public static String formatExp(int exp) {
+        return exp / 1_000 + "km";
+    }
+
+    public static String formatLevelName(long level) {
+        return "Level " + level;
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/member/MemberLevel.java
+++ b/src/main/java/com/dnd/runus/domain/member/MemberLevel.java
@@ -1,7 +1,11 @@
 package com.dnd.runus.domain.member;
 
+import com.dnd.runus.domain.level.Level;
+
 public record MemberLevel(long memberLevelId, Member member, long levelId, int exp) {
     public MemberLevel(Member member) {
         this(0, member, 1, 0);
     }
+
+    public record Current(Level level, int currentExp) {}
 }

--- a/src/main/java/com/dnd/runus/domain/member/MemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/domain/member/MemberLevelRepository.java
@@ -8,6 +8,8 @@ public interface MemberLevelRepository {
 
     Optional<MemberLevel> findByMemberId(long memberId);
 
+    MemberLevel.Current findByMemberIdWithLevel(long memberId);
+
     void deleteByMemberId(long memberId);
 
     void updateMemberLevel(long memberId, int plusExp);

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/member/MemberLevelRepositoryImpl.java
@@ -33,6 +33,11 @@ public class MemberLevelRepositoryImpl implements MemberLevelRepository {
     }
 
     @Override
+    public MemberLevel.Current findByMemberIdWithLevel(long memberId) {
+        return jooqMemberLevelRepository.findByMemberIdWithLevel(memberId);
+    }
+
+    @Override
     public void deleteByMemberId(long memberId) {
         jpaMemberLevelRepository.deleteByMemberId(memberId);
     }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/member/JooqMemberLevelRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/member/JooqMemberLevelRepository.java
@@ -1,8 +1,12 @@
 package com.dnd.runus.infrastructure.persistence.jooq.member;
 
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.domain.member.MemberLevel;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
 import org.springframework.stereotype.Repository;
 
 import static com.dnd.runus.jooq.Tables.LEVEL;
@@ -26,5 +30,27 @@ public class JooqMemberLevelRepository {
                                 .limit(1))
                 .where(MEMBER_LEVEL.MEMBER_ID.eq(memberId))
                 .execute();
+    }
+
+    public MemberLevel.Current findByMemberIdWithLevel(long memberId) {
+        return dsl.select()
+                .from(MEMBER_LEVEL)
+                .leftJoin(LEVEL)
+                .on(MEMBER_LEVEL.LEVEL_ID.eq(LEVEL.ID))
+                .where(MEMBER_LEVEL.MEMBER_ID.eq(memberId))
+                .fetchOne(new MemberLevelWithLevelMapper());
+    }
+
+    private static class MemberLevelWithLevelMapper implements RecordMapper<Record, MemberLevel.Current> {
+        @Override
+        public MemberLevel.Current map(Record record) {
+            return new MemberLevel.Current(
+                    new Level(
+                            record.get(LEVEL.ID, long.class),
+                            record.get(LEVEL.EXP_RANGE_START, int.class),
+                            record.get(LEVEL.EXP_RANGE_END, int.class),
+                            record.get(LEVEL.IMAGE_URL, String.class)),
+                    record.get(MEMBER_LEVEL.EXP, int.class));
+        }
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/member/MemberProfileController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/member/MemberProfileController.java
@@ -1,0 +1,24 @@
+package com.dnd.runus.presentation.v1.member;
+
+import com.dnd.runus.application.member.MemberService;
+import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/members/profiles")
+public class MemberProfileController {
+    private final MemberService memberService;
+
+    @GetMapping("me")
+    @ResponseStatus(HttpStatus.OK)
+    public MyProfileResponse getMyProfile(@MemberId long memberId) {
+        return memberService.getMyProfile(memberId);
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponse.java
@@ -1,0 +1,15 @@
+package com.dnd.runus.presentation.v1.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyProfileResponse(
+        @Schema(description = "현재 프로필 이미지")
+        String profileImageUrl,
+        @Schema(description = "지금까지 달린 거리")
+        String currentKm,
+        @Schema(description = "다음 레벨 이름")
+        String nextLevelName,
+        @Schema(description = "다음 레벨까지 남은 거리")
+        String nextLevelKm
+) {
+}

--- a/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
@@ -1,0 +1,58 @@
+package com.dnd.runus.application.member;
+
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.domain.member.MemberLevel;
+import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberLevelRepository memberLevelRepository;
+
+    @DisplayName("내 프로필 조회 성공 - 현재 레벨 1, 경험치 500일때, 0km로 표현 (소수점 버림)")
+    @Test
+    void getMyProfile_givenCurrentLevel1AndExp500_thenSuccess() {
+        // given
+        long memberId = 1L;
+        Level level = new Level(1, 0, 1000, "imageUrl");
+        given(memberLevelRepository.findByMemberIdWithLevel(memberId)).willReturn(new MemberLevel.Current(level, 500));
+
+        // when
+        MyProfileResponse myProfileResponse = memberService.getMyProfile(memberId);
+
+        // then
+        assertEquals("imageUrl", myProfileResponse.profileImageUrl());
+        assertEquals("0km", myProfileResponse.currentKm());
+        assertEquals("Level 2", myProfileResponse.nextLevelName());
+    }
+
+    @DisplayName("내 프로필 조회 성공 - 현재 레벨 2, 경험치 1500일때, 1km로 표현 (소수점 버림)")
+    @Test
+    void getMyProfile_givenCurrentLevel1AndExp1500_thenSuccess() {
+        // given
+        long memberId = 1L;
+        Level level = new Level(2, 1000, 2000, "imageUrl");
+        given(memberLevelRepository.findByMemberIdWithLevel(memberId)).willReturn(new MemberLevel.Current(level, 1500));
+
+        // when
+        MyProfileResponse myProfileResponse = memberService.getMyProfile(memberId);
+
+        // then
+        assertEquals("imageUrl", myProfileResponse.profileImageUrl());
+        assertEquals("1km", myProfileResponse.currentKm());
+        assertEquals("Level 3", myProfileResponse.nextLevelName());
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #75 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `api/v1/members/profiles/me`: 자신의 프로필 조회

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 사용자 자신의 프로필 조회 API를 새롭게 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 달린 거리를 문자열로 변환하는 로직은 `Level` 도메인 클래스에 두었는데 좋을까요?
- 컨트롤러 테스트는 없고, 서비스 테스트만 추가했어요
