### PR TITLE
Fix : 챌린지 성취 관련 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
+++ b/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
@@ -6,8 +6,6 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
 import com.dnd.runus.domain.challenge.achievement.dto.ChallengeAchievementDto;
-import com.dnd.runus.domain.member.Member;
-import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.global.exception.NotFoundException;
@@ -30,7 +28,6 @@ public class ChallengeService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeAchievementRepository challengeAchievementRepository;
 
-    private final MemberRepository memberRepository;
     private final RunningRecordRepository runningRecordRepository;
 
     public List<ChallengesResponse> getChallenges(long memberId) {
@@ -48,7 +45,7 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeAchievementDto save(Member member, RunningRecord runningRecord, long challengeId) {
+    public ChallengeAchievementDto save(RunningRecord runningRecord, long challengeId) {
         Challenge challenge = challengeRepository
                 .findById(challengeId)
                 .orElseThrow(() -> new NotFoundException(Challenge.class, challengeId));
@@ -62,7 +59,7 @@ public class ChallengeService {
             OffsetDateTime yesterdayMidnight = midnight.minusDays(1);
 
             RunningRecord yesterdayRecord = runningRecordRepository
-                    .findByMemberIdAndStartAtBetween(member.memberId(), yesterdayMidnight, midnight)
+                    .findByMemberIdAndStartAtBetween(runningRecord.member().memberId(), yesterdayMidnight, midnight)
                     .get(0);
 
             challenge
@@ -74,7 +71,7 @@ public class ChallengeService {
         ChallengeAchievementRecord achievementRecord = challenge.getAchievementRecord(runningRecord);
 
         ChallengeAchievement savedAchievement = challengeAchievementRepository.save(
-                new ChallengeAchievement(member, runningRecord, challengeId, achievementRecord));
+                new ChallengeAchievement(runningRecord.member(), runningRecord, challengeId, achievementRecord));
 
         return ChallengeAchievementDto.from(savedAchievement, challenge);
     }

--- a/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
+++ b/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
@@ -5,12 +5,12 @@ import com.dnd.runus.domain.challenge.ChallengeRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.dto.ChallengeAchievementDto;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.global.exception.NotFoundException;
-import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengeAchievementResponse;
 import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,9 +48,7 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeAchievementResponse save(long memberId, RunningRecord runningRecord, long challengeId) {
-        Member member =
-                memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(Member.class, memberId));
+    public ChallengeAchievementDto save(Member member, RunningRecord runningRecord, long challengeId) {
         Challenge challenge = challengeRepository
                 .findById(challengeId)
                 .orElseThrow(() -> new NotFoundException(Challenge.class, challengeId));
@@ -64,7 +62,7 @@ public class ChallengeService {
             OffsetDateTime yesterdayMidnight = midnight.minusDays(1);
 
             RunningRecord yesterdayRecord = runningRecordRepository
-                    .findByMemberIdAndStartAtBetween(memberId, yesterdayMidnight, midnight)
+                    .findByMemberIdAndStartAtBetween(member.memberId(), yesterdayMidnight, midnight)
                     .get(0);
 
             challenge
@@ -78,11 +76,11 @@ public class ChallengeService {
         ChallengeAchievement savedAchievement = challengeAchievementRepository.save(
                 new ChallengeAchievement(member, runningRecord, challengeId, achievementRecord));
 
-        return ChallengeAchievementResponse.from(savedAchievement, challenge);
+        return ChallengeAchievementDto.from(savedAchievement, challenge);
     }
 
     @Transactional(readOnly = true)
-    public ChallengeAchievementResponse findChallengeAchievementBy(long memberId, long runningId) {
+    public ChallengeAchievementDto findChallengeAchievementBy(long memberId, long runningId) {
 
         ChallengeAchievement challengeAchievement = challengeAchievementRepository
                 .findByMemberIdAndRunningRecordId(memberId, runningId)
@@ -95,6 +93,6 @@ public class ChallengeService {
                 .findById(challengeAchievement.challengeId())
                 .orElseThrow(() -> new NotFoundException(Challenge.class, challengeAchievement.challengeId()));
 
-        return ChallengeAchievementResponse.from(challengeAchievement, challenge);
+        return ChallengeAchievementDto.from(challengeAchievement, challenge);
     }
 }

--- a/src/main/java/com/dnd/runus/domain/challenge/ChallengeCondition.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/ChallengeCondition.java
@@ -11,7 +11,7 @@ public class ChallengeCondition {
 
     private final long challengeConditionId;
     private final long challengeId;
-    private final ChallengeGoalType goalType;
+    private final GoalType goalType;
     private final ComparisonType comparisonType;
     private final int goalValue; // 목표 값(챌린지가 지정한)
 
@@ -20,7 +20,7 @@ public class ChallengeCondition {
     public ChallengeCondition(
             long challengeConditionId,
             long challengeId,
-            ChallengeGoalType goalType,
+            GoalType goalType,
             ComparisonType comparisonType,
             int goalValue) {
         this.challengeConditionId = challengeConditionId;

--- a/src/main/java/com/dnd/runus/domain/challenge/GoalType.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/GoalType.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
  * <p>챌린지 타입에 따라 챌린지 결과 기록을 다르게 계산합니다.
  */
 @RequiredArgsConstructor
-public enum ChallengeGoalType {
+public enum GoalType {
     DISTANCE,
     TIME,
     PACE,

--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/dto/ChallengeAchievementDto.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/dto/ChallengeAchievementDto.java
@@ -1,16 +1,13 @@
-package com.dnd.runus.presentation.v1.challenge.dto.response;
+package com.dnd.runus.domain.challenge.achievement.dto;
 
 
 import com.dnd.runus.domain.challenge.Challenge;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
-import com.dnd.runus.global.constant.ChallengeResultComment;
+import com.dnd.runus.global.constant.RunningResultComment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jetbrains.annotations.NotNull;
 
-public record ChallengeAchievementResponse(
-    @NotNull
-    @Schema(description = "챌린지 id")
-    long challengeId,
+public record ChallengeAchievementDto(
     @NotNull
     @Schema(description = "챌린지 이미지 url")
     String imageUrl,
@@ -27,12 +24,11 @@ public record ChallengeAchievementResponse(
     @Schema(description = "챌린지 성공, 실패 여부")
     Boolean successStatus
 ) {
-    public static ChallengeAchievementResponse from(ChallengeAchievement achievement, Challenge challenge) {
-        return new ChallengeAchievementResponse(
-            challenge.challengeId(),
+    public static ChallengeAchievementDto from(ChallengeAchievement achievement, Challenge challenge) {
+        return new ChallengeAchievementDto(
             challenge.imageUrl(),
             challenge.name(),
-            ChallengeResultComment.getComment(achievement.record().successStatus()),
+            RunningResultComment.getComment(achievement.record().successStatus()),
             achievement.record().successStatus()
         );
     }

--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/dto/ChallengeAchievementDto.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/dto/ChallengeAchievementDto.java
@@ -3,7 +3,7 @@ package com.dnd.runus.domain.challenge.achievement.dto;
 
 import com.dnd.runus.domain.challenge.Challenge;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
-import com.dnd.runus.global.constant.RunningResultComment;
+import com.dnd.runus.global.constant.ChallengeResultComment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,7 +28,7 @@ public record ChallengeAchievementDto(
         return new ChallengeAchievementDto(
             challenge.imageUrl(),
             challenge.name(),
-            RunningResultComment.getComment(achievement.record().successStatus()),
+            ChallengeResultComment.getComment(achievement.record().successStatus()),
             achievement.record().successStatus()
         );
     }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeData.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeData.java
@@ -2,8 +2,8 @@ package com.dnd.runus.infrastructure.persistence.jpa.challenge.entity;
 
 import com.dnd.runus.domain.challenge.Challenge;
 import com.dnd.runus.domain.challenge.ChallengeCondition;
-import com.dnd.runus.domain.challenge.ChallengeGoalType;
 import com.dnd.runus.domain.challenge.ChallengeType;
+import com.dnd.runus.domain.challenge.GoalType;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -12,12 +12,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.dnd.runus.domain.challenge.ChallengeGoalType.DISTANCE;
-import static com.dnd.runus.domain.challenge.ChallengeGoalType.PACE;
-import static com.dnd.runus.domain.challenge.ChallengeGoalType.TIME;
 import static com.dnd.runus.domain.challenge.ChallengeType.DEFEAT_YESTERDAY;
 import static com.dnd.runus.domain.challenge.ChallengeType.DISTANCE_IN_TIME;
 import static com.dnd.runus.domain.challenge.ChallengeType.TODAY;
+import static com.dnd.runus.domain.challenge.GoalType.DISTANCE;
+import static com.dnd.runus.domain.challenge.GoalType.PACE;
+import static com.dnd.runus.domain.challenge.GoalType.TIME;
 
 /**
  * ChallengeData 오늘의 챌린지 data입니다. (FIXME)
@@ -25,7 +25,7 @@ import static com.dnd.runus.domain.challenge.ChallengeType.TODAY;
  * <p>{@code expectedTime} : 예상 소모 시간(sec),
  * <p> 목표가 시간이면 해당 시간(분*60)으로, 거리면 거리(km)* 기본페이스(8분)*60 으로,
  * 거리+페이스면 거리면 거리(km)* 페이스(분)*60 으로, 페이스면 0으로 직접 입력합니다.
- * <p>{@code targetValues} : Map<GoalType, Integer> key: {@link ChallengeGoalType} 값, value:
+ * <p>{@code targetValues} : Map<GoalType, Integer> key: {@link GoalType} 값, value:
  * GoalType과 관련된 목표 값
  * DISTANCE는 미터, TIME과 PACE는 초단위다.
  */
@@ -78,7 +78,7 @@ public enum ChallengeData {
     private final String expectedTime;
     private final String name;
     private final ChallengeType challengeType;
-    private final Map<ChallengeGoalType, Integer> targetValues;
+    private final Map<GoalType, Integer> targetValues;
     private final String imageUrl;
 
     public static List<ChallengeData> getChallenges(boolean hasPreRecord) {

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -4,6 +4,7 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengePercentageValues;
+import com.dnd.runus.domain.challenge.achievement.dto.ChallengeAchievementDto;
 import com.dnd.runus.domain.challenge.*;
 import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.common.Pace;
@@ -13,7 +14,6 @@ import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
-import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengeAchievementResponse;
 import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengesResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -124,8 +124,7 @@ class ChallengeServiceTest {
                 "25분",
                 "url",
                 ChallengeType.DEFEAT_YESTERDAY,
-                List.of(new ChallengeCondition(
-                        1, 1, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
+                List.of(new ChallengeCondition(1, 1, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
 
         OffsetDateTime yesterdayMidnight = todayMidnight.minusDays(1);
 
@@ -173,8 +172,7 @@ class ChallengeServiceTest {
         given(challengeAchievementRepository.save(expected)).willReturn(expected);
 
         // when
-        ChallengeAchievementResponse response =
-                challengeService.save(member.memberId(), runningRecord, challenge.challengeId());
+        ChallengeAchievementDto response = challengeService.save(member, runningRecord, challenge.challengeId());
 
         // then
         assertNotNull(response);
@@ -194,8 +192,7 @@ class ChallengeServiceTest {
                 "25분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(
-                        1, 1, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
+                List.of(new ChallengeCondition(1, 1, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
 
         RunningRecord runningRecord = new RunningRecord(
                 2,
@@ -211,7 +208,6 @@ class ChallengeServiceTest {
                 "end location",
                 RunningEmoji.SOSO);
 
-        given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
         given(challengeRepository.findById(challenge.challengeId())).willReturn(Optional.of(challenge));
 
         ChallengePercentageValues percentageValues =
@@ -224,8 +220,7 @@ class ChallengeServiceTest {
         given(challengeAchievementRepository.save(expected)).willReturn(expected);
 
         // when
-        ChallengeAchievementResponse response =
-                challengeService.save(member.memberId(), runningRecord, challenge.challengeId());
+        ChallengeAchievementDto response = challengeService.save(member, runningRecord, challenge.challengeId());
 
         // then
         assertNotNull(response);
@@ -245,8 +240,7 @@ class ChallengeServiceTest {
                 "25분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(
-                        1L, challengeId, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, 1000)));
+                List.of(new ChallengeCondition(1L, challengeId, GoalType.DISTANCE, ComparisonType.GREATER, 1000)));
         RunningRecord runningRecord = new RunningRecord(
                 runningId,
                 new Member(MemberRole.USER, "nickname"),
@@ -270,8 +264,7 @@ class ChallengeServiceTest {
         given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
 
         // when
-        ChallengeAchievementResponse response =
-                challengeService.findChallengeAchievementBy(member.memberId(), runningId);
+        ChallengeAchievementDto response = challengeService.findChallengeAchievementBy(member.memberId(), runningId);
 
         // then
         assertNotNull(response);
@@ -289,8 +282,7 @@ class ChallengeServiceTest {
                 .willReturn(Optional.empty());
 
         // when
-        ChallengeAchievementResponse response =
-                challengeService.findChallengeAchievementBy(member.memberId(), runningId);
+        ChallengeAchievementDto response = challengeService.findChallengeAchievementBy(member.memberId(), runningId);
 
         // then
         assertNull(response);

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -9,7 +9,6 @@ import com.dnd.runus.domain.challenge.*;
 import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.member.Member;
-import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.global.constant.MemberRole;
@@ -48,9 +47,6 @@ class ChallengeServiceTest {
 
     @Mock
     private ChallengeRepository challengeRepository;
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @InjectMocks
     private ChallengeService challengeService;
@@ -156,7 +152,6 @@ class ChallengeServiceTest {
                 "end location",
                 RunningEmoji.SOSO);
 
-        given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
         given(challengeRepository.findById(challenge.challengeId())).willReturn(Optional.of(challenge));
         given(runningRecordRepository.findByMemberIdAndStartAtBetween(
                         member.memberId(), yesterdayMidnight, todayMidnight))

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -167,7 +167,7 @@ class ChallengeServiceTest {
         given(challengeAchievementRepository.save(expected)).willReturn(expected);
 
         // when
-        ChallengeAchievementDto response = challengeService.save(member, runningRecord, challenge.challengeId());
+        ChallengeAchievementDto response = challengeService.save(runningRecord, challenge.challengeId());
 
         // then
         assertNotNull(response);
@@ -215,7 +215,7 @@ class ChallengeServiceTest {
         given(challengeAchievementRepository.save(expected)).willReturn(expected);
 
         // when
-        ChallengeAchievementDto response = challengeService.save(member, runningRecord, challenge.challengeId());
+        ChallengeAchievementDto response = challengeService.save(runningRecord, challenge.challengeId());
 
         // then
         assertNotNull(response);

--- a/src/test/java/com/dnd/runus/domain/challenge/ChallengeTest.java
+++ b/src/test/java/com/dnd/runus/domain/challenge/ChallengeTest.java
@@ -38,14 +38,14 @@ class ChallengeTest {
                 "0분",
                 "url",
                 ChallengeType.DEFEAT_YESTERDAY,
-                List.of(new ChallengeCondition(1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, 500)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, 500)));
         Challenge todyaChallenge = new Challenge(
                 1L,
                 "otherChallenge",
                 "0분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, 500)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, 500)));
         Challenge otherChallenge = new Challenge(
                 1L,
                 "otherChallenge",
@@ -53,8 +53,8 @@ class ChallengeTest {
                 "url",
                 ChallengeType.DISTANCE_IN_TIME,
                 List.of(
-                        new ChallengeCondition(1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, 500),
-                        new ChallengeCondition(1L, 1L, ChallengeGoalType.PACE, ComparisonType.GREATER, 6 * 60)));
+                        new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, 500),
+                        new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.GREATER, 6 * 60)));
 
         // when & then
         assertTrue(defeatYesterdayChallenge.isDefeatYesterdayChallenge());
@@ -76,8 +76,7 @@ class ChallengeTest {
                 "4분",
                 "url",
                 ChallengeType.DEFEAT_YESTERDAY,
-                List.of(new ChallengeCondition(
-                        1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalChallengeDis)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalChallengeDis)));
 
         Challenge challengeDataForTime = new Challenge(
                 2L,
@@ -85,8 +84,7 @@ class ChallengeTest {
                 "10분",
                 "url",
                 ChallengeType.DEFEAT_YESTERDAY,
-                List.of(new ChallengeCondition(
-                        1L, 2L, ChallengeGoalType.TIME, ComparisonType.GREATER, goalChallengeTime)));
+                List.of(new ChallengeCondition(1L, 2L, GoalType.TIME, ComparisonType.GREATER, goalChallengeTime)));
         Challenge challengeDataForPace = new Challenge(
                 3L,
                 "어제보다 10초 더빠른 페이스로 달리기",
@@ -94,7 +92,7 @@ class ChallengeTest {
                 "url",
                 ChallengeType.DEFEAT_YESTERDAY,
                 List.of(new ChallengeCondition(
-                        3L, 2L, ChallengeGoalType.PACE, ComparisonType.LESS, goalChallengePace.toSeconds())));
+                        3L, 2L, GoalType.PACE, ComparisonType.LESS, goalChallengePace.toSeconds())));
 
         RunningRecord yesterdayRecord = new RunningRecord(
                 0,
@@ -149,8 +147,7 @@ class ChallengeTest {
                 "25분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(
-                        1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
         RunningRecord runningRecord = new RunningRecord(
                 0,
                 new Member(MemberRole.USER, "nickname"),
@@ -190,8 +187,7 @@ class ChallengeTest {
                 "25분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(
-                        1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance)));
 
         RunningRecord runningRecord = new RunningRecord(
                 0,
@@ -233,7 +229,7 @@ class ChallengeTest {
                 "1시간 30분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(1L, 1L, ChallengeGoalType.TIME, ComparisonType.GREATER, goalTime)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.TIME, ComparisonType.GREATER, goalTime)));
         RunningRecord runningRecord = new RunningRecord(
                 0,
                 new Member(MemberRole.USER, "nickname"),
@@ -278,7 +274,7 @@ class ChallengeTest {
                 "1시간 30분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(1L, 1L, ChallengeGoalType.TIME, ComparisonType.GREATER, goalTime)));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.TIME, ComparisonType.GREATER, goalTime)));
 
         RunningRecord runningRecord = new RunningRecord(
                 0,
@@ -323,7 +319,7 @@ class ChallengeTest {
                 "0분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(1L, 1L, ChallengeGoalType.PACE, ComparisonType.LESS, pace.toSeconds())));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.LESS, pace.toSeconds())));
 
         RunningRecord runningRecord = new RunningRecord(
                 0,
@@ -359,7 +355,7 @@ class ChallengeTest {
                 "1시간 30분",
                 "url",
                 ChallengeType.TODAY,
-                List.of(new ChallengeCondition(1L, 1L, ChallengeGoalType.PACE, ComparisonType.LESS, pace.toSeconds())));
+                List.of(new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.LESS, pace.toSeconds())));
 
         RunningRecord runningRecord = new RunningRecord(
                 0,
@@ -398,10 +394,8 @@ class ChallengeTest {
                 "url",
                 ChallengeType.DISTANCE_IN_TIME,
                 List.of(
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
+                        new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
+                        new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
         RunningRecord runningRecord = new RunningRecord(
                 0,
                 new Member(MemberRole.USER, "nickname"),
@@ -439,10 +433,8 @@ class ChallengeTest {
                 "url",
                 ChallengeType.DISTANCE_IN_TIME,
                 List.of(
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
+                        new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
+                        new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
         RunningRecord runningRecord = new RunningRecord(
                 0,
                 new Member(MemberRole.USER, "nickname"),
@@ -480,10 +472,8 @@ class ChallengeTest {
                 "url",
                 ChallengeType.DISTANCE_IN_TIME,
                 List.of(
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
+                        new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
+                        new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
 
         RunningRecord runningRecord = new RunningRecord(
                 0,
@@ -522,10 +512,8 @@ class ChallengeTest {
                 "url",
                 ChallengeType.DISTANCE_IN_TIME,
                 List.of(
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
-                        new ChallengeCondition(
-                                1L, 1L, ChallengeGoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
+                        new ChallengeCondition(1L, 1L, GoalType.DISTANCE, ComparisonType.GREATER, goalDistance),
+                        new ChallengeCondition(1L, 1L, GoalType.PACE, ComparisonType.LESS, goalPace.toSeconds())));
 
         RunningRecord runningRecord = new RunningRecord(
                 0,


### PR DESCRIPTION
- 목표 성취 도메인과 같이 사용하기위해 ChallengeGoalType -> GoalType 으로 변경
- 성취 save 메서드 인자 memberId에서 member객체로 변경

## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- X

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 목표 성취와 같이 사용하면 좋을 것 같아서 ChallengeGoalType을 -> GoalType으로 변경했습니다.
- 챌린지 성취를 저장메서드는 러닝 저장 메서드에서 불러와서 memberId로 find한후 저장한는 것보다 메서드 호출시 member 도메인을 인자로 받는게 좋을 것 같아서 long memberId -> Member member로 변경했습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 아래 사항 보고 러닝 서비스에 챌린지 관련 로직 추가하시면 될 것 같습니다.
- 러닝 저장 후 -> 러닝 타입이 챌린지 일경우 -> save(Member member, RunningRecord runningRecord, long challengeId) 호출하고 -> ChallengeAchievementDto값을 리턴 값에 추가 하면 될 것 같습니다.
- 러닝 상세 조회 -> 러닝 타입이 챌린지 일경우 findChallengeAchievementBy(long memberId, long runningId) 호출 -> ChallengeAchievementDto값을 리턴 값에 추가 하면 될 것 같습니다.
- findChallengeAchievementBy는 러닝 타입이 없을 을 때 구현 완료 된 값이라, 성취 챌린지가 없을 경우 null 값을 보내 줬는데 추후에 값이 없을 경우 오류 처리를 하는게 좋을 것 같은데 어떻게 생각하시나요?
