### PR TITLE
Feat: scale 기록 조회 함수를 ScaleAchievementRepository에 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementLog.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementLog.java
@@ -1,0 +1,7 @@
+package com.dnd.runus.domain.scale;
+
+import io.micrometer.common.lang.Nullable;
+
+import java.time.OffsetDateTime;
+
+public record ScaleAchievementLog(Scale scale, @Nullable OffsetDateTime achievedDate) {}

--- a/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.runus.domain.scale;
+
+import java.util.List;
+
+public interface ScaleAchievementRepository {
+    List<ScaleAchievementLog> findScaleAchievementLogs(long memberId);
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.dnd.runus.infrastructure.persistence.domain.scale;
+
+import com.dnd.runus.domain.scale.ScaleAchievementLog;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.infrastructure.persistence.jooq.scale.JooqScaleAchievementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ScaleAchievementRepositoryImpl implements ScaleAchievementRepository {
+
+    private final JooqScaleAchievementRepository jooqScaleAchievementRepository;
+
+    @Override
+    public List<ScaleAchievementLog> findScaleAchievementLogs(long memberId) {
+        return jooqScaleAchievementRepository.findScaleAchievementLogs(memberId);
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleAchievementRepository.java
@@ -1,0 +1,56 @@
+package com.dnd.runus.infrastructure.persistence.jooq.scale;
+
+import com.dnd.runus.domain.scale.Scale;
+import com.dnd.runus.domain.scale.ScaleAchievementLog;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static com.dnd.runus.jooq.Tables.SCALE;
+import static com.dnd.runus.jooq.Tables.SCALE_ACHIEVEMENT;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqScaleAchievementRepository {
+
+    private final DSLContext dsl;
+
+    public List<ScaleAchievementLog> findScaleAchievementLogs(long memberId) {
+        return dsl
+                .select(
+                        SCALE.ID,
+                        SCALE.NAME,
+                        SCALE.SIZE_METER,
+                        SCALE.INDEX,
+                        SCALE.START_NAME,
+                        SCALE.END_NAME,
+                        SCALE_ACHIEVEMENT.ACHIEVED_DATE)
+                .from(SCALE)
+                .leftJoin(SCALE_ACHIEVEMENT)
+                .on(SCALE.ID.eq(SCALE_ACHIEVEMENT.SCALE_ID).and(SCALE_ACHIEVEMENT.MEMBER_ID.eq(memberId)))
+                .fetch(new ScaleAchievementLogMapper())
+                .stream()
+                .sorted(Comparator.comparingInt(log -> log.scale().index()))
+                .toList();
+    }
+
+    private static class ScaleAchievementLogMapper implements RecordMapper<Record, ScaleAchievementLog> {
+        @Override
+        public ScaleAchievementLog map(Record record) {
+            return new ScaleAchievementLog(
+                    new Scale(
+                            record.get(SCALE.ID),
+                            record.get(SCALE.NAME),
+                            record.get(SCALE.SIZE_METER),
+                            record.get(SCALE.INDEX),
+                            record.get(SCALE.START_NAME),
+                            record.get(SCALE.END_NAME)),
+                    record.get(SCALE_ACHIEVEMENT.ACHIEVED_DATE));
+        }
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/member/entity/MemberEntity.java
@@ -30,7 +30,7 @@ public class MemberEntity extends BaseTimeEntity {
 
     public static MemberEntity from(Member member) {
         MemberEntity memberEntity = new MemberEntity();
-        memberEntity.id = member.memberId();
+        memberEntity.id = member.memberId() == 0 ? null : member.memberId();
         memberEntity.role = member.role();
         memberEntity.nickname = member.nickname();
         return memberEntity;

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
@@ -74,7 +74,7 @@ public class RunningRecordEntity extends BaseTimeEntity {
 
     public static RunningRecordEntity from(RunningRecord runningRecord) {
         return RunningRecordEntity.builder()
-                .id(runningRecord.runningId())
+                .id(runningRecord.runningId() == 0 ? null : runningRecord.runningId())
                 .member(MemberEntity.from(runningRecord.member()))
                 .distanceMeter(runningRecord.distanceMeter())
                 .durationSeconds((int) runningRecord.duration().toSeconds())

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleAchievementEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleAchievementEntity.java
@@ -36,6 +36,15 @@ public class ScaleAchievementEntity extends BaseTimeEntity {
     @NotNull
     private OffsetDateTime achievedDate;
 
+    public static ScaleAchievementEntity from(ScaleAchievement scaleAchievement) {
+        ScaleAchievementEntity scaleAchievementEntity = new ScaleAchievementEntity();
+        scaleAchievementEntity.id = scaleAchievement.id() == 0 ? null : scaleAchievement.id();
+        scaleAchievementEntity.member = MemberEntity.from(scaleAchievement.member());
+        scaleAchievementEntity.scale = ScaleEntity.from(scaleAchievement.scale());
+        scaleAchievementEntity.achievedDate = scaleAchievement.achievedDate();
+        return scaleAchievementEntity;
+    }
+
     public ScaleAchievement toDomain() {
         return new ScaleAchievement(id, member.toDomain(), scale.toDomain(), achievedDate);
     }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleEntity.java
@@ -48,6 +48,7 @@ public class ScaleEntity {
 
     public static ScaleEntity from(Scale scale) {
         return ScaleEntity.builder()
+                .id(scale.scaleId() == 0 ? null : scale.scaleId())
                 .name(scale.name())
                 .sizeMeter(scale.sizeMeter())
                 .index(scale.index())

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.dnd.runus.infrastructure.persistence.domain.scale;
+
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.scale.Scale;
+import com.dnd.runus.domain.scale.ScaleAchievement;
+import com.dnd.runus.domain.scale.ScaleAchievementLog;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleAchievementEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RepositoryTest
+public class ScaleAchievementRepositoryTest {
+
+    @Autowired
+    private ScaleAchievementRepository scaleAchievementRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private long memberId;
+    private Scale scale1;
+    private Scale scale2;
+
+    @BeforeEach
+    void setUp() {
+        MemberEntity memberEntity = MemberEntity.from(new Member(MemberRole.USER, "nickname"));
+        em.persist(memberEntity);
+        ScaleEntity scaleEntity1 = ScaleEntity.from(new Scale(0, "test", 200, 1, "test1", "test2"));
+        ScaleEntity scaleEntity2 = ScaleEntity.from(new Scale(0, "test11", 1000, 2, "test1", "test2"));
+        em.persist(scaleEntity1);
+        em.persist(scaleEntity2);
+        em.flush();
+        Member member = memberEntity.toDomain();
+        memberId = member.memberId();
+        scale1 = scaleEntity1.toDomain();
+        scale2 = scaleEntity2.toDomain();
+        ScaleAchievement scaleAchievement = new ScaleAchievement(0, member, scale1, OffsetDateTime.now());
+        em.persist(ScaleAchievementEntity.from(scaleAchievement));
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("해당 코스를 달성했다면, achievedDate는 null이 아니다.")
+    void findScaleAchievementLogs() {
+        List<ScaleAchievementLog> scaleAchievementLogs = scaleAchievementRepository.findScaleAchievementLogs(memberId);
+
+        assertEquals(2, scaleAchievementLogs.size());
+
+        assertEquals(scale1, scaleAchievementLogs.get(0).scale());
+        assertNotNull(scaleAchievementLogs.get(0).achievedDate());
+
+        assertEquals(scale2, scaleAchievementLogs.get(1).scale());
+        assertNull(scaleAchievementLogs.get(1).achievedDate());
+    }
+}

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -28,10 +28,9 @@ public class ScaleRepositoryImplTest {
     void getSummary() {
         // given
         // test data insert
-        Scale scale1 = new Scale(1, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)");
-        Scale scale2 = new Scale(2, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)");
-
-        Scale scale3 = new Scale(3, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)");
+        Scale scale1 = new Scale(0, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)");
+        Scale scale2 = new Scale(0, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)");
+        Scale scale3 = new Scale(0, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)");
 
         em.persist(ScaleEntity.from(scale1));
         em.persist(ScaleEntity.from(scale2));

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntityTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntityTest.java
@@ -23,8 +23,8 @@ class RunningRecordEntityTest {
     void setUp() {
         runningRecord = RunningRecord.builder()
                 .runningId(1L)
-                .member(new Member(MemberRole.USER, "nickname-1"))
                 .distanceMeter(500)
+                .member(new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now()))
                 .duration(Duration.ofSeconds(100))
                 .calorie(1.0)
                 .averagePace(Pace.ofSeconds(100))


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #141 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- scale 기록 조회 함수를 ScaleAchievementRepository에 추가합니다.
  - jOOQ를 이용해 구현했고, `ScaleAchievementLog` record 클래스를 추가해 `scale`, `scale_achievement` 테이블의 `achived_date` 만 가져옵니다.
  - `scale left join scale_achievement`로 가져오므로 달성일자는 null일수 있습니다. 그래서 `ScaleAchievementLog` 클래스의 `achievedDate` 필드에 `@Nullable`을 달았습니다.
- 추가적으로 엔티티 클래스의 `from()` 함수에서, 도메인 클래스의 id가 0인 경우에 오류가 있었습니다.
  - JPA persist 함수 호출시 엔티티 id값이 0이라도 id가 유효하다고 판단해서, 
    엔티티 클래스의 `from()` 함수에서 id가 0인 경우에는 엔티티 클래스의 id에 null를 저장하도록 했습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
