### PR TITLE
Fix: 지구 한 바퀴 성취 엔티티 member, scale의 연관 관계 수정

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleAchievementEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleAchievementEntity.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,11 +26,11 @@ public class ScaleAchievementEntity extends BaseTimeEntity {
     private Long id;
 
     @NotNull
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     private MemberEntity member;
 
     @NotNull
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     private ScaleEntity scale;
 
     @NotNull

--- a/src/main/resources/db/migration/V5.0.11__remove_uk_alter_scale_achievement_table.sql
+++ b/src/main/resources/db/migration/V5.0.11__remove_uk_alter_scale_achievement_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scale_achievement DROP CONSTRAINT uk_member_id_scale_achievement;
+ALTER TABLE scale_achievement DROP CONSTRAINT uk_scale_id_scale_achievement;


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #137 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- scale_achievement의 `member_id`, `scale_id`의 유니크키 인덱스를 삭제합니다.
- 지구 한 바퀴 성취 엔티티의 member, scale의 연관 관계를 `@OneToOne` 에서 `@ManyToOne`으로 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
