### PR TITLE
Feat: 회원 탈퇴 시 회원 관련 데이터 삭제(hard delete)

### DIFF
--- a/src/main/java/com/dnd/runus/domain/oauth/OauthRepository.java
+++ b/src/main/java/com/dnd/runus/domain/oauth/OauthRepository.java
@@ -1,0 +1,9 @@
+package com.dnd.runus.domain.oauth;
+
+/**
+ * 회원 탈퇴(hard delete)를 위한 임시 구현
+ * FIXME soft delete 완료 후 삭제
+ */
+public interface OauthRepository {
+    void deleteAllDataAboutMember(long memberId);
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/oauth/OauthRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/oauth/OauthRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.dnd.runus.infrastructure.persistence.domain.oauth;
+
+import com.dnd.runus.domain.oauth.OauthRepository;
+import com.dnd.runus.infrastructure.persistence.jooq.oauth.JooqOauthRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 회원 탈퇴(hard delete)를 위한 임시 구현
+ * FIXME soft delete 완료 후 삭제
+ */
+@Repository
+@RequiredArgsConstructor
+public class OauthRepositoryImpl implements OauthRepository {
+
+    private final JooqOauthRepository jooqOauthRepository;
+
+    private final EntityManager em;
+
+    @Override
+    public void deleteAllDataAboutMember(long memberId) {
+        em.flush();
+        em.clear();
+        jooqOauthRepository.deleteAllDataAboutMember(memberId);
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/oauth/JooqOauthRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/oauth/JooqOauthRepository.java
@@ -1,0 +1,63 @@
+package com.dnd.runus.infrastructure.persistence.jooq.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import static com.dnd.runus.jooq.Tables.CHALLENGE_ACHIEVEMENT;
+import static com.dnd.runus.jooq.Tables.CHALLENGE_ACHIEVEMENT_PERCENTAGE;
+import static com.dnd.runus.jooq.Tables.GOAL_ACHIEVEMENT;
+import static com.dnd.runus.jooq.Tables.MEMBER_LEVEL;
+import static com.dnd.runus.jooq.Tables.RUNNING_RECORD;
+import static com.dnd.runus.jooq.Tables.SCALE_ACHIEVEMENT;
+import static com.dnd.runus.jooq.Tables.SOCIAL_PROFILE;
+import static com.dnd.runus.jooq.tables.Member.MEMBER;
+import static org.jooq.impl.DSL.select;
+
+/**
+ * 회원 탈퇴(hard delete)를 위한 임시 리파지토리
+ * FIXME soft delete 완료 후 삭제
+ */
+@Repository
+@RequiredArgsConstructor
+public class JooqOauthRepository {
+    private final DSLContext dsl;
+
+    public void deleteAllDataAboutMember(long memberId) {
+        // 1. CHALLENGE_ACHIEVEMENT_PERCENTAGE 삭제
+        dsl.deleteFrom(CHALLENGE_ACHIEVEMENT_PERCENTAGE)
+                .where(CHALLENGE_ACHIEVEMENT_PERCENTAGE.CHALLENGE_ACHIEVEMENT_ID.in(select(CHALLENGE_ACHIEVEMENT.ID)
+                        .from(CHALLENGE_ACHIEVEMENT)
+                        .where(CHALLENGE_ACHIEVEMENT.RUNNING_RECORD_ID.in(dsl.select(RUNNING_RECORD.ID)
+                                .from(RUNNING_RECORD)
+                                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))))))
+                .execute();
+
+        // 2. CHALLENGE_ACHIEVEMENT, GOAL_ACHIEVEMENT 삭제
+        dsl.deleteFrom(CHALLENGE_ACHIEVEMENT)
+                .where(CHALLENGE_ACHIEVEMENT.RUNNING_RECORD_ID.in(dsl.select(RUNNING_RECORD.ID)
+                        .from(RUNNING_RECORD)
+                        .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))))
+                .execute();
+        dsl.deleteFrom(GOAL_ACHIEVEMENT)
+                .where(GOAL_ACHIEVEMENT.RUNNING_RECORD_ID.in(dsl.select(RUNNING_RECORD.ID)
+                        .from(RUNNING_RECORD)
+                        .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))))
+                .execute();
+
+        // 3. RUNNING_RECORD, SCALE_ACHIEVEMENT, MEMBER_LEVEL, SOCIAL_PROFILE 삭제
+        dsl.deleteFrom(RUNNING_RECORD)
+                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .execute();
+        dsl.deleteFrom(SCALE_ACHIEVEMENT)
+                .where(SCALE_ACHIEVEMENT.MEMBER_ID.eq(memberId))
+                .execute();
+        dsl.deleteFrom(MEMBER_LEVEL).where(MEMBER_LEVEL.MEMBER_ID.eq(memberId)).execute();
+        dsl.deleteFrom(SOCIAL_PROFILE)
+                .where(SOCIAL_PROFILE.MEMBER_ID.eq(memberId))
+                .execute();
+
+        // 4.MEMBER 삭제
+        dsl.deleteFrom(MEMBER).where(MEMBER.ID.eq(memberId)).execute();
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeEntity.java
@@ -39,7 +39,6 @@ public class ChallengeEntity {
 
     public static ChallengeEntity from(Challenge challenge) {
         return ChallengeEntity.builder()
-                .id(challenge.challengeId())
                 .name(challenge.name())
                 .expectedTime(challenge.expectedTime())
                 .challengeType(challenge.challengeType())

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/level/entity/LevelEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/level/entity/LevelEntity.java
@@ -30,7 +30,6 @@ public class LevelEntity {
 
     public static LevelEntity from(Level level) {
         LevelEntity levelEntity = new LevelEntity();
-        levelEntity.id = level.levelId();
         levelEntity.expRangeStart = level.expRangeStart();
         levelEntity.expRangeEnd = level.expRangeEnd();
         levelEntity.imageUrl = level.imageUrl();

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/oauth/OauthRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/oauth/OauthRepositoryImplTest.java
@@ -1,0 +1,206 @@
+package com.dnd.runus.infrastructure.persistence.domain.oauth;
+
+import com.dnd.runus.domain.challenge.Challenge;
+import com.dnd.runus.domain.challenge.ChallengeType;
+import com.dnd.runus.domain.challenge.GoalMetricType;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.PercentageValues;
+import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.goalAchievement.GoalAchievement;
+import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevel;
+import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.member.SocialProfile;
+import com.dnd.runus.domain.member.SocialProfileRepository;
+import com.dnd.runus.domain.oauth.OauthRepository;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.Scale;
+import com.dnd.runus.domain.scale.ScaleAchievement;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.global.constant.SocialType;
+import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementPercentageEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.level.entity.LevelEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberLevelEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.running.entity.RunningRecordEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@RepositoryTest
+class OauthRepositoryImplTest {
+
+    @Autowired
+    private OauthRepository oauthRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SocialProfileRepository socialProfileRepository;
+
+    @Autowired
+    private MemberLevelRepository memberLevelRepository;
+
+    @Autowired
+    private RunningRecordRepository runningRecordRepository;
+
+    @Autowired
+    private ScaleAchievementRepository scaleAchievementRepository;
+
+    @Autowired
+    private ChallengeAchievementRepository challengeAchievementRepository;
+
+    @Autowired
+    private GoalAchievementRepository goalAchievementRepository;
+
+    @Autowired
+    private ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+
+    private long levelId;
+    private long scaleId;
+    private Challenge challenge;
+
+    @BeforeEach
+    void setUp() {
+        // set up level, challenge, scale
+        em.persist(LevelEntity.from(new Level(0, 0, 1000000, "img")));
+        em.persist(ScaleEntity.from(new Scale(0, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)")));
+        em.persist(ChallengeEntity.from(new Challenge(0, "challenge", 0, "img", ChallengeType.TODAY)));
+        em.flush();
+
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+
+        CriteriaQuery<LevelEntity> levelQuery = criteriaBuilder.createQuery(LevelEntity.class);
+        Root<LevelEntity> levelFrom = levelQuery.from(LevelEntity.class);
+        levelQuery.select(levelFrom);
+        levelId = em.createQuery(levelQuery).getResultList().get(0).getId();
+
+        CriteriaQuery<ScaleEntity> scaleQuery = criteriaBuilder.createQuery(ScaleEntity.class);
+        Root<ScaleEntity> scaleFrom = scaleQuery.from(ScaleEntity.class);
+        scaleQuery.select(scaleFrom);
+        scaleId = em.createQuery(scaleQuery).getResultList().get(0).getId();
+
+        CriteriaQuery<ChallengeEntity> challengeQuery = criteriaBuilder.createQuery(ChallengeEntity.class);
+        Root<ChallengeEntity> challengeFrom = challengeQuery.from(ChallengeEntity.class);
+        challengeQuery.select(challengeFrom);
+        challenge = em.createQuery(challengeQuery).getResultList().get(0).toDomain();
+    }
+
+    @DisplayName("회원 탈퇴 시 회원의 모든 데이터를 삭제 한다.")
+    @Test
+    void withdraw() {
+        // given
+        // 1. member, socialProfile 저장
+        Member savedMember = memberRepository.save(new Member(MemberRole.USER, "nickname"));
+        SocialProfile savedSocialProfile =
+                socialProfileRepository.save(new SocialProfile(0, savedMember, SocialType.APPLE, "oauthId", "email"));
+        // 2. member_level 저장
+        memberLevelRepository.save(new MemberLevel(0, savedMember, levelId, 0));
+
+        // 3. running record 저장
+        RunningRecord savedRunningRecord = runningRecordRepository.save(new RunningRecord(
+                0,
+                savedMember,
+                1_100_000,
+                Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                1,
+                new Pace(5, 11),
+                OffsetDateTime.now(),
+                OffsetDateTime.now().plusHours(1),
+                List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                "start location",
+                "end location",
+                RunningEmoji.SOSO));
+
+        // 4. scale achievement 저장
+        scaleAchievementRepository.saveAll(
+                List.of(new ScaleAchievement(savedMember, new Scale(scaleId), OffsetDateTime.now())));
+
+        // 5. challenge achievement, goal achievement 저장
+        ChallengeAchievement savedChallengeAc =
+                challengeAchievementRepository.save(new ChallengeAchievement(challenge, savedRunningRecord, true));
+        goalAchievementRepository.save(new GoalAchievement(savedRunningRecord, GoalMetricType.DISTANCE, 1000, true));
+
+        // 6. challenge achievement percentage 저장
+        challengeAchievementPercentageRepository.save(
+                new ChallengeAchievementRecord(savedChallengeAc, new PercentageValues(0, 0, 0)));
+
+        // when
+        oauthRepository.deleteAllDataAboutMember(savedMember.memberId());
+
+        // then
+        // 1. member, socialProfile 확인
+        assertFalse(memberRepository.findById(savedMember.memberId()).isPresent());
+        assertFalse(socialProfileRepository
+                .findById(savedSocialProfile.socialProfileId())
+                .isPresent());
+
+        // running record 확인
+        assertFalse(
+                runningRecordRepository.findById(savedRunningRecord.runningId()).isPresent());
+
+        // scale achievement 확인
+        assertNull(scaleAchievementRepository
+                .findScaleAchievementLogs(savedMember.memberId())
+                .get(0)
+                .achievedDate());
+
+        // goal achievement 확인
+        assertFalse(goalAchievementRepository
+                .findByRunningRecordId(savedRunningRecord.runningId())
+                .isPresent());
+
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+
+        // member_level 확인
+        CriteriaQuery<MemberLevelEntity> memberLevelQuery = criteriaBuilder.createQuery(MemberLevelEntity.class);
+        List<MemberLevelEntity> memberLevelSelect = em.createQuery(
+                        memberLevelQuery.select(memberLevelQuery.from(MemberLevelEntity.class)))
+                .getResultList();
+        assertThat(memberLevelSelect.size()).isEqualTo(0);
+
+        // running record 확인
+        CriteriaQuery<RunningRecordEntity> runningQuery = criteriaBuilder.createQuery(RunningRecordEntity.class);
+        List<RunningRecordEntity> runningSelect = em.createQuery(
+                        runningQuery.select(runningQuery.from(RunningRecordEntity.class)))
+                .getResultList();
+        assertThat(runningSelect.size()).isEqualTo(0);
+
+        // challenge achievement percentage 확인
+        CriteriaQuery<ChallengeAchievementPercentageEntity> percentageQuery =
+                criteriaBuilder.createQuery(ChallengeAchievementPercentageEntity.class);
+        List<ChallengeAchievementPercentageEntity> percentageSelect = em.createQuery(
+                        percentageQuery.select(percentageQuery.from(ChallengeAchievementPercentageEntity.class)))
+                .getResultList();
+        assertThat(percentageSelect.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원 탈퇴 시 해당 회원에 관한 모든 데이터를 삭제 합니다.(hard delete)
- 기존 JPA를 이용해 삭제하는 방식에서 Jooq로 한번에 삭제하는 방식으로 변경합니다.


## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 회원 탈퇴 관련 삭제을 위해 `OauthRepository`를 추가합니다.
- 해당 리파지토리는 추후 soft delete 방식 변경의 편의를 위해 추가합니다.
