### PR TITLE
Feat: 저장할 수 있는 scale_id 리스트 조회 repository

### DIFF
--- a/src/main/java/com/dnd/runus/domain/scale/ScaleRepository.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleRepository.java
@@ -1,5 +1,9 @@
 package com.dnd.runus.domain.scale;
 
+import java.util.List;
+
 public interface ScaleRepository {
     ScaleSummary getSummary();
+
+    List<Long> findAchievableScaleIds(long memberId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.dnd.runus.infrastructure.persistence.jooq.scale.JooqScaleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class ScaleRepositoryImpl implements ScaleRepository {
@@ -15,5 +17,10 @@ public class ScaleRepositoryImpl implements ScaleRepository {
     @Override
     public ScaleSummary getSummary() {
         return jooqScaleRepository.getSummary();
+    }
+
+    @Override
+    public List<Long> findAchievableScaleIds(long memberId) {
+        return jooqScaleRepository.findAchievableScaleIds(memberId);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
@@ -2,14 +2,24 @@ package com.dnd.runus.infrastructure.persistence.jooq.scale;
 
 import com.dnd.runus.domain.scale.ScaleSummary;
 import lombok.RequiredArgsConstructor;
+import org.jooq.CommonTableExpression;
 import org.jooq.DSLContext;
 import org.jooq.Record;
+import org.jooq.Record1;
+import org.jooq.Record2;
 import org.jooq.RecordMapper;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Objects;
+
+import static com.dnd.runus.jooq.Tables.RUNNING_RECORD;
+import static com.dnd.runus.jooq.Tables.SCALE_ACHIEVEMENT;
 import static com.dnd.runus.jooq.tables.Scale.SCALE;
 import static org.jooq.impl.DSL.coalesce;
 import static org.jooq.impl.DSL.count;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.sum;
 
 @Repository
@@ -23,6 +33,34 @@ public class JooqScaleRepository {
                         count().as("count"), coalesce(sum(SCALE.SIZE_METER), 0).as("total_meter"))
                 .from(SCALE)
                 .fetchOne(new ScaleSummaryMapper());
+    }
+
+    public List<Long> findAchievableScaleIds(long memberId) {
+
+        CommonTableExpression<Record1<Integer>> totalDistance = name("total_distance")
+                .fields("total_distance_meter")
+                .as(select(sum(RUNNING_RECORD.DISTANCE_METER).cast(int.class))
+                        .from(RUNNING_RECORD)
+                        .where(RUNNING_RECORD.MEMBER_ID.eq(memberId)));
+
+        CommonTableExpression<Record2<Long, Integer>> cumulativeScale = name("cumulative_scale")
+                .fields("id", "cumulative_sum")
+                .as(select(
+                                SCALE.ID,
+                                sum(SCALE.SIZE_METER).over().orderBy(SCALE.ID).cast(int.class))
+                        .from(SCALE)
+                        .where(SCALE.ID.notIn(select(SCALE_ACHIEVEMENT.SCALE_ID)
+                                .from(SCALE_ACHIEVEMENT)
+                                .where(SCALE_ACHIEVEMENT.MEMBER_ID.eq(memberId)))));
+
+        return dsl.with(totalDistance)
+                .with(cumulativeScale)
+                .select(cumulativeScale.field("id", Long.class))
+                .from(cumulativeScale)
+                .join(totalDistance)
+                .on(Objects.requireNonNull(cumulativeScale.field("cumulative_sum", Integer.class))
+                        .le(totalDistance.field("total_distance_meter", Integer.class)))
+                .fetchInto(Long.class);
     }
 
     private static class ScaleSummaryMapper implements RecordMapper<Record, ScaleSummary> {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
@@ -11,7 +11,6 @@ import org.jooq.RecordMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Objects;
 
 import static com.dnd.runus.jooq.Tables.RUNNING_RECORD;
 import static com.dnd.runus.jooq.Tables.SCALE_ACHIEVEMENT;
@@ -58,7 +57,7 @@ public class JooqScaleRepository {
                 .select(cumulativeScale.field("id", Long.class))
                 .from(cumulativeScale)
                 .join(totalDistance)
-                .on(Objects.requireNonNull(cumulativeScale.field("cumulative_sum", Integer.class))
+                .on(coalesce(cumulativeScale.field("cumulative_sum", Integer.class), 0)
                         .le(totalDistance.field("total_distance_meter", Integer.class)))
                 .fetchInto(Long.class);
     }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -67,7 +67,6 @@ public class ScaleRepositoryImplTest {
         assertThat(summary.totalCourseDistanceKm()).isEqualTo((4_100 * 1000));
     }
 
-    @Transactional
     @DisplayName("성취 가능한 scale_id를 반환한다.")
     @Test
     void findAchievableScaleIds() {

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -1,17 +1,31 @@
 package com.dnd.runus.infrastructure.persistence.domain.scale;
 
+import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.domain.scale.Scale;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.domain.scale.ScaleSummary;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
 import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @RepositoryTest
 public class ScaleRepositoryImplTest {
@@ -22,12 +36,15 @@ public class ScaleRepositoryImplTest {
     @Autowired
     private ScaleRepository scaleRepository;
 
-    @Transactional
-    @DisplayName("지구 한바퀴 코스 조회:코스 수, 전체 코스 거리를 반환한다.")
-    @Test
-    void getSummary() {
-        // given
-        // test data insert
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RunningRecordRepository runningRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        // insert test data
         Scale scale1 = new Scale(0, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)");
         Scale scale2 = new Scale(0, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)");
         Scale scale3 = new Scale(0, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)");
@@ -36,12 +53,51 @@ public class ScaleRepositoryImplTest {
         em.persist(ScaleEntity.from(scale2));
         em.persist(ScaleEntity.from(scale3));
         em.flush();
+    }
 
+    @Transactional
+    @DisplayName("지구 한바퀴 코스 조회:코스 수, 전체 코스 거리를 반환한다.")
+    @Test
+    void getSummary() {
         // when
         ScaleSummary summary = scaleRepository.getSummary();
 
         // then
         assertThat(summary.totalCourseCnt()).isEqualTo(3);
         assertThat(summary.totalCourseDistanceKm()).isEqualTo((4_100 * 1000));
+    }
+
+    @Transactional
+    @DisplayName("성취 가능한 scale_id를 반환한다.")
+    @Test
+    void findAchievableScaleIds() {
+        // given
+        Member savedMember = memberRepository.save(
+                new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now()));
+        for (int i = 0; i < 3; i++) {
+            RunningRecord runningRecord = new RunningRecord(
+                    0,
+                    savedMember,
+                    1_100_000,
+                    Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now().plusHours(1),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO);
+            runningRecordRepository.save(runningRecord);
+        }
+
+        // when
+        List<Long> achievableScaleIds = scaleRepository.findAchievableScaleIds(savedMember.memberId());
+
+        // then
+        assertNotNull(achievableScaleIds);
+        assertThat(achievableScaleIds.size()).isEqualTo(2);
+        assertNotNull(achievableScaleIds.get(0));
+        assertNotNull(achievableScaleIds.get(1));
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #140

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 사용자 member_id, 사용자의 전체 달린 거리에 따라 scale_achievement에 저장할 수 있는 scale_id 리스트를 조회합니다.
- ex)
    - 사용자가 이번 러닝에서 2.5km을 뜀
    - 사용자의 전체 러닝 달린 기록이 3km
    - `scale` 기준이 아래와 같음
         -  id:1, 코스1, 누적 거리 500m, 순서:1
         -  id:2, 코스2, 누적 거리 1km, 순서:2
         -  id:3, 코스3, 누적 거리 3km, 순서 3
    - 현재 `scale_achievement` 테이블에 저장 된 사용자의 데이터 값
      - scale_id가 1인 데이터
- 위의 예시의 경우 이번 러닝에서 `scale_achievement`에 저장할 수 있는 `scale_id` 값은 2, 3이 되고 `findAchievableScaleIds`은 [2,3]을 반환하다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
