### PR TITLE
Feat: 지구 한 바퀴 코스 서머리 조회

### DIFF
--- a/src/main/java/com/dnd/runus/application/scale/ScaleService.java
+++ b/src/main/java/com/dnd/runus/application/scale/ScaleService.java
@@ -6,6 +6,8 @@ import com.dnd.runus.presentation.v1.scale.dto.ScaleSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE_EARTH;
+
 @Service
 @RequiredArgsConstructor
 public class ScaleService {
@@ -16,6 +18,6 @@ public class ScaleService {
         ScaleSummary summary = scaleRepository.getSummary();
 
         return new ScaleSummaryResponse(
-                summary.totalCourseCnt(), summary.totalCourseDistanceKm(), summary.earthDistanceKm());
+                summary.totalCourseCnt(), summary.totalCourseDistanceKm(), DISTANCE_KM_AROUND_THE_EARTH);
     }
 }

--- a/src/main/java/com/dnd/runus/application/scale/ScaleService.java
+++ b/src/main/java/com/dnd/runus/application/scale/ScaleService.java
@@ -1,0 +1,21 @@
+package com.dnd.runus.application.scale;
+
+import com.dnd.runus.domain.scale.ScaleRepository;
+import com.dnd.runus.domain.scale.ScaleSummary;
+import com.dnd.runus.presentation.v1.scale.dto.ScaleSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScaleService {
+
+    private final ScaleRepository scaleRepository;
+
+    public ScaleSummaryResponse getSummary() {
+        ScaleSummary summary = scaleRepository.getSummary();
+
+        return new ScaleSummaryResponse(
+                summary.totalCourseCnt(), summary.totalCourseDistanceKm(), summary.earthDistanceKm());
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/scale/Scale.java
+++ b/src/main/java/com/dnd/runus/domain/scale/Scale.java
@@ -1,3 +1,3 @@
 package com.dnd.runus.domain.scale;
 
-public record Scale(long scaleId, String name, int sizeMeter, int index, String startName, String end) {}
+public record Scale(long scaleId, String name, int sizeMeter, int index, String startName, String endName) {}

--- a/src/main/java/com/dnd/runus/domain/scale/Scale.java
+++ b/src/main/java/com/dnd/runus/domain/scale/Scale.java
@@ -1,3 +1,3 @@
-package com.dnd.runus.infrastructure.persistence.domain.scale;
+package com.dnd.runus.domain.scale;
 
 public record Scale(long scaleId, String name, int sizeMeter, int index, String startName, String end) {}

--- a/src/main/java/com/dnd/runus/domain/scale/ScaleRepository.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleRepository.java
@@ -1,0 +1,5 @@
+package com.dnd.runus.domain.scale;
+
+public interface ScaleRepository {
+    ScaleSummary getSummary();
+}

--- a/src/main/java/com/dnd/runus/domain/scale/ScaleSummary.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleSummary.java
@@ -1,25 +1,3 @@
 package com.dnd.runus.domain.scale;
 
-import java.text.NumberFormat;
-import java.util.Locale;
-
-import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE_EARTH;
-
-public record ScaleSummary(String totalCourseCnt, String totalCourseDistanceKm, String earthDistanceKm) {
-
-    public ScaleSummary(int totalCourse, int totalCourseDistanceMeter) {
-        this(courseCountFormater(totalCourse), meterToKM(totalCourseDistanceMeter), DISTANCE_KM_AROUND_THE_EARTH);
-    }
-
-    private static String meterToKM(int totalCourseDistanceMeter) {
-        double kilometers = totalCourseDistanceMeter / 1000.0;
-
-        NumberFormat numberFormat = NumberFormat.getInstance(Locale.US);
-        numberFormat.setGroupingUsed(true); // 쉼표 구분 사용
-        return numberFormat.format(kilometers) + "km";
-    }
-
-    private static String courseCountFormater(int totalCourseCnt) {
-        return totalCourseCnt + "코스";
-    }
-}
+public record ScaleSummary(int totalCourseCnt, int totalCourseDistanceKm) {}

--- a/src/main/java/com/dnd/runus/domain/scale/ScaleSummary.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleSummary.java
@@ -1,0 +1,25 @@
+package com.dnd.runus.domain.scale;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE_EARTH;
+
+public record ScaleSummary(String totalCourseCnt, String totalCourseDistanceKm, String earthDistanceKm) {
+
+    public ScaleSummary(int totalCourse, int totalCourseDistanceMeter) {
+        this(courseCountFormater(totalCourse), meterToKM(totalCourseDistanceMeter), DISTANCE_KM_AROUND_THE_EARTH);
+    }
+
+    private static String meterToKM(int totalCourseDistanceMeter) {
+        double kilometers = totalCourseDistanceMeter / 1000.0;
+
+        NumberFormat numberFormat = NumberFormat.getInstance(Locale.US);
+        numberFormat.setGroupingUsed(true); // 쉼표 구분 사용
+        return numberFormat.format(kilometers) + "km";
+    }
+
+    private static String courseCountFormater(int totalCourseCnt) {
+        return totalCourseCnt + "코스";
+    }
+}

--- a/src/main/java/com/dnd/runus/global/constant/ScaleConstant.java
+++ b/src/main/java/com/dnd/runus/global/constant/ScaleConstant.java
@@ -1,0 +1,7 @@
+package com.dnd.runus.global.constant;
+
+public final class ScaleConstant {
+
+    // 지구 한바퀴 km 거리
+    public static final String DISTANCE_KM_AROUND_THE_EARTH = "40,075km";
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.dnd.runus.infrastructure.persistence.domain.scale;
+
+import com.dnd.runus.domain.scale.ScaleRepository;
+import com.dnd.runus.domain.scale.ScaleSummary;
+import com.dnd.runus.infrastructure.persistence.jooq.scale.JooqScaleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ScaleRepositoryImpl implements ScaleRepository {
+
+    private final JooqScaleRepository jooqScaleRepository;
+
+    @Override
+    public ScaleSummary getSummary() {
+        return jooqScaleRepository.getSummary();
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
@@ -1,0 +1,36 @@
+package com.dnd.runus.infrastructure.persistence.jooq.scale;
+
+import com.dnd.runus.domain.scale.ScaleSummary;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+import org.springframework.stereotype.Repository;
+
+import static com.dnd.runus.jooq.tables.Scale.SCALE;
+import static org.jooq.impl.DSL.coalesce;
+import static org.jooq.impl.DSL.count;
+import static org.jooq.impl.DSL.sum;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqScaleRepository {
+
+    private final DSLContext dsl;
+
+    public ScaleSummary getSummary() {
+        return dsl.select(
+                        count().as("count"), coalesce(sum(SCALE.SIZE_METER), 0).as("total_meter"))
+                .from(SCALE)
+                .fetchOne(new ScaleSummaryMapper());
+    }
+
+    private static class ScaleSummaryMapper implements RecordMapper<Record, ScaleSummary> {
+
+        @Override
+        public ScaleSummary map(Record record) {
+
+            return new ScaleSummary(record.get("count", int.class), record.get("total_meter", int.class));
+        }
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
@@ -26,10 +26,8 @@ public class JooqScaleRepository {
     }
 
     private static class ScaleSummaryMapper implements RecordMapper<Record, ScaleSummary> {
-
         @Override
         public ScaleSummary map(Record record) {
-
             return new ScaleSummary(record.get("count", int.class), record.get("total_meter", int.class));
         }
     }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
@@ -1,6 +1,6 @@
 package com.dnd.runus.infrastructure.persistence.jpa.scale.entity;
 
-import com.dnd.runus.infrastructure.persistence.domain.scale.Scale;
+import com.dnd.runus.domain.scale.Scale;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
@@ -7,14 +7,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Entity(name = "scale")
 @NoArgsConstructor(access = PROTECTED)
+@Builder(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class ScaleEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,5 +44,15 @@ public class ScaleEntity {
 
     public Scale toDomain() {
         return new Scale(id, name, sizeMeter, index, startName, endName);
+    }
+
+    public static ScaleEntity from(Scale scale) {
+        return ScaleEntity.builder()
+                .name(scale.name())
+                .sizeMeter(scale.sizeMeter())
+                .index(scale.index())
+                .startName(scale.startName())
+                .endName(scale.endName())
+                .build();
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/scale/ScaleController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/ScaleController.java
@@ -1,0 +1,34 @@
+package com.dnd.runus.presentation.v1.scale;
+
+import com.dnd.runus.application.scale.ScaleService;
+import com.dnd.runus.presentation.v1.scale.dto.ScaleSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "지구 한 바퀴")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/scale")
+public class ScaleController {
+
+    private final ScaleService scaleService;
+
+    @Operation(
+            summary = "지구 한 바퀴 코스 서머리",
+            description =
+                    """
+                지구 한 바퀴 코스 서머리를 조회 합니다.<br>
+                [달성 기록] - [런어스랑 지구한바퀴 달리기]의 전체 코스, 런어스 총 거리, 지구 한 바퀴의 값을 리턴합니다.
+                """)
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("course-summary")
+    public ScaleSummaryResponse getScaleSummary() {
+        return scaleService.getSummary();
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleSummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleSummaryResponse.java
@@ -1,0 +1,14 @@
+package com.dnd.runus.presentation.v1.scale.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ScaleSummaryResponse(
+    @Schema(description = "전체 코스 수", example = "18코스")
+    String courseCount,
+    @Schema(description = "런어스 총 거리", example = "43,800km")
+    String runUsDistanceKm,
+    @Schema(description = "지구 한 바퀴 거리", example = "40,075km")
+    String earthDistanceKm
+) {
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleSummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleSummaryResponse.java
@@ -2,6 +2,8 @@ package com.dnd.runus.presentation.v1.scale.dto;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 public record ScaleSummaryResponse(
     @Schema(description = "전체 코스 수", example = "18코스")
@@ -11,4 +13,19 @@ public record ScaleSummaryResponse(
     @Schema(description = "지구 한 바퀴 거리", example = "40,075km")
     String earthDistanceKm
 ) {
+    public ScaleSummaryResponse(int totalCourseCnt, int totalCourseDistanceMeter, String earthDistanceKm) {
+        this(courseCountFormater(totalCourseCnt), meterToKM(totalCourseDistanceMeter), earthDistanceKm);
+    }
+
+    private static String meterToKM(int totalCourseDistanceMeter) {
+        double kilometers = totalCourseDistanceMeter / 1000.0;
+
+        NumberFormat numberFormat = NumberFormat.getInstance(Locale.US);
+        numberFormat.setGroupingUsed(true); // 쉼표 구분 사용
+        return numberFormat.format(kilometers) + "km";
+    }
+
+    private static String courseCountFormater(int totalCourseCnt) {
+        return totalCourseCnt + "코스";
+    }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -1,22 +1,23 @@
 package com.dnd.runus.infrastructure.persistence.domain.scale;
 
+import com.dnd.runus.domain.scale.Scale;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.domain.scale.ScaleSummary;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE_EARTH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RepositoryTest
 public class ScaleRepositoryImplTest {
 
     @Autowired
-    private JdbcTemplate jdbcTemplate;
+    private EntityManager em;
 
     @Autowired
     private ScaleRepository scaleRepository;
@@ -27,37 +28,21 @@ public class ScaleRepositoryImplTest {
     void getSummary() {
         // given
         // test data insert
-        String insertSql =
-                """
-            insert into scale (name, size_meter, start_name, end_name, index)
-            values (?, ?, ?, ?, ?),
-            (?, ?, ?, ?, ?),
-            (?, ?, ?, ?, ?)
-            """;
-        jdbcTemplate.update(
-                insertSql,
-                "scale1",
-                1_000_000,
-                "서울(한국)",
-                "도쿄(일본)",
-                1,
-                "scale2",
-                2_100_000,
-                "도쿄(일본)",
-                "베이징(중국)",
-                2,
-                "scale3",
-                1_000_000,
-                "베이징(중국)",
-                "타이베이(대만)",
-                3);
+        Scale scale1 = new Scale(1, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)");
+        Scale scale2 = new Scale(2, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)");
+
+        Scale scale3 = new Scale(3, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)");
+
+        em.persist(ScaleEntity.from(scale1));
+        em.persist(ScaleEntity.from(scale2));
+        em.persist(ScaleEntity.from(scale3));
+        em.flush();
 
         // when
         ScaleSummary summary = scaleRepository.getSummary();
 
         // then
-        assertThat(summary.totalCourseCnt()).isEqualTo("3코스");
-        assertThat(summary.earthDistanceKm()).isEqualTo(DISTANCE_KM_AROUND_THE_EARTH);
-        assertThat(summary.totalCourseDistanceKm()).isEqualTo("4,100km");
+        assertThat(summary.totalCourseCnt()).isEqualTo(3);
+        assertThat(summary.totalCourseDistanceKm()).isEqualTo((4_100 * 1000));
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -1,0 +1,63 @@
+package com.dnd.runus.infrastructure.persistence.domain.scale;
+
+import com.dnd.runus.domain.scale.ScaleRepository;
+import com.dnd.runus.domain.scale.ScaleSummary;
+import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE_EARTH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+public class ScaleRepositoryImplTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ScaleRepository scaleRepository;
+
+    @Transactional
+    @DisplayName("지구 한바퀴 코스 조회:코스 수, 전체 코스 거리를 반환한다.")
+    @Test
+    void getSummary() {
+        // given
+        // test data insert
+        String insertSql =
+                """
+            insert into scale (name, size_meter, start_name, end_name, index)
+            values (?, ?, ?, ?, ?),
+            (?, ?, ?, ?, ?),
+            (?, ?, ?, ?, ?)
+            """;
+        jdbcTemplate.update(
+                insertSql,
+                "scale1",
+                1_000_000,
+                "서울(한국)",
+                "도쿄(일본)",
+                1,
+                "scale2",
+                2_100_000,
+                "도쿄(일본)",
+                "베이징(중국)",
+                2,
+                "scale3",
+                1_000_000,
+                "베이징(중국)",
+                "타이베이(대만)",
+                3);
+
+        // when
+        ScaleSummary summary = scaleRepository.getSummary();
+
+        // then
+        assertThat(summary.totalCourseCnt()).isEqualTo("3코스");
+        assertThat(summary.earthDistanceKm()).isEqualTo(DISTANCE_KM_AROUND_THE_EARTH);
+        assertThat(summary.totalCourseDistanceKm()).isEqualTo("4,100km");
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #135 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `/api/v1/scale/course-summary`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 지구 한 바퀴 코스 서머리를 조회합니다.
- `Scale` 도메인 클래스를 `com.dnd.runus.infrastructure.persistence.domain.scale` 에서 `com.dnd.runus.domain.scale`로 이동합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

-  
