### PR TITLE
Feat: scale 코스 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/scale/ScaleService.java
+++ b/src/main/java/com/dnd/runus/application/scale/ScaleService.java
@@ -1,10 +1,18 @@
 package com.dnd.runus.application.scale;
 
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementLog;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.domain.scale.ScaleSummary;
+import com.dnd.runus.presentation.v1.scale.dto.ScaleCoursesResponse;
 import com.dnd.runus.presentation.v1.scale.dto.ScaleSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
 
 import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE_EARTH;
 
@@ -13,11 +21,76 @@ import static com.dnd.runus.global.constant.ScaleConstant.DISTANCE_KM_AROUND_THE
 public class ScaleService {
 
     private final ScaleRepository scaleRepository;
+    private final ScaleAchievementRepository scaleAchievementRepository;
+    private final RunningRecordRepository runningRecordRepository;
 
     public ScaleSummaryResponse getSummary() {
         ScaleSummary summary = scaleRepository.getSummary();
 
         return new ScaleSummaryResponse(
                 summary.totalCourseCnt(), summary.totalCourseDistanceKm(), DISTANCE_KM_AROUND_THE_EARTH);
+    }
+
+    public ScaleCoursesResponse getAchievements(long memberId) {
+        List<ScaleAchievementLog> scaleAchievementLogs = scaleAchievementRepository.findScaleAchievementLogs(memberId);
+
+        ScaleCoursesResponse.Info info = new ScaleCoursesResponse.Info(
+                scaleAchievementLogs.size(),
+                scaleAchievementLogs.stream()
+                        .mapToInt(log -> log.scale().sizeMeter())
+                        .sum());
+
+        return new ScaleCoursesResponse(
+                info,
+                getAchievedCourses(scaleAchievementLogs),
+                calculateCurrentScaleLeftMeter(scaleAchievementLogs, memberId));
+    }
+
+    private List<ScaleCoursesResponse.AchievedCourse> getAchievedCourses(
+            List<ScaleAchievementLog> scaleAchievementLogs) {
+        boolean hasAchievedCourse = scaleAchievementLogs.stream().anyMatch(log -> log.achievedDate() != null);
+        if (!hasAchievedCourse) {
+            return List.of();
+        }
+
+        return scaleAchievementLogs.stream()
+                .filter(log -> log.achievedDate() != null)
+                .map(log -> new ScaleCoursesResponse.AchievedCourse(
+                        log.scale().name(),
+                        log.scale().sizeMeter(),
+                        log.achievedDate().toLocalDate()))
+                .toList();
+    }
+
+    private ScaleCoursesResponse.CurrentCourse calculateCurrentScaleLeftMeter(
+            List<ScaleAchievementLog> scaleAchievementLogs, long memberId) {
+
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime start = OffsetDateTime.of(LocalDate.of(1, 1, 1).atStartOfDay(), now.getOffset());
+        int memberRunMeterSum = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId, start, now);
+
+        ScaleAchievementLog currentScale = scaleAchievementLogs.stream()
+                .filter(log -> log.achievedDate() == null)
+                .findFirst()
+                .orElse(null);
+
+        if (currentScale == null) {
+            return new ScaleCoursesResponse.CurrentCourse("지구 한바퀴", 0, 0, "축하합니다! 지구 한바퀴 완주하셨네요!");
+        }
+
+        int achievedCourseMeterSum = scaleAchievementLogs.stream()
+                .filter(log -> log.achievedDate() != null)
+                .mapToInt(log -> log.scale().sizeMeter())
+                .sum();
+
+        double remainingKm = (currentScale.scale().sizeMeter() + achievedCourseMeterSum - memberRunMeterSum) / 1000.0;
+
+        String message = String.format("%s까지 %.1fkm 남았어요!", currentScale.scale().endName(), remainingKm);
+
+        return new ScaleCoursesResponse.CurrentCourse(
+                currentScale.scale().name(),
+                currentScale.scale().sizeMeter(),
+                memberRunMeterSum - achievedCourseMeterSum,
+                message);
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/scale/ScaleController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/ScaleController.java
@@ -1,6 +1,8 @@
 package com.dnd.runus.presentation.v1.scale;
 
 import com.dnd.runus.application.scale.ScaleService;
+import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.scale.dto.ScaleCoursesResponse;
 import com.dnd.runus.presentation.v1.scale.dto.ScaleSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,12 +25,26 @@ public class ScaleController {
             summary = "지구 한 바퀴 코스 서머리",
             description =
                     """
-                지구 한 바퀴 코스 서머리를 조회 합니다.<br>
-                [달성 기록] - [런어스랑 지구한바퀴 달리기]의 전체 코스, 런어스 총 거리, 지구 한 바퀴의 값을 리턴합니다.
-                """)
+                            지구 한 바퀴 코스 서머리를 조회 합니다.<br>
+                            [달성 기록] - [런어스랑 지구한바퀴 달리기]의 전체 코스, 런어스 총 거리, 지구 한 바퀴의 값을 리턴합니다.
+                            """)
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("course-summary")
     public ScaleSummaryResponse getScaleSummary() {
         return scaleService.getSummary();
+    }
+
+    @GetMapping("courses")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "달성 기록 목록 조회",
+            description =
+                    """
+                            달성한 코스 목록을 조회합니다. 달성한 코스 목록, 현재 진행중인 코스 정보를 반환합니다.<br>
+                            - 달성한 코스가 없다면, 빈 리스트를 반환합니다.<br>
+                            - 달성한 코스가 있다면, 달성한 코스 목록과 현재 진행중인 코스 정보를 반환합니다.
+                            """)
+    public ScaleCoursesResponse getCourses(@MemberId long memberId) {
+        return scaleService.getAchievements(memberId);
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleCoursesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleCoursesResponse.java
@@ -1,0 +1,42 @@
+package com.dnd.runus.presentation.v1.scale.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ScaleCoursesResponse(
+        Info info,
+        List<AchievedCourse> achievedCourses,
+        CurrentCourse currentCourse
+) {
+    public record Info(
+            @Schema(description = "총 코스 수 (공개되지 않은 코스 포함)", example = "18")
+            int totalCourses,
+            @Schema(description = "총 런어스 거리 (미터)", example = "43800000")
+            int totalMeter
+    ) {
+    }
+
+    public record AchievedCourse(
+            @Schema(description = "코스 이름", example = "서울에서 부산")
+            String name,
+            @Schema(description = "코스 총 거리 (미터)", example = "300000")
+            int meter,
+            @Schema(description = "달성 일자")
+            LocalDate achievedAt
+    ) {
+    }
+
+    public record CurrentCourse(
+            @Schema(description = "현재 코스 이름", example = "서울에서 부산")
+            String name,
+            @Schema(description = "현재 코스 총 거리 (미터)", example = "300000")
+            int totalMeter,
+            @Schema(description = "현재 달성한 거리 (미터), 현재 50m 달성", example = "50")
+            int achievedMeter,
+            @Schema(description = "현재 코스 설명 메시지", example = "대전까지 100km 남았어요!")
+            String message
+    ) {
+    }
+}

--- a/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
@@ -1,0 +1,96 @@
+package com.dnd.runus.application.scale;
+
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.Scale;
+import com.dnd.runus.domain.scale.ScaleAchievementLog;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.presentation.v1.scale.dto.ScaleCoursesResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ScaleServiceTest {
+
+    @InjectMocks
+    private ScaleService scaleService;
+
+    @Mock
+    private RunningRecordRepository runningRecordRepository;
+
+    @Mock
+    private ScaleAchievementRepository scaleAchievementRepository;
+
+    private long memberId;
+    private Scale scale1;
+    private Scale scale2;
+    private Scale scale3;
+
+    @BeforeEach
+    void setUp() {
+        memberId = 1;
+        scale1 = new Scale(1, "서울에서 인천", 200, 1, "서울", "인천");
+        scale2 = new Scale(2, "인천에서 대전", 1000, 2, "인천", "대전");
+        scale3 = new Scale(3, "대전에서 대구", 3000, 3, "대전", "대구");
+    }
+
+    @DisplayName("달성한 코스가 없는 경우, 달성한 코스는 빈 리스트를 반환한다. 현재 진행중인 코스의 달성 거리는 지금까지 달린 거리와 동일해야 한다")
+    @Test
+    void getAchievements() {
+        // given
+        given(scaleAchievementRepository.findScaleAchievementLogs(memberId))
+                .willReturn(List.of(
+                        new ScaleAchievementLog(scale1, null),
+                        new ScaleAchievementLog(scale2, null),
+                        new ScaleAchievementLog(scale3, null)));
+        int runningMeterSum = 50;
+        given(runningRecordRepository.findTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
+                .willReturn(runningMeterSum);
+
+        // when
+        ScaleCoursesResponse response = scaleService.getAchievements(memberId);
+
+        // then
+        assertNotNull(response);
+        assertTrue(response.achievedCourses().isEmpty());
+        assertEquals(runningMeterSum, response.currentCourse().achievedMeter());
+    }
+
+    @DisplayName("달성한 코스가 있는 경우, 달성한 코스, 현재 진행중인 코스 정보를 반환한다.")
+    @Test
+    void getAchievementsWithAchievedCourse() {
+        // given
+        given(scaleAchievementRepository.findScaleAchievementLogs(memberId))
+                .willReturn(List.of(
+                        new ScaleAchievementLog(scale1, OffsetDateTime.now()),
+                        new ScaleAchievementLog(scale2, null),
+                        new ScaleAchievementLog(scale3, null)));
+        given(runningRecordRepository.findTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
+                .willReturn(1000);
+
+        // when
+        ScaleCoursesResponse response = scaleService.getAchievements(memberId);
+
+        // then
+        assertNotNull(response);
+        assertEquals(1, response.achievedCourses().size());
+
+        assertEquals(scale1.name(), response.achievedCourses().get(0).name());
+        assertEquals(200, response.achievedCourses().get(0).meter());
+
+        assertEquals(scale2.name(), response.currentCourse().name());
+        assertEquals(800, response.currentCourse().achievedMeter());
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #141 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `api/v1/scale/courses`: 달성 코스 목록 조회

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 달성 코스 목록 조회 API를 추가합니다.
  - 코스 정보(개수, 총 거리)
  - 달성한 코스들 리스트( 없는 경우, 빈 리스트 )
  - 현재 진행중인 코스

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- `api/v1/scale/course-summary`에서 반환하던 코스 개수나 거리도 지금 추가하려는 API에 포함시켰어요
