### PR TITLE
Fix: level formatExp에서 최대 소수점 2자리까지 표현하도록 변경

### DIFF
--- a/src/main/java/com/dnd/runus/domain/level/Level.java
+++ b/src/main/java/com/dnd/runus/domain/level/Level.java
@@ -2,7 +2,18 @@ package com.dnd.runus.domain.level;
 
 public record Level(long levelId, int expRangeStart, int expRangeEnd, String imageUrl) {
     public static String formatExp(int exp) {
-        return exp / 1_000 + "km";
+        double km = exp / 1000.0;
+        String formatted = String.format("%.2f", km);
+
+        if (formatted.contains(".")) {
+            formatted = formatted.replaceAll("0*$", "");
+        }
+
+        if (formatted.endsWith(".")) {
+            formatted = formatted.substring(0, formatted.length() - 1);
+        }
+
+        return formatted + "km";
     }
 
     public static String formatLevelName(long level) {

--- a/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
@@ -35,7 +35,7 @@ class MemberServiceTest {
 
         // then
         assertEquals("imageUrl", myProfileResponse.profileImageUrl());
-        assertEquals("0km", myProfileResponse.currentKm());
+        assertEquals("0.5km", myProfileResponse.currentKm());
         assertEquals("Level 2", myProfileResponse.nextLevelName());
     }
 
@@ -52,7 +52,7 @@ class MemberServiceTest {
 
         // then
         assertEquals("imageUrl", myProfileResponse.profileImageUrl());
-        assertEquals("1km", myProfileResponse.currentKm());
+        assertEquals("1.5km", myProfileResponse.currentKm());
         assertEquals("Level 3", myProfileResponse.nextLevelName());
     }
 }

--- a/src/test/java/com/dnd/runus/domain/level/LevelTest.java
+++ b/src/test/java/com/dnd/runus/domain/level/LevelTest.java
@@ -1,0 +1,26 @@
+package com.dnd.runus.domain.level;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LevelTest {
+    @DisplayName("Level 클래스의 formatExp 메서드는 경험치를 km 단위로 소수점 두 자리까지 0을 생략해서 표시한다.")
+    @Test
+    void formatExp() {
+        assertEquals("0km", Level.formatExp(0));
+        assertEquals("0.5km", Level.formatExp(500));
+        assertEquals("0.56km", Level.formatExp(560));
+        assertEquals("1km", Level.formatExp(1000));
+        assertEquals("1.01km", Level.formatExp(1010));
+        assertEquals("1.1km", Level.formatExp(1100));
+        assertEquals("1.23km", Level.formatExp(1230));
+        assertEquals("1.23km", Level.formatExp(1234));
+    }
+
+    @Test
+    void formatLevelName() {
+        assertEquals("Level 2", Level.formatLevelName(2));
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #75

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 사용자의 레벨에서 경험치는 지금 기획상에서는 러닝한 meter 단위입니다.
- 경험치를 문자열로 변환할때, 

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- X
