### PR TITLE
Feat: ScaleAchievement 저장 함수 리파지토리 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/scale/Scale.java
+++ b/src/main/java/com/dnd/runus/domain/scale/Scale.java
@@ -1,3 +1,7 @@
 package com.dnd.runus.domain.scale;
 
-public record Scale(long scaleId, String name, int sizeMeter, int index, String startName, String endName) {}
+public record Scale(long scaleId, String name, int sizeMeter, int index, String startName, String endName) {
+    public Scale(long scaleId) {
+        this(scaleId, null, 0, 0, null, null);
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/scale/ScaleAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleAchievement.java
@@ -4,4 +4,4 @@ import com.dnd.runus.domain.member.Member;
 
 import java.time.OffsetDateTime;
 
-public record ScaleAchievement(long id, Member member, Scale scale, OffsetDateTime achievedDate) {}
+public record ScaleAchievement(Member member, Scale scale, OffsetDateTime achievedDate) {}

--- a/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementRepository.java
@@ -4,4 +4,6 @@ import java.util.List;
 
 public interface ScaleAchievementRepository {
     List<ScaleAchievementLog> findScaleAchievementLogs(long memberId);
+
+    List<ScaleAchievement> saveAll(List<ScaleAchievement> scaleAchievements);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.dnd.runus.infrastructure.persistence.domain.scale;
 
+import com.dnd.runus.domain.scale.ScaleAchievement;
 import com.dnd.runus.domain.scale.ScaleAchievementLog;
 import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jooq.scale.JooqScaleAchievementRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.JpaScaleAchievementRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleAchievementEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,9 +16,21 @@ import java.util.List;
 public class ScaleAchievementRepositoryImpl implements ScaleAchievementRepository {
 
     private final JooqScaleAchievementRepository jooqScaleAchievementRepository;
+    private final JpaScaleAchievementRepository jpaScaleAchievementRepository;
 
     @Override
     public List<ScaleAchievementLog> findScaleAchievementLogs(long memberId) {
         return jooqScaleAchievementRepository.findScaleAchievementLogs(memberId);
+    }
+
+    @Override
+    public List<ScaleAchievement> saveAll(List<ScaleAchievement> scaleAchievements) {
+        return jpaScaleAchievementRepository
+                .saveAll(scaleAchievements.stream()
+                        .map(ScaleAchievementEntity::from)
+                        .toList())
+                .stream()
+                .map(ScaleAchievementEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/JpaScaleAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/JpaScaleAchievementRepository.java
@@ -1,0 +1,6 @@
+package com.dnd.runus.infrastructure.persistence.jpa.scale;
+
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleAchievementEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaScaleAchievementRepository extends JpaRepository<ScaleAchievementEntity, Long> {}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleAchievementEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/entity/ScaleAchievementEntity.java
@@ -38,7 +38,6 @@ public class ScaleAchievementEntity extends BaseTimeEntity {
 
     public static ScaleAchievementEntity from(ScaleAchievement scaleAchievement) {
         ScaleAchievementEntity scaleAchievementEntity = new ScaleAchievementEntity();
-        scaleAchievementEntity.id = scaleAchievement.id() == 0 ? null : scaleAchievement.id();
         scaleAchievementEntity.member = MemberEntity.from(scaleAchievement.member());
         scaleAchievementEntity.scale = ScaleEntity.from(scaleAchievement.scale());
         scaleAchievementEntity.achievedDate = scaleAchievement.achievedDate();
@@ -46,6 +45,6 @@ public class ScaleAchievementEntity extends BaseTimeEntity {
     }
 
     public ScaleAchievement toDomain() {
-        return new ScaleAchievement(id, member.toDomain(), scale.toDomain(), achievedDate);
+        return new ScaleAchievement(member.toDomain(), scale.toDomain(), achievedDate);
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryTest.java
@@ -8,7 +8,6 @@ import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
 import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberEntity;
-import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleAchievementEntity;
 import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +29,7 @@ public class ScaleAchievementRepositoryTest {
     @Autowired
     private EntityManager em;
 
-    private long memberId;
+    private Member member;
     private Scale scale1;
     private Scale scale2;
 
@@ -43,19 +42,17 @@ public class ScaleAchievementRepositoryTest {
         em.persist(scaleEntity1);
         em.persist(scaleEntity2);
         em.flush();
-        Member member = memberEntity.toDomain();
-        memberId = member.memberId();
+        member = memberEntity.toDomain();
         scale1 = scaleEntity1.toDomain();
         scale2 = scaleEntity2.toDomain();
-        ScaleAchievement scaleAchievement = new ScaleAchievement(0, member, scale1, OffsetDateTime.now());
-        em.persist(ScaleAchievementEntity.from(scaleAchievement));
-        em.flush();
     }
 
     @Test
     @DisplayName("해당 코스를 달성했다면, achievedDate는 null이 아니다.")
     void findScaleAchievementLogs() {
-        List<ScaleAchievementLog> scaleAchievementLogs = scaleAchievementRepository.findScaleAchievementLogs(memberId);
+        scaleAchievementRepository.saveAll(List.of(new ScaleAchievement(member, scale1, OffsetDateTime.now())));
+        List<ScaleAchievementLog> scaleAchievementLogs =
+                scaleAchievementRepository.findScaleAchievementLogs(member.memberId());
 
         assertEquals(2, scaleAchievementLogs.size());
 
@@ -64,5 +61,16 @@ public class ScaleAchievementRepositoryTest {
 
         assertEquals(scale2, scaleAchievementLogs.get(1).scale());
         assertNull(scaleAchievementLogs.get(1).achievedDate());
+    }
+
+    @Test
+    @DisplayName("코스 성취 기록을 저장한다.")
+    void saveTest() {
+        List<ScaleAchievement> saved = scaleAchievementRepository.saveAll(List.of(
+                new ScaleAchievement(member, new Scale(scale1.scaleId()), OffsetDateTime.now()),
+                new ScaleAchievement(member, new Scale(scale2.scaleId()), OffsetDateTime.now())));
+
+        assertNotNull(saved);
+        assertNotNull(saved.get(0));
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #140 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `scale_achievement`의 데이터를 저장하는 함수를 리파지토리에 추가합니다.
- `ScaleAchievement` 도메인의 `id`를 사용하지 않아 삭제합니다.
- `id`로 `Scale` 도메인을 생성할 수 있는 생성자를 추가합니다.
    - 사용자가 저장할 수 있는 scale_id 값을 조회 -> 알맞게 `ScaleAchievement`로 변환 후 저장할 예정입니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
