### PR TITLE
Fix: RunningService.getRunningRecordSummaries 메서드에 readOnly 트랜잭션 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -76,6 +76,7 @@ public class RunningRecordService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public RunningRecordSummaryResponse getRunningRecordSummaries(long memberId, LocalDate date) {
         OffsetDateTime from = date.atStartOfDay().atOffset(defaultZoneOffset);
         OffsetDateTime to = from.plusDays(1);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #132 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- RunningService.getRunningRecordSummaries 메서드에 readOnly 트랜잭션 추가합니다.
- 이를 통해 no session 에러가 없도룩 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
