### PR TITLE
Feat: scale index 순서 컬럼 추가

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/Scale.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/Scale.java
@@ -1,0 +1,3 @@
+package com.dnd.runus.infrastructure.persistence.domain.scale;
+
+public record Scale(long scaleId, String name, int sizeMeter, int index) {}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
@@ -1,5 +1,6 @@
 package com.dnd.runus.infrastructure.persistence.jpa.scale.entity;
 
+import com.dnd.runus.infrastructure.persistence.domain.scale.Scale;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,4 +24,11 @@ public class ScaleEntity {
 
     @NotNull
     private Integer sizeMeter;
+
+    @NotNull
+    private Integer index;
+
+    public Scale toDomain() {
+        return new Scale(id, name, sizeMeter, index);
+    }
 }

--- a/src/main/resources/db/migration/V5.0.8__scale_index.sql
+++ b/src/main/resources/db/migration/V5.0.8__scale_index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scale ADD COLUMN index integer NOT NULL;


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #127 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `scale` 테이블에 달성 단위 순서를 의미하는 `index` 컬럼을 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- postgresql에서 `index`가 컬럼 이름으로 사용될때 문제는 없다고 하는데 `index`라는 이름이 좋을까요?
