### PR TITLE
Feat: 획득한 badge 조회 API 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/badge/BadgeService.java
+++ b/src/main/java/com/dnd/runus/application/badge/BadgeService.java
@@ -1,0 +1,22 @@
+package com.dnd.runus.application.badge;
+
+import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.presentation.v1.badge.dto.response.AchievedBadgesResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+    private final BadgeAchievementRepository badgeAchievementRepository;
+
+    public AchievedBadgesResponse getAchievedBadges(long memberId) {
+        return new AchievedBadgesResponse(badgeAchievementRepository.findByMemberIdWithBadge(memberId).stream()
+                .map(badgeAchievement -> new AchievedBadgesResponse.AchievedBadge(
+                        badgeAchievement.badge().badgeId(),
+                        badgeAchievement.badge().name(),
+                        badgeAchievement.badge().imageUrl(),
+                        badgeAchievement.createdAt().toLocalDateTime()))
+                .toList());
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeAchievement.java
@@ -10,4 +10,6 @@ public record BadgeAchievement(
     public BadgeAchievement(Badge badge, Member member) {
         this(0, badge, member, null, null);
     }
+
+    public record OnlyBadge(long badgeAchievementId, Badge badge, OffsetDateTime createdAt, OffsetDateTime updatedAt) {}
 }

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeAchievementRepository.java
@@ -1,10 +1,13 @@
 package com.dnd.runus.domain.badge;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BadgeAchievementRepository {
 
     Optional<BadgeAchievement> findById(long id);
+
+    List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadge(long memberId);
 
     BadgeAchievement save(BadgeAchievement badgeAchievement);
 

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImpl.java
@@ -2,11 +2,13 @@ package com.dnd.runus.infrastructure.persistence.domain.badge;
 
 import com.dnd.runus.domain.badge.BadgeAchievement;
 import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.infrastructure.persistence.jooq.badge.JooqBadgeAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.badge.JpaBadgeAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.badge.entity.BadgeAchievementEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,10 +16,16 @@ import java.util.Optional;
 public class BadgeAchievementRepositoryImpl implements BadgeAchievementRepository {
 
     private final JpaBadgeAchievementRepository jpaBadgeAchievementRepository;
+    private final JooqBadgeAchievementRepository jooqBadgeAchievementRepository;
 
     @Override
     public Optional<BadgeAchievement> findById(long id) {
         return jpaBadgeAchievementRepository.findById(id).map(BadgeAchievementEntity::toDomain);
+    }
+
+    @Override
+    public List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadge(long memberId) {
+        return jooqBadgeAchievementRepository.findByMemberIdWithBadge(memberId);
     }
 
     @Override

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
@@ -1,0 +1,40 @@
+package com.dnd.runus.infrastructure.persistence.jooq.badge;
+
+import com.dnd.runus.domain.badge.BadgeAchievement;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static com.dnd.runus.jooq.Tables.BADGE;
+import static com.dnd.runus.jooq.Tables.BADGE_ACHIEVEMENT;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqBadgeAchievementRepository {
+    private final DSLContext dsl;
+
+    public List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadge(long memberId) {
+        return dsl.select()
+                .from(BADGE_ACHIEVEMENT)
+                .join(BADGE)
+                .on(BADGE_ACHIEVEMENT.BADGE_ID.eq(BADGE.ID))
+                .where(BADGE_ACHIEVEMENT.MEMBER_ID.eq(memberId))
+                .fetch(new BadgeAchievementMapper());
+    }
+
+    private static class BadgeAchievementMapper implements RecordMapper<Record, BadgeAchievement.OnlyBadge> {
+        @Override
+        public BadgeAchievement.OnlyBadge map(Record record) {
+            return new BadgeAchievement.OnlyBadge(
+                    record.get(BADGE_ACHIEVEMENT.ID),
+                    new JooqBadgeMapper().map(record),
+                    record.get(BADGE_ACHIEVEMENT.CREATED_AT, OffsetDateTime.class),
+                    record.get(BADGE_ACHIEVEMENT.UPDATED_AT, OffsetDateTime.class));
+        }
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeMapper.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeMapper.java
@@ -1,0 +1,22 @@
+package com.dnd.runus.infrastructure.persistence.jooq.badge;
+
+import com.dnd.runus.domain.badge.Badge;
+import com.dnd.runus.global.constant.BadgeType;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+
+import static com.dnd.runus.jooq.Tables.BADGE;
+
+public class JooqBadgeMapper implements RecordMapper<Record, Badge> {
+
+    @Override
+    public Badge map(Record record) {
+        return new Badge(
+                record.get(BADGE.ID),
+                record.get(BADGE.NAME),
+                record.get(BADGE.DESCRIPTION),
+                record.get(BADGE.IMAGE_URL),
+                BadgeType.valueOf(record.get(BADGE.TYPE)),
+                record.get(BADGE.REQUIRED_VALUE));
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/badge/BadgeController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/badge/BadgeController.java
@@ -1,0 +1,23 @@
+package com.dnd.runus.presentation.v1.badge;
+
+import com.dnd.runus.application.badge.BadgeService;
+import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.badge.dto.response.AchievedBadgesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/badges")
+public class BadgeController {
+    private final BadgeService badgeService;
+
+    @GetMapping("/me")
+    @Operation(summary = "자신이 획득한 뱃지 전체 조회", description = "자신이 획득한 뱃지를 전체 조회합니다.")
+    public AchievedBadgesResponse getMyBadges(@MemberId long memberId) {
+        return badgeService.getAchievedBadges(memberId);
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/badge/dto/response/AchievedBadgesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/badge/dto/response/AchievedBadgesResponse.java
@@ -1,0 +1,16 @@
+package com.dnd.runus.presentation.v1.badge.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AchievedBadgesResponse(
+        List<AchievedBadge> badges
+) {
+    public record AchievedBadge(
+            long badgeId,
+            String name,
+            String imageUrl,
+            LocalDateTime achievedAt
+    ) {
+    }
+}

--- a/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
@@ -1,0 +1,67 @@
+package com.dnd.runus.application.badge;
+
+import com.dnd.runus.domain.badge.Badge;
+import com.dnd.runus.domain.badge.BadgeAchievement;
+import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.global.constant.BadgeType;
+import com.dnd.runus.presentation.v1.badge.dto.response.AchievedBadgesResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class BadgeServiceTest {
+    @InjectMocks
+    private BadgeService badgeService;
+
+    @Mock
+    private BadgeAchievementRepository badgeAchievementRepository;
+
+    @Test
+    @DisplayName("자신이 획득한 뱃지 전체 조회에 성공")
+    void getAchievedBadges() {
+        // given
+        Badge badge1 = new Badge(1L, "badge1", "description", "imageUrl1", BadgeType.RUNNING_COUNT, 100);
+        Badge badge2 = new Badge(2L, "badge2", "description", "imageUrl2", BadgeType.DISTANCE_METER, 1000);
+
+        given(badgeAchievementRepository.findByMemberIdWithBadge(1L))
+                .willReturn(List.of(
+                        new BadgeAchievement.OnlyBadge(1, badge1, OffsetDateTime.now(), OffsetDateTime.now()),
+                        new BadgeAchievement.OnlyBadge(2, badge2, OffsetDateTime.now(), OffsetDateTime.now())));
+
+        // when
+        AchievedBadgesResponse achievedBadgesResponse = badgeService.getAchievedBadges(1L);
+
+        // then
+        List<AchievedBadgesResponse.AchievedBadge> achievedBadges = achievedBadgesResponse.badges();
+        AchievedBadgesResponse.AchievedBadge achievedBadge1 = achievedBadges.get(0);
+        AchievedBadgesResponse.AchievedBadge achievedBadge2 = achievedBadges.get(1);
+        assertEquals("badge1", achievedBadge1.name());
+        assertEquals("imageUrl1", achievedBadge1.imageUrl());
+        assertEquals("badge2", achievedBadge2.name());
+        assertEquals("imageUrl2", achievedBadge2.imageUrl());
+    }
+
+    @Test
+    @DisplayName("자신이 획득한 뱃지가 없다면, 뱃지가 없는 응답을 반환한다.")
+    void getAchievedBadges_Empty() {
+        // given
+        given(badgeAchievementRepository.findByMemberIdWithBadge(1L)).willReturn(List.of());
+
+        // when
+        AchievedBadgesResponse achievedBadgesResponse = badgeService.getAchievedBadges(1L);
+
+        // then
+        List<AchievedBadgesResponse.AchievedBadge> achievedBadges = achievedBadgesResponse.badges();
+        assertEquals(0, achievedBadges.size());
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #83 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `api/v1/badges/me`: 사용자가 획득한 배지 정보(이름, 이미지 url, 획득 일자)들을 반환합니다.

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 사용자가 획득한 배지 정보 조회 API를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- `BadgeAchievement`를 조회할 때, member는 같이 조회할 필요가 없어서, `BadgeAchievement.OnlyBadge`라는 도메인 클래스를 추가했습니다.
- 더 좋은 이름이 있으면 좋을 것 같은데 잘 모르겠어요
- 다른 방법으로는 `badge_achivement` 테이블에서 조회할때 `OnlyBadge`라는 도메인 클래스없이,
   `BadgeAchievement` 도메인 클래스를 사용해서 member도 같이 조인해서 조회하는 게 나을까요?
