### PR TITLE
Fix: 잘못된 ZoneOffset 대신 defaultZoneOffset을 사용하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -63,7 +63,7 @@ public class RunningRecordService {
 
     @Transactional(readOnly = true)
     public List<LocalDate> getRunningRecordDates(long memberId, int year, int month) {
-        OffsetDateTime from = LocalDate.of(year, month, 1).atStartOfDay().atOffset((ZoneOffset.of(SERVER_TIMEZONE)));
+        OffsetDateTime from = LocalDate.of(year, month, 1).atStartOfDay().atOffset(defaultZoneOffset);
         OffsetDateTime to = from.plusMonths(1);
 
         List<RunningRecord> records = runningRecordRepository.findByMemberIdAndStartAtBetween(memberId, from, to);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #90

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `ZoneOffset.of(SERVER_TIMEZONE)` 대신 `defaultZoneOffset`을 사용하도록 합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
