### PR TITLE
Fix: 챌린지 성취 퍼센테이지 저장 버그 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -186,7 +186,8 @@ public class RunningRecordService {
         ChallengeAchievement achievement =
                 challengeAchievementRepository.save(achievementRecord.challengeAchievement());
         if (achievementRecord.percentageValues() != null) {
-            percentageValuesRepository.save(achievementRecord);
+            percentageValuesRepository.save(
+                    new ChallengeAchievementRecord(achievement, achievementRecord.percentageValues()));
         }
         return achievement;
     }

--- a/src/main/java/com/dnd/runus/domain/challenge/ChallengeWithCondition.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/ChallengeWithCondition.java
@@ -15,13 +15,13 @@ public record ChallengeWithCondition(Challenge challenge, List<ChallengeConditio
                         !condition.isAchieved(condition.goalMetricType().getActualValue(runningRecord)))
                 .findFirst();
 
-        boolean hasNoRangeCondition = conditions.stream()
-                .noneMatch(condition -> condition.goalMetricType().hasPercentage());
+        boolean hasRangeCondition = conditions.stream()
+                .allMatch(condition -> condition.goalMetricType().hasPercentage());
 
         ChallengeAchievement achievement =
                 new ChallengeAchievement(challenge, runningRecord, failedCondition.isEmpty());
 
-        if (hasNoRangeCondition) {
+        if (!hasRangeCondition) {
             return new ChallengeAchievementRecord(achievement);
         }
 

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeAchievementEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeAchievementEntity.java
@@ -41,6 +41,10 @@ public class ChallengeAchievementEntity extends BaseTimeEntity {
 
     public static ChallengeAchievementEntity from(ChallengeAchievement challengeAchievement) {
         return ChallengeAchievementEntity.builder()
+                .id(
+                        challengeAchievement.ChallengeAchievementId() == 0
+                                ? null
+                                : challengeAchievement.ChallengeAchievementId())
                 .runningRecord(RunningRecordEntity.from(challengeAchievement.runningRecord()))
                 .challengeId(challengeAchievement.challenge().challengeId())
                 .successStatus(challengeAchievement.isSuccess())


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #159 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- challenge_achievement_percentage저장 시 challenge_achievement_id null 관련 버그를 수정합니다.
   - 저장된 `ChallengeAchievement`의 id값이 필요 하므로, 챌린지 펀센티이지 저장 시 `new ChallengeAchievementRecord(achievement, achievementRecord.percentageValues())` 로 새로운 ChallengeAchievementRecord객체를 생성합니다.
   - `ChallengeAchievementEntity`의 from 메서드에 id값을 셋팅하는 코드를 추가합니다.
- 데이터 잘못 저장되는 버그(퍼센테이지 저장 유무가 false인 조건이 하나라도 있는 경우, 퍼센테이지가 저장됨.)를 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
