### PR TITLE
Feat: 러닝 저장 시 사용자 ScaleAchievement 저장 로직 추가 

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
@@ -47,10 +47,7 @@ public class JooqScaleRepository {
                 .as(select(
                                 SCALE.ID,
                                 sum(SCALE.SIZE_METER).over().orderBy(SCALE.ID).cast(int.class))
-                        .from(SCALE)
-                        .where(SCALE.ID.notIn(select(SCALE_ACHIEVEMENT.SCALE_ID)
-                                .from(SCALE_ACHIEVEMENT)
-                                .where(SCALE_ACHIEVEMENT.MEMBER_ID.eq(memberId)))));
+                        .from(SCALE));
 
         return dsl.with(totalDistance)
                 .with(cumulativeScale)
@@ -59,6 +56,10 @@ public class JooqScaleRepository {
                 .join(totalDistance)
                 .on(coalesce(cumulativeScale.field("cumulative_sum", Integer.class), 0)
                         .le(totalDistance.field("total_distance_meter", Integer.class)))
+                .where(coalesce(cumulativeScale.field("id", Long.class), -1)
+                        .notIn(select(SCALE_ACHIEVEMENT.SCALE_ID)
+                                .from(SCALE_ACHIEVEMENT)
+                                .where(SCALE_ACHIEVEMENT.MEMBER_ID.eq(memberId))))
                 .fetchInto(Long.class);
     }
 

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -14,6 +14,8 @@ import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.BusinessException;
@@ -68,6 +70,12 @@ class RunningRecordServiceTest {
     @Mock
     private GoalAchievementRepository goalAchievementRepository;
 
+    @Mock
+    private ScaleRepository scaleRepository;
+
+    @Mock
+    private ScaleAchievementRepository scaleAchievementRepository;
+
     private final ZoneOffset defaultZoneOffset = ZoneOffset.of("+9");
 
     @BeforeEach
@@ -80,6 +88,8 @@ class RunningRecordServiceTest {
                 challengeAchievementRepository,
                 percentageValuesRepository,
                 goalAchievementRepository,
+                scaleRepository,
+                scaleAchievementRepository,
                 defaultZoneOffset);
     }
 

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RepositoryTest
@@ -71,6 +72,10 @@ public class ScaleAchievementRepositoryTest {
                 new ScaleAchievement(member, new Scale(scale2.scaleId()), OffsetDateTime.now())));
 
         assertNotNull(saved);
+        assertThat(saved.size()).isEqualTo(2);
         assertNotNull(saved.get(0));
+        assertNotNull(saved.get(1));
+        assertNotNull(saved.get(0).achievedDate());
+        assertNotNull(saved.get(1).achievedDate());
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -7,6 +7,8 @@ import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.domain.scale.Scale;
+import com.dnd.runus.domain.scale.ScaleAchievement;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.domain.scale.ScaleSummary;
 import com.dnd.runus.global.constant.MemberRole;
