### PR TITLE
Fix: Pace json format 형식에서 '가 아닌 prime 기호도 허용하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -18,14 +18,14 @@ public record Pace(int minute, int second) {
 
     @JsonCreator
     public static Pace from(String pace) {
-        // e.g. 5'30"
-        String[] paceArr = pace.split("'|''");
+        // e.g. 5'30" or 5’30”
+        String[] paceArr = pace.split("[’']|”");
         return new Pace(Integer.parseInt(paceArr[0]), Integer.parseInt(paceArr[1]));
     }
 
     @JsonValue
     public String getPace() {
-        return minute + "'" + second + "''";
+        return minute + "’" + second + "”";
     }
 
     public int toSeconds() {

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/RunningRecordMetricsDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/RunningRecordMetricsDto.java
@@ -1,13 +1,9 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
-import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.common.Pace;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 
 import java.time.Duration;
-import java.util.List;
 
 public record RunningRecordMetricsDto(
         @Schema(description = "평균 페이스", example = "5'30''")

--- a/src/test/java/com/dnd/runus/domain/common/PaceTest.java
+++ b/src/test/java/com/dnd/runus/domain/common/PaceTest.java
@@ -24,12 +24,13 @@ class PaceTest {
     @DisplayName("올바른 형태의 문자열을 입력받아 Pace 객체를 생성한다.")
     void from() {
         assertEquals(Pace.from("5'30''"), pace);
+        assertEquals(Pace.from("5’30”"), pace);
     }
 
     @Test
     @DisplayName("Pace 객체를 올바른 형태의 문자열로 변환한다.")
     void getPace() {
-        assertEquals("5'30''", pace.getPace());
+        assertEquals("5’30”", pace.getPace());
     }
 
     @Test


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #151 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에는 5'30'' 형태로 역직렬화 했습니다.
  - `5'30''`과 `5’30”` 2가지 방식을 허용합니다. (prime 기호인 `’`)
- 직렬화 할때에는 prime 기호를 사용한 `5’30”`을 반환하도록 합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
