### PR TITLE
Feat: 회원 탈퇴를 위한 ChallengeAchievementRepository에 관련 메서드 구현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievementRepository.java
@@ -1,6 +1,14 @@
 package com.dnd.runus.domain.challenge.achievement;
 
+import com.dnd.runus.domain.running.RunningRecord;
+
+import java.util.List;
+
 public interface ChallengeAchievementRepository {
 
     ChallengeAchievement save(ChallengeAchievement challengeAchievement);
+
+    List<Long> findIdsByRunningRecords(List<RunningRecord> runningRecords);
+
+    void deleteByIds(List<Long> ids);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImpl.java
@@ -2,10 +2,13 @@ package com.dnd.runus.infrastructure.persistence.domain.challenge;
 
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.infrastructure.persistence.jpa.challenge.JpaChallengeAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,5 +21,20 @@ public class ChallengeAchievementRepositoryImpl implements ChallengeAchievementR
         return jpaChallengeAchievementRepository
                 .save(ChallengeAchievementEntity.from(challengeAchievement))
                 .toDomain(challengeAchievement.challenge());
+    }
+
+    @Override
+    public List<Long> findIdsByRunningRecords(List<RunningRecord> runningRecords) {
+        return jpaChallengeAchievementRepository
+                .findAllByRunningRecordIdIn(
+                        runningRecords.stream().map(RunningRecord::runningId).toList())
+                .stream()
+                .map(ChallengeAchievementEntity::getId)
+                .toList();
+    }
+
+    @Override
+    public void deleteByIds(List<Long> ids) {
+        jpaChallengeAchievementRepository.deleteAllById(ids);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeAchievementRepository.java
@@ -3,8 +3,11 @@ package com.dnd.runus.infrastructure.persistence.jpa.challenge;
 import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JpaChallengeAchievementRepository extends JpaRepository<ChallengeAchievementEntity, Long> {
-    Optional<ChallengeAchievementEntity> findByRunningRecordId(Long runningId);
+    Optional<ChallengeAchievementEntity> findByRunningRecordId(long runningId);
+
+    List<ChallengeAchievementEntity> findAllByRunningRecordIdIn(List<Long> runningIds);
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
@@ -13,6 +13,10 @@ import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,8 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,14 +43,18 @@ public class ChallengeAchievementRepositoryImplTest {
     @Autowired
     private RunningRecordRepository runningRecordRepository;
 
-    private RunningRecord runningRecord;
+    @Autowired
+    private EntityManager em;
+
+    private List<RunningRecord> savedRunningRecords;
     private Challenge challenge;
 
     @BeforeEach
     void setUp() {
         Member savedMember = memberRepository.save(new Member(MemberRole.USER, "nickname"));
-        runningRecord = runningRecordRepository.save(new RunningRecord(
-                1,
+
+        RunningRecord runningRecord = new RunningRecord(
+                0,
                 savedMember,
                 1,
                 Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
@@ -55,7 +65,12 @@ public class ChallengeAchievementRepositoryImplTest {
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",
-                RunningEmoji.SOSO));
+                RunningEmoji.SOSO);
+
+        savedRunningRecords = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            savedRunningRecords.add(runningRecordRepository.save(runningRecord));
+        }
         challenge = new Challenge(1, "name", 60, "imageUrl", ChallengeType.DEFEAT_YESTERDAY);
     }
 
@@ -63,7 +78,8 @@ public class ChallengeAchievementRepositoryImplTest {
     @Test
     void saveAchievement() {
         // given
-        ChallengeAchievement challengeAchievement = new ChallengeAchievement(challenge, runningRecord, true);
+        ChallengeAchievement challengeAchievement =
+                new ChallengeAchievement(challenge, savedRunningRecords.get(0), true);
 
         // when
         ChallengeAchievement saved = challengeAchievementRepository.save(challengeAchievement);
@@ -71,5 +87,50 @@ public class ChallengeAchievementRepositoryImplTest {
         // then
         assertNotNull(saved);
         assertTrue(saved.isSuccess());
+    }
+
+    @DisplayName("러닝 레코드 리스트로 ChallengeAchievement의 id 찾기")
+    @Test
+    void findIdsByRunningRecordsTest() {
+        // given
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            ids.add(challengeAchievementRepository
+                    .save(new ChallengeAchievement(challenge, savedRunningRecords.get(i), true))
+                    .ChallengeAchievementId());
+        }
+
+        // then
+        List<Long> resultIds = challengeAchievementRepository.findIdsByRunningRecords(savedRunningRecords);
+
+        // when
+        assertNotNull(resultIds);
+        assertThat(resultIds.size()).isEqualTo(ids.size());
+        assertTrue(resultIds.containsAll(ids));
+    }
+
+    @DisplayName("Challenge achievement 삭제 : id 리스트로")
+    @Test
+    void deleteAchievementByIdsTest() {
+        // given
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            ids.add(challengeAchievementRepository
+                    .save(new ChallengeAchievement(challenge, savedRunningRecords.get(i), true))
+                    .ChallengeAchievementId());
+        }
+
+        // when
+        challengeAchievementRepository.deleteByIds(ids);
+
+        // then
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+
+        CriteriaQuery<ChallengeAchievementEntity> query = criteriaBuilder.createQuery(ChallengeAchievementEntity.class);
+        List<ChallengeAchievementEntity> selectAll = em.createQuery(
+                        query.select(query.from(ChallengeAchievementEntity.class)))
+                .getResultList();
+
+        assertThat(selectAll.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원 탈퇴를 위해 ChallengeAchievementRepository에 관련 메서드를 추가합니다.
  - `List<RunningRecord>`로 ChallengeAchievement의 id 리스트를 찾는 메서드를 추가합니다.
  - ChallengeAchievement의 id로 챌린지 성취 값을 삭제하는 메서드를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
