### PR TITLE
Fix: route에 임시 좌표로 running_record를 저장하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -8,6 +8,7 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.goalAchievement.GoalAchievement;
 import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
 import com.dnd.runus.domain.level.Level;
@@ -100,6 +101,9 @@ public class RunningRecordService {
         Member member =
                 memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(Member.class, memberId));
 
+        Coordinate emptyCoordinate = new Coordinate(0, 0, 0);
+        List<Coordinate> route = List.of(emptyCoordinate, emptyCoordinate);
+
         RunningRecord record = runningRecordRepository.save(RunningRecord.builder()
                 .member(member)
                 .startAt(request.startAt().atOffset(defaultZoneOffset))
@@ -111,6 +115,7 @@ public class RunningRecordService {
                 .duration(request.runningData().runningTime())
                 .calorie(request.runningData().calorie())
                 .averagePace(request.runningData().averagePace())
+                .route(route)
                 .build());
 
         memberLevelRepository.updateMemberLevel(memberId, request.runningData().distanceMeter());

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -4,6 +4,7 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
 import com.dnd.runus.domain.challenge.*;
+import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
 import com.dnd.runus.domain.level.Level;
@@ -110,6 +111,7 @@ class RunningRecordServiceTest {
                 .duration(request.runningData().runningTime())
                 .calorie(request.runningData().calorie())
                 .averagePace(request.runningData().averagePace())
+                .route(List.of(new Coordinate(0, 0, 0), new Coordinate(0, 0, 0)))
                 .build();
 
         ChallengeWithCondition challengeWithCondition = new ChallengeWithCondition(


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #87 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- route에 임시 좌표를 저장하도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
