### PR TITLE
Feat: 이번 달 러닝 기록 조회 구현

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -129,7 +129,7 @@ public class RunningRecordService {
 
         int monthValue = startDateOfMonth.getMonthValue();
 
-        int monthlyTotalDistance = runningRecordRepository.findMonthlyTotalDistanceByMemberId(
+        int monthlyTotalDistance = runningRecordRepository.findMonthlyTotalDistanceMeterByMemberId(
                 memberId, startDateOfMonth, startDateOfNextMonth);
 
         MemberLevel.Current currentMemberLevel = memberLevelRepository.findByMemberIdWithLevel(memberId);

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -129,7 +129,7 @@ public class RunningRecordService {
 
         int monthValue = startDateOfMonth.getMonthValue();
 
-        int monthlyTotalDistance = runningRecordRepository.findMonthlyTotalDistanceMeterByMemberId(
+        int monthlyTotalDistance = runningRecordRepository.findTotalDistanceMeterByMemberId(
                 memberId, startDateOfMonth, startDateOfNextMonth);
 
         MemberLevel.Current currentMemberLevel = memberLevelRepository.findByMemberIdWithLevel(memberId);

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -7,7 +7,9 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.level.Level;
 import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevel;
 import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
@@ -17,6 +19,7 @@ import com.dnd.runus.global.exception.NotFoundException;
 import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordSummaryResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -26,6 +29,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
@@ -114,6 +118,30 @@ public class RunningRecordService {
             }
         }
         return RunningRecordAddResultResponse.from(record);
+    }
+
+    @Transactional(readOnly = true)
+    public RunningRecordMonthlySummaryResponse getMonthlyRunningSummery(long memberId) {
+
+        OffsetDateTime startDateOfMonth =
+                OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE)).withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+        OffsetDateTime startDateOfNextMonth = startDateOfMonth.plusMonths(1);
+
+        int monthValue = startDateOfMonth.getMonthValue();
+
+        int monthlyTotalDistance = runningRecordRepository.findMonthlyTotalDistanceByMemberId(
+                memberId, startDateOfMonth, startDateOfNextMonth);
+
+        MemberLevel.Current currentMemberLevel = memberLevelRepository.findByMemberIdWithLevel(memberId);
+
+        long nextLevel = currentMemberLevel.level().levelId() + 1;
+        int remainingKmToNextLevel = currentMemberLevel.level().expRangeEnd() - currentMemberLevel.currentExp();
+
+        return new RunningRecordMonthlySummaryResponse(
+                monthValue,
+                monthlyTotalDistance,
+                Level.formatLevelName(nextLevel),
+                Level.formatExp(remainingKmToNextLevel));
     }
 
     private ChallengeAchievement handleChallengeMode(Long challengeId, long memberId, RunningRecord runningRecord) {

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -16,5 +16,5 @@ public interface RunningRecordRepository {
 
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
-    int findMonthlyTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
+    int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 }

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -15,4 +15,7 @@ public interface RunningRecordRepository {
             long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
+
+    int findMonthlyTotalDistanceByMemberId(
+            long memberId, OffsetDateTime startDateOfMonth, OffsetDateTime startDateOfNextMonth);
 }

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -16,6 +16,5 @@ public interface RunningRecordRepository {
 
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
-    int findMonthlyTotalDistanceByMemberId(
-            long memberId, OffsetDateTime startDateOfMonth, OffsetDateTime startDateOfNextMonth);
+    int findMonthlyTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.dnd.runus.infrastructure.persistence.domain.running;
 
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.infrastructure.persistence.jooq.running.JooqRunningRecordRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.running.JpaRunningRecordRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.running.entity.RunningRecordEntity;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 public class RunningRecordRepositoryImpl implements RunningRecordRepository {
 
     private final JpaRunningRecordRepository jpaRunningRecordRepository;
+    private final JooqRunningRecordRepository jooqRunningRecordRepository;
 
     @Override
     public Optional<RunningRecord> findById(long runningRecordId) {
@@ -46,5 +48,12 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     @Override
     public boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime) {
         return jpaRunningRecordRepository.existsByMemberIdAndStartAtBetween(memberId, startTime, endTime);
+    }
+
+    @Override
+    public int findMonthlyTotalDistanceByMemberId(
+            long memberId, OffsetDateTime startDateOfMonth, OffsetDateTime startDateOfNextMonth) {
+        return jooqRunningRecordRepository.findMonthlyTotalDistanceByMemberId(
+                memberId, startDateOfMonth, startDateOfNextMonth);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -51,8 +51,7 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public int findMonthlyTotalDistanceMeterByMemberId(
-            long memberId, OffsetDateTime startDate, OffsetDateTime endtDate) {
-        return jooqRunningRecordRepository.findMonthlyTotalDistanceMeterByMemberId(memberId, startDate, endtDate);
+    public int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endtDate) {
+        return jooqRunningRecordRepository.findTotalDistanceMeterByMemberId(memberId, startDate, endtDate);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -51,9 +51,8 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public int findMonthlyTotalDistanceByMemberId(
-            long memberId, OffsetDateTime startDateOfMonth, OffsetDateTime startDateOfNextMonth) {
-        return jooqRunningRecordRepository.findMonthlyTotalDistanceByMemberId(
-                memberId, startDateOfMonth, startDateOfNextMonth);
+    public int findMonthlyTotalDistanceMeterByMemberId(
+            long memberId, OffsetDateTime startDate, OffsetDateTime endtDate) {
+        return jooqRunningRecordRepository.findMonthlyTotalDistanceMeterByMemberId(memberId, startDate, endtDate);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -15,8 +15,7 @@ import static org.jooq.impl.DSL.sum;
 public class JooqRunningRecordRepository {
     private final DSLContext dsl;
 
-    public int findMonthlyTotalDistanceMeterByMemberId(
-            long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
+    public int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         Record1<Integer> result = dsl.select(sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
                 .from(RUNNING_RECORD)
                 .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -1,0 +1,28 @@
+package com.dnd.runus.infrastructure.persistence.jooq.running;
+
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Record1;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+
+import static com.dnd.runus.jooq.Tables.RUNNING_RECORD;
+import static org.jooq.impl.DSL.sum;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqRunningRecordRepository {
+    private final DSLContext dsl;
+
+    public int findMonthlyTotalDistanceByMemberId(
+            long memberId, OffsetDateTime startDateOfMonth, OffsetDateTime startDateOfNextMonth) {
+        Record1<Integer> result = dsl.select(sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
+                .from(RUNNING_RECORD)
+                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .and(RUNNING_RECORD.START_AT.ge(startDateOfMonth))
+                .and(RUNNING_RECORD.START_AT.lessThan(startDateOfNextMonth))
+                .fetchOne();
+        return result != null ? result.value1() : 0;
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -15,13 +15,13 @@ import static org.jooq.impl.DSL.sum;
 public class JooqRunningRecordRepository {
     private final DSLContext dsl;
 
-    public int findMonthlyTotalDistanceByMemberId(
-            long memberId, OffsetDateTime startDateOfMonth, OffsetDateTime startDateOfNextMonth) {
+    public int findMonthlyTotalDistanceMeterByMemberId(
+            long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         Record1<Integer> result = dsl.select(sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
                 .from(RUNNING_RECORD)
                 .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
-                .and(RUNNING_RECORD.START_AT.ge(startDateOfMonth))
-                .and(RUNNING_RECORD.START_AT.lessThan(startDateOfNextMonth))
+                .and(RUNNING_RECORD.START_AT.ge(startDate))
+                .and(RUNNING_RECORD.START_AT.lessThan(endDate))
                 .fetchOne();
         return result != null ? result.value1() : 0;
     }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -7,6 +7,7 @@ import com.dnd.runus.presentation.annotation.MemberId;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlyDatesResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -53,5 +54,18 @@ public class RunningRecordController {
     public RunningRecordAddResultResponse addRunningRecord(
             @MemberId long memberId, @Valid @RequestBody RunningRecordRequest request) {
         return runningRecordService.addRunningRecord(memberId, request);
+    }
+
+    @Operation(
+            summary = "이번 달 러닝 기록 조회(홈화면)",
+            description =
+                    """
+            홈화면의 이번 달 러닝 기록을 조회 합니다.<br>
+            이번 달, 이번 달 달린 키로수, 다음 레벨, 다음 레벨까지 남은 키로 수를 반환합니다.
+            """)
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("monthly-summary")
+    public RunningRecordMonthlySummaryResponse getMonthlyRunningSummary(@MemberId long memberId) {
+        return runningRecordService.getMonthlyRunningSummery(memberId);
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record RunningRecordMonthlySummaryResponse(
     @Schema(description = "이번 달", example = "8월")
     String month,
-    @Schema(description = "이번 달에 달린 키로 수", example = "2.55KM")
+    @Schema(description = "이번 달에 달린 키로 수", example = "2.55km")
     String monthlyKm,
     @Schema(description = "다음 레벨", example = "Leve 2")
     String nextLevelName,
@@ -14,11 +14,7 @@ public record RunningRecordMonthlySummaryResponse(
     String nextLevelKm
 ) {
     public RunningRecordMonthlySummaryResponse(int monthValue, int monthlyTotalMeter, String nextLevelName, String nextLevelKm) {
-        this(formatToMonth(monthValue), formatMeterToKm(monthlyTotalMeter), nextLevelName, nextLevelKm);
-    }
-
-    private static String formatToMonth(int monthValue) {
-        return monthValue + "월";
+        this(monthValue+"월", formatMeterToKm(monthlyTotalMeter), nextLevelName, nextLevelKm);
     }
 
     private static String formatMeterToKm(int meter) {
@@ -32,6 +28,6 @@ public record RunningRecordMonthlySummaryResponse(
             formatted = formatted.substring(0, formatted.length() - 1);
         }
 
-        return formatted + "KM";
+        return formatted + "km";
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
@@ -1,0 +1,37 @@
+package com.dnd.runus.presentation.v1.running.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RunningRecordMonthlySummaryResponse(
+    @Schema(description = "이번 달", example = "8월")
+    String month,
+    @Schema(description = "이번 달에 달린 키로 수", example = "2.55KM")
+    String monthlyKm,
+    @Schema(description = "다음 레벨", example = "Leve 2")
+    String nextLevelName,
+    @Schema(description = "다음 레벨까지 남은 키로 수", example = "2.55km")
+    String nextLevelKm
+) {
+    public RunningRecordMonthlySummaryResponse(int monthValue, int monthlyTotalMeter, String nextLevelName, String nextLevelKm) {
+        this(formatToMonth(monthValue), formatMeterToKm(monthlyTotalMeter), nextLevelName, nextLevelKm);
+    }
+
+    private static String formatToMonth(int monthValue) {
+        return monthValue + "월";
+    }
+
+    private static String formatMeterToKm(int meter) {
+        String formatted = String.format("%.2f", Math.floor(meter / 1000.0 * 100) / 100);
+
+        if (formatted.contains(".")) {
+            formatted = formatted.replaceAll("0*$", "");
+        }
+
+        if (formatted.endsWith(".")) {
+            formatted = formatted.substring(0, formatted.length() - 1);
+        }
+
+        return formatted + "KM";
+    }
+}

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -169,7 +169,7 @@ class RunningRecordServiceTest {
                     .when(() -> OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE)))
                     .thenReturn(fixedDate);
 
-            given(runningRecordRepository.findMonthlyTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
+            given(runningRecordRepository.findTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
                     .willReturn(45_780);
 
             given(memberLevelRepository.findByMemberIdWithLevel(memberId))

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -5,7 +5,9 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentage
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
 import com.dnd.runus.domain.challenge.*;
 import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.level.Level;
 import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevel;
 import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
@@ -18,22 +20,33 @@ import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDto;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class RunningRecordServiceTest {
@@ -142,5 +155,36 @@ class RunningRecordServiceTest {
                 assertThrows(BusinessException.class, () -> runningRecordService.addRunningRecord(1L, request));
         // then
         assertEquals(ErrorType.START_AFTER_END, exception.getType());
+    }
+
+    @Test
+    @DisplayName("이번 달, 달린 키로 수, 러닝 레벨을 조회한다.")
+    void getMonthlyRunningSummery() {
+        // given
+        long memberId = 1;
+        OffsetDateTime fixedDate = ZonedDateTime.of(2021, 1, 15, 9, 0, 0, 0, ZoneId.of(SERVER_TIMEZONE))
+                .toOffsetDateTime();
+        try (MockedStatic<OffsetDateTime> mockedStatic = mockStatic(OffsetDateTime.class)) {
+            mockedStatic
+                    .when(() -> OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE)))
+                    .thenReturn(fixedDate);
+
+            given(runningRecordRepository.findMonthlyTotalDistanceByMemberId(eq(memberId), any(), any()))
+                    .willReturn(45_780);
+
+            given(memberLevelRepository.findByMemberIdWithLevel(memberId))
+                    .willReturn(new MemberLevel.Current(new Level(1, 0, 50_000, "image"), 45_780));
+
+            // when
+            RunningRecordMonthlySummaryResponse monthlyRunningSummery =
+                    runningRecordService.getMonthlyRunningSummery(memberId);
+
+            // then
+            assertNotNull(monthlyRunningSummery);
+            assertThat(monthlyRunningSummery.month()).isEqualTo("1월");
+            assertThat(monthlyRunningSummery.monthlyKm()).isEqualTo("45.78KM");
+            assertThat(monthlyRunningSummery.nextLevelName()).isEqualTo("Level 2");
+            assertThat(monthlyRunningSummery.nextLevelKm()).isEqualTo("4.22km");
+        }
     }
 }

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -182,7 +182,7 @@ class RunningRecordServiceTest {
             // then
             assertNotNull(monthlyRunningSummery);
             assertThat(monthlyRunningSummery.month()).isEqualTo("1월");
-            assertThat(monthlyRunningSummery.monthlyKm()).isEqualTo("45.78KM");
+            assertThat(monthlyRunningSummery.monthlyKm()).isEqualTo("45.78km");
             assertThat(monthlyRunningSummery.nextLevelName()).isEqualTo("Level 2");
             assertThat(monthlyRunningSummery.nextLevelKm()).isEqualTo("4.22km");
         }

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -169,7 +169,7 @@ class RunningRecordServiceTest {
                     .when(() -> OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE)))
                     .thenReturn(fixedDate);
 
-            given(runningRecordRepository.findMonthlyTotalDistanceByMemberId(eq(memberId), any(), any()))
+            given(runningRecordRepository.findMonthlyTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
                     .willReturn(45_780);
 
             given(memberLevelRepository.findByMemberIdWithLevel(memberId))


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #106 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `/api/v1/running-records/monthly-summary`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 홈화면의 이번 달 러닝 기록을 조회하는 기능을 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 러닝 관련해서 조회하는 기능이라 러닝 컨트롤러와 서비스 쪽에 두었어요.
- 해당 기능을 따로 새로운 도메인쪽(예를 들어 home이라든지)에 분리하는게 좋을까요? 아니면 지금처럼 러닝쪽에 두는게 좋을 까요?