@@ -14,11 +16,13 @@ import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
 import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -26,6 +30,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RepositoryTest
 public class ScaleRepositoryImplTest {
@@ -42,20 +47,37 @@ public class ScaleRepositoryImplTest {
     @Autowired
     private RunningRecordRepository runningRecordRepository;
 
+    @Autowired
+    private ScaleAchievementRepository scaleAchievementRepository;
+
+    private Long scale1Id;
+    private Long scale2Id;
+    private Long scale3Id;
+
     @BeforeEach
     void setUp() {
         // insert test data
-        Scale scale1 = new Scale(0, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)");
-        Scale scale2 = new Scale(0, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)");
-        Scale scale3 = new Scale(0, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)");
-
-        em.persist(ScaleEntity.from(scale1));
-        em.persist(ScaleEntity.from(scale2));
-        em.persist(ScaleEntity.from(scale3));
+        em.persist(ScaleEntity.from(new Scale(0, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)"))); // 누적 달성 거리 : 1_000_000
+        em.persist(ScaleEntity.from(new Scale(0, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)"))); // 누적 달성 거리 : 3_100_000
+        em.persist(
+                ScaleEntity.from(new Scale(0, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)"))); // 누적 달성 거리 : 4_100_000
+        em.persist(
+                ScaleEntity.from(new Scale(0, "scale4", 1_000_000, 4, "베이징(중국)", "타이베이(대만)"))); // 누적 달성 거리 : 5_100_000
         em.flush();
+
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+        CriteriaQuery<ScaleEntity> query = criteriaBuilder.createQuery(ScaleEntity.class);
+        Root<ScaleEntity> from = query.from(ScaleEntity.class);
+        query.select(from).orderBy(criteriaBuilder.asc(from.get("index")));
+
+        List<Long> idList =
+                em.createQuery(query).getResultStream().map(ScaleEntity::getId).toList();
+
+        scale1Id = idList.get(0);
+        scale2Id = idList.get(1);
+        scale3Id = idList.get(2);
     }
 
-    @Transactional
     @DisplayName("지구 한바퀴 코스 조회:코스 수, 전체 코스 거리를 반환한다.")
     @Test
     void getSummary() {
@@ -63,13 +85,13 @@ public class ScaleRepositoryImplTest {
         ScaleSummary summary = scaleRepository.getSummary();
 
         // then
-        assertThat(summary.totalCourseCnt()).isEqualTo(3);
-        assertThat(summary.totalCourseDistanceKm()).isEqualTo((4_100 * 1000));
+        assertThat(summary.totalCourseCnt()).isEqualTo(4);
+        assertThat(summary.totalCourseDistanceKm()).isEqualTo(5_100_000);
     }
 
-    @DisplayName("성취 가능한 scale_id를 반환한다.")
+    @DisplayName("scale_achievement에 기록이 없는 경우 성취 가능한 scale_id를 반환한다.")
     @Test
-    void findAchievableScaleIds() {
+    void findAchievableScaleIdsWithoutNoAchievementRecords() {
         // given
         Member savedMember = memberRepository.save(
                 new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now()));
@@ -96,7 +118,57 @@ public class ScaleRepositoryImplTest {
         // then
         assertNotNull(achievableScaleIds);
         assertThat(achievableScaleIds.size()).isEqualTo(2);
-        assertNotNull(achievableScaleIds.get(0));
-        assertNotNull(achievableScaleIds.get(1));
+        assertTrue(achievableScaleIds.contains(scale1Id));
+        assertTrue(achievableScaleIds.contains(scale2Id));
+    }
+
+    @DisplayName("scale_achievement에 기록이 존재 할 경우, 성취 가능한 scale_id를 반환한다.")
+    @Test
+    void findAchievableScaleIds() {
+        // given
+        Member savedMember = memberRepository.save(
+                new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now()));
+        runningRecordRepository.save(new RunningRecord(
+                0,
+                savedMember,
+                1_100_000,
+                Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                1,
+                new Pace(5, 11),
+                OffsetDateTime.now(),
+                OffsetDateTime.now().plusHours(1),
+                List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                "start location",
+                "end location",
+                RunningEmoji.SOSO));
+        // scale1 기록 달성(달성 거리 1_000_000 달성), 현재 누적 거리 : 1_100_000
+        scaleAchievementRepository.saveAll(
+                List.of(new ScaleAchievement(savedMember, new Scale(scale1Id), OffsetDateTime.now())));
+
+        for (int i = 0; i < 3; i++) {
+            RunningRecord runningRecord = new RunningRecord(
+                    0,
+                    savedMember,
+                    1_100_000,
+                    Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now().plusHours(1),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO);
+            runningRecordRepository.save(runningRecord);
+        } // 현재 누넉 거리 : 4_400_000
+
+        // when
+        List<Long> achievableScaleIds = scaleRepository.findAchievableScaleIds(savedMember.memberId());
+
+        // then
+        assertNotNull(achievableScaleIds);
+        assertThat(achievableScaleIds.size()).isEqualTo(2);
+        assertTrue(achievableScaleIds.contains(scale2Id));
+        assertTrue(achievableScaleIds.contains(scale3Id));
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #140 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 러닝 이 저장 되면 아래의 순서로 사용자의 지구 한 바퀴 성취 기록이 저장 됩니다.
   - 사용자의 전체 달린 거리, 기존의 사용자의 지구 한 바퀴 성취 기록을 이용해 사용자가 성취 할 수 있는 지구 한 바퀴 id를 조회하는 `scaleRepository.findAchievableScaleIds(member.memberId())`를 호출 합니다.
   - 사용자가 성취 할 수 있는 지구 한 바퀴 id가 존재 하면, 사용자의 지구 한 바퀴 성취 기록을 저장합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
