### PR TITLE
Feat: weather 조회 api 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/weather/WeatherService.java
+++ b/src/main/java/com/dnd/runus/application/weather/WeatherService.java
@@ -1,0 +1,24 @@
+package com.dnd.runus.application.weather;
+
+import com.dnd.runus.infrastructure.weather.WeatherClient;
+import com.dnd.runus.infrastructure.weather.WeatherInfo;
+import com.dnd.runus.presentation.v1.weather.dto.WeatherResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+    private final WeatherClient weatherClient;
+
+    public WeatherResponse getWeather(double longitude, double latitude) {
+        WeatherInfo info = weatherClient.getWeatherInfo(longitude, latitude);
+        return new WeatherResponse(
+                info.weatherType().getKoreanName(),
+                info.weatherType().getKoreanDescription(),
+                info.weatherType().getIconUrl(),
+                (int) info.apparentTemperature(),
+                (int) info.minTemperature(),
+                (int) info.maxTemperature());
+    }
+}

--- a/src/main/java/com/dnd/runus/global/constant/WeatherType.java
+++ b/src/main/java/com/dnd/runus/global/constant/WeatherType.java
@@ -1,13 +1,24 @@
 package com.dnd.runus.global.constant;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@Getter
+@RequiredArgsConstructor(access = PACKAGE)
 public enum WeatherType {
-    CLEAR,
-    CLOUDY,
-    CLOUDY_MORE,
-    RAIN,
-    SNOW,
-    FOG,
-    STORM,
-    HEAT_WAVE,
-    COLD_WAVE
+    CLEAR("맑음", "해가 쨍쨍하니 러닝하면 어떨까요?", "https://d27big3ufowabi.cloudfront.net/weather/A1.png"),
+    CLOUDY("구름 조금", "구름이 조금 있는 날씨입니다", "https://d27big3ufowabi.cloudfront.net/weather/A2.png"),
+    CLOUDY_MORE("흐림", "구름이 많은 날씨입니다", "https://d27big3ufowabi.cloudfront.net/weather/A3.png"),
+    RAIN("비내리는 날", "빗물이 고인 곳이 많을 수 있으니 달리며 미끄러지지 않도록 조심하세요", "https://d27big3ufowabi.cloudfront.net/weather/A4.png"),
+    SNOW("눈", "눈길에 미끄러지지 않도록 조심하세요", "https://d27big3ufowabi.cloudfront.net/weather/B1.png"),
+    FOG("안개", "안개가 짙으니 시야확보에 유의하세요", "https://d27big3ufowabi.cloudfront.net/weather/B2.png"),
+    STORM("폭풍", "폭풍이 몰아치는 날씨입니다. 외부 활동을 삼가하세요", "https://d27big3ufowabi.cloudfront.net/weather/B3.png"),
+    HEAT_WAVE("폭염", "기온이 매우 높으니 충분한 수분 섭취에 유의하세요", "https://d27big3ufowabi.cloudfront.net/weather/C1.png"),
+    COLD_WAVE("한파", "기온이 매우 낮으니 러닝 전 따뜻하게 준비하세요", "https://d27big3ufowabi.cloudfront.net/weather/C2.png"),
+    ;
+    private final String koreanName;
+    private final String koreanDescription;
+    private final String iconUrl;
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/weather/WeatherController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/weather/WeatherController.java
@@ -1,0 +1,23 @@
+package com.dnd.runus.presentation.v1.weather;
+
+import com.dnd.runus.application.weather.WeatherService;
+import com.dnd.runus.presentation.v1.weather.dto.WeatherResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/weathers")
+public class WeatherController {
+    private final WeatherService weatherService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public WeatherResponse getWeather(double longitude, double latitude) {
+        return weatherService.getWeather(longitude, latitude);
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/weather/dto/WeatherResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/weather/dto/WeatherResponse.java
@@ -1,0 +1,19 @@
+package com.dnd.runus.presentation.v1.weather.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WeatherResponse(
+        @Schema(description = "날씨 이름", example = "맑음")
+        String weatherName,
+        @Schema(description = "날씨 안내 문구", example = "해가 쨍쨍한 날씨입니다.")
+        String weatherDescription,
+        @Schema(description = "날씨 아이콘 URL", format = "uri")
+        String weatherIconUrl,
+        @Schema(description = "체감온도 (°C)", example = "23")
+        int apparentTemperature,
+        @Schema(description = "최저기온 (°C)", example = "20")
+        int minTemperature,
+        @Schema(description = "최고기온 (°C)", example = "25")
+        int maxTemperature
+) {
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #105 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `api/v1/weathers`: 위도, 경도로 날씨 정보 조회

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 위도, 경도로 날씨 정보를 조회하는 API를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 논의한대로, WeatherType enum에 날씨 이름과 문구를 관리하도록 했습니다.
