### PR TITLE
Fix: running record 저장시 challenge sub title 정보도 반환하도록 변경

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievement.java
@@ -3,9 +3,16 @@ package com.dnd.runus.domain.challenge.achievement;
 import com.dnd.runus.domain.challenge.Challenge;
 import com.dnd.runus.domain.running.RunningRecord;
 
+import static com.dnd.runus.global.constant.RunningResultComment.FAILURE;
+import static com.dnd.runus.global.constant.RunningResultComment.SUCCESS;
+
 public record ChallengeAchievement(
         long ChallengeAchievementId, Challenge challenge, RunningRecord runningRecord, boolean isSuccess) {
     public ChallengeAchievement(Challenge challenge, RunningRecord runningRecord, boolean isSuccess) {
         this(0, challenge, runningRecord, isSuccess);
+    }
+
+    public String description() {
+        return isSuccess ? SUCCESS.getComment() : FAILURE.getComment();
     }
 }

--- a/src/main/java/com/dnd/runus/global/constant/RunningResultComment.java
+++ b/src/main/java/com/dnd/runus/global/constant/RunningResultComment.java
@@ -1,16 +1,13 @@
 package com.dnd.runus.global.constant;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum RunningResultComment {
-    SUCCESS_COMMENT("정말 대단해요! 잘하셨어요"),
-    FAILURE_COMMENT("아쉬워요. 내일 다시 도전해보세요!");
+    SUCCESS("정말 대단해요! 잘하셨어요"),
+    FAILURE("아쉬워요. 내일 다시 도전해보세요!");
 
     private final String comment;
-
-    // TODO(subtitle(comment) 리턴, 챌린지 성취, 목표 성취 값 리턴 할 때 사용)
-    public static String getComment(boolean successStatus) {
-        return successStatus ? SUCCESS_COMMENT.comment : FAILURE_COMMENT.comment;
-    }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -46,8 +46,7 @@ public class RunningRecordController {
             description = "러닝 기록을 추가합니다.<br>"
                     + "러닝 기록은 시작 시간, 종료 시간, 이모지, 챌린지 ID, 러닝 데이터로 구성됩니다. <br> "
                     + "러닝 데이터는 route(코스), 위치, 거리, 시간, 칼로리, 평균 페이스로 구성됩니다. <br> "
-                    + "route는 최소 2개의 좌표를 가져야 합니다. <br> "
-                    + "러닝 기록 추가에 성공하면 러닝 기록 ID, 기록 정보와 사용자 닉네임, 프로필 url을 반환합니다. <br>")
+                    + "러닝 기록 추가에 성공하면 러닝 기록 ID, 기록 정보를 반환합니다. <br>")
     @ApiErrorType({ErrorType.START_AFTER_END})
     @PostMapping
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/ChallengeDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/ChallengeDto.java
@@ -1,20 +1,21 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.jetbrains.annotations.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record ChallengeDto(
+        @Schema(description = "챌린지 ID")
         long challengeId,
-        @Schema(description = "챌린지 이름")
-        @NotNull
+        @NotBlank
+        @Schema(description = "챌린지 이름", example = "오늘 30분 동안 뛰기")
         String title,
-        @Schema(
-                description = "예상 소요 시간",
-                example = "25분"
-        )
-        String expectedTime,
-        @Schema(description = "챌린지 이미지 URL")
-        @NotNull
-        String icon
+        @NotBlank
+        @Schema(description = "챌린지 결과 문구", example = "성공했어요!")
+        String subTitle,
+        @NotBlank
+        @Schema(description = "챌린지 아이콘 이미지 URL")
+        String iconUrl,
+        @Schema(description = "챌린지 성공 여부")
+        boolean isSuccess
 ) {
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
@@ -44,8 +44,9 @@ public record RunningRecordAddResultResponse(
                 new ChallengeDto(
                         achievement.challenge().challengeId(),
                         achievement.challenge().name(),
-                        achievement.challenge().formatExpectedTime(),
-                        achievement.challenge().imageUrl()
+                        achievement.description(),
+                        achievement.challenge().imageUrl(),
+                        achievement.isSuccess()
                 ),
                 new RunningRecordMetricsDto(
                         runningRecord.averagePace(),


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #87 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- running record 저장시, 반환 response의 필드를 수정합니다.
  - 챌린지 결과 문구인 `subTitle`을 포함하도록 합니다.
  - `isSuccess` 성공 유무를 추가합니다.
  - `expectedTime`을 삭제합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
