### PR TITLE
Fix: scale 테이블에 달성 목표 값을 나타내는 achievement_value_meter컬럼 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/scale/Scale.java
+++ b/src/main/java/com/dnd/runus/domain/scale/Scale.java
@@ -1,3 +1,10 @@
 package com.dnd.runus.domain.scale;
 
-public record Scale(long scaleId, String name, int sizeMeter, int index, String startName, String endName) {}
+public record Scale(
+        long scaleId,
+        String name,
+        int sizeMeter,
+        int achievementValueMeter,
+        int index,
+        String startName,
+        String endName) {}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
@@ -32,6 +32,9 @@ public class ScaleEntity {
     private Integer sizeMeter;
 
     @NotNull
+    private Integer achievementValueMeter;
+
+    @NotNull
     private Integer index;
 
     @NotNull
@@ -43,7 +46,7 @@ public class ScaleEntity {
     private String endName;
 
     public Scale toDomain() {
-        return new Scale(id, name, sizeMeter, index, startName, endName);
+        return new Scale(id, name, sizeMeter, index, achievementValueMeter, startName, endName);
     }
 
     public static ScaleEntity from(Scale scale) {
@@ -53,6 +56,7 @@ public class ScaleEntity {
                 .index(scale.index())
                 .startName(scale.startName())
                 .endName(scale.endName())
+                .achievementValueMeter(scale.achievementValueMeter())
                 .build();
     }
 }

--- a/src/main/resources/db/migration/V5.0.12__add_scale_from_to_column.sql
+++ b/src/main/resources/db/migration/V5.0.12__add_scale_from_to_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scale ADD COLUMN achievement_value_meter integer NOT NULL;

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -28,10 +28,10 @@ public class ScaleRepositoryImplTest {
     void getSummary() {
         // given
         // test data insert
-        Scale scale1 = new Scale(1, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)");
-        Scale scale2 = new Scale(2, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)");
+        Scale scale1 = new Scale(1, "scale1", 1_000_000, 1, 1_000_000, "서울(한국)", "도쿄(일본)");
+        Scale scale2 = new Scale(2, "scale2", 2_100_000, 2, 3_100_000, "도쿄(일본)", "베이징(중국)");
 
-        Scale scale3 = new Scale(3, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)");
+        Scale scale3 = new Scale(3, "scale3", 1_000_000, 3, 4_100_000, "베이징(중국)", "타이베이(대만)");
 
         em.persist(ScaleEntity.from(scale1));
         em.persist(ScaleEntity.from(scale2));


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #149 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- scale 테이블에 `achievement_value_meter`컬럼(달성 조건 컬럼)을 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 기존 `size_meter` 컬럼은 시작 지점에서 끝 지점 사이의 거리를 나타내어서 사용자가 해당 코스를 달성했는지 확인하기가 복잡합니다. 따라서 해당 코스를 달성했는지 확인 하기 위해 해당 row의 index이전의 거리의 합을 나타내는 컬럼(달성 조건 거리를 나타내는 컬럼)을 추가합니다.
