### PR TITLE
Feat: running record 저장시 목표 성취 정보를 같이 반환하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
@@ -4,10 +4,12 @@ import com.dnd.runus.domain.challenge.GoalMetricType;
 import com.dnd.runus.domain.running.RunningRecord;
 
 import static com.dnd.runus.domain.challenge.GoalMetricType.DISTANCE;
+import static com.dnd.runus.global.constant.RunningResultComment.FAILURE;
+import static com.dnd.runus.global.constant.RunningResultComment.SUCCESS;
 
 public record GoalAchievement(
         RunningRecord runningRecord, GoalMetricType goalMetricType, int achievementValue, boolean isAchieved) {
-    public GoalAchievement(RunningRecord runningRecord, GoalMetricType goalMetricType, Integer achievementValue) {
+    public GoalAchievement(RunningRecord runningRecord, GoalMetricType goalMetricType, int achievementValue) {
         this(
                 runningRecord,
                 goalMetricType,
@@ -22,6 +24,10 @@ public record GoalAchievement(
         }
 
         return formatSecondToKoreanHHMM(achievementValue) + " 달성";
+    }
+
+    public String getDescription() {
+        return isAchieved ? SUCCESS.getComment() : FAILURE.getComment();
     }
 
     private String formatMeterToKm(int meter) {

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/GoalResultDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/GoalResultDto.java
@@ -1,0 +1,13 @@
+package com.dnd.runus.presentation.v1.running.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GoalResultDto(
+        @Schema(description = "설정된 목표 제목", example = "오늘 30분 동안 뛰기")
+        String title,
+        @Schema(description = "설정된 목표 결과 문구", example = "성공했어요!")
+        String subTitle,
+        @Schema(description = "설정된 목표 성공 여부")
+        boolean isSuccess
+) {
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
@@ -1,9 +1,11 @@
 package com.dnd.runus.presentation.v1.running.dto.response;
 
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
+import com.dnd.runus.domain.goalAchievement.GoalAchievement;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.presentation.v1.running.dto.ChallengeDto;
+import com.dnd.runus.presentation.v1.running.dto.GoalResultDto;
 import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -15,32 +17,19 @@ public record RunningRecordAddResultResponse(
         LocalDateTime startAt,
         LocalDateTime endAt,
         RunningEmoji emoji,
-        @Schema(description = "챌린지 정보, 챌린지를 하지 않은 경우 null입니다.")
+        @Schema(description = "챌린지 정보, achievementMode가 challenge인 경우에만 값이 존재합니다.")
         ChallengeDto challenge,
+        @Schema(description = "목표 결과 정보, achievementMode가 goal인 경우에만 값이 존재합니다.")
+        GoalResultDto goal,
         @NotNull
         RunningRecordMetricsDto runningData
 ) {
     public static RunningRecordAddResultResponse from(RunningRecord runningRecord) {
-        return new RunningRecordAddResultResponse(
-                runningRecord.runningId(),
-                runningRecord.startAt().toLocalDateTime(),
-                runningRecord.endAt().toLocalDateTime(),
-                runningRecord.emoji(),
-                null,
-                new RunningRecordMetricsDto(
-                        runningRecord.averagePace(),
-                        runningRecord.duration(),
-                        runningRecord.distanceMeter(),
-                        runningRecord.calorie()
-                ));
+        return buildResponse(runningRecord, null, null);
     }
 
     public static RunningRecordAddResultResponse of(RunningRecord runningRecord, ChallengeAchievement achievement) {
-        return new RunningRecordAddResultResponse(
-                runningRecord.runningId(),
-                runningRecord.startAt().toLocalDateTime(),
-                runningRecord.endAt().toLocalDateTime(),
-                runningRecord.emoji(),
+        return buildResponse(runningRecord,
                 new ChallengeDto(
                         achievement.challenge().challengeId(),
                         achievement.challenge().name(),
@@ -48,11 +37,35 @@ public record RunningRecordAddResultResponse(
                         achievement.challenge().imageUrl(),
                         achievement.isSuccess()
                 ),
+                null
+        );
+    }
+
+    public static RunningRecordAddResultResponse of(RunningRecord runningRecord, GoalAchievement achievement) {
+        return buildResponse(runningRecord,
+                null,
+                new GoalResultDto(
+                        achievement.getTitle(),
+                        achievement.getDescription(),
+                        achievement.isAchieved()
+                )
+        );
+    }
+
+    private static RunningRecordAddResultResponse buildResponse(RunningRecord runningRecord, ChallengeDto challenge, GoalResultDto goal) {
+        return new RunningRecordAddResultResponse(
+                runningRecord.runningId(),
+                runningRecord.startAt().toLocalDateTime(),
+                runningRecord.endAt().toLocalDateTime(),
+                runningRecord.emoji(),
+                challenge,
+                goal,
                 new RunningRecordMetricsDto(
                         runningRecord.averagePace(),
                         runningRecord.duration(),
                         runningRecord.distanceMeter(),
                         runningRecord.calorie()
-                ));
+                )
+        );
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #111 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- running record 기록 저장시, `goal` 정보도 반환하도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- RunningRecord 서비스에서 achievementMode가 goal일때 저장하는 로직은 추가하지 않았어요!
