### PR TITLE
Fix: 이번달 달린 거리 조회시 null 처리 관련 수정

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -22,6 +22,9 @@ public class JooqRunningRecordRepository {
                 .and(RUNNING_RECORD.START_AT.ge(startDate))
                 .and(RUNNING_RECORD.START_AT.lessThan(endDate))
                 .fetchOne();
-        return result != null ? result.value1() : 0;
+        if (result != null && result.value1() != null) {
+            return result.value1();
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #106 

## 📋 버그 내용

<!-- 버그에 대한 내용을 작성해주세요 -->
<!-- 예시: 로그인 시도 시, http 400 응답과 함께 로그인이 되지 않습니다. -->

- 특정 기간 안에 달린 거리 조회 시 러닝 데이터가 없을 경우 result.value1()이 null인경우에 대해서 오류가 발생합니다.

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- result.value1()이 null인경우에 대해 null 인 경우 0을 리턴하게 수정합니다.
- 특정 기간 안에 달린 거리를 조회하는 리파지토리의 테스트 코드를 추가합니다.
## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
