### PR TITLE
Feat: 회원 탈퇴를 위한 챌린지 성취 퍼센테이지 삭제 메서드 구현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievementPercentageRepository.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievementPercentageRepository.java
@@ -1,5 +1,9 @@
 package com.dnd.runus.domain.challenge.achievement;
 
+import java.util.List;
+
 public interface ChallengeAchievementPercentageRepository {
     PercentageValues save(ChallengeAchievementRecord challengeAchievementRecord);
+
+    void deleteByChallengeAchievementIds(List<Long> challengeAchievementIds);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImpl.java
@@ -8,6 +8,8 @@ import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAc
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class ChallengeAchievementPercentageRepositoryImpl implements ChallengeAchievementPercentageRepository {
@@ -20,5 +22,10 @@ public class ChallengeAchievementPercentageRepositoryImpl implements ChallengeAc
                 .save(ChallengeAchievementPercentageEntity.from(
                         record.percentageValues(), record.challengeAchievement()))
                 .toDomain();
+    }
+
+    @Override
+    public void deleteByChallengeAchievementIds(List<Long> challengeAchievementIds) {
+        jpaPercentageRepository.deleteAllByChallengeAchievementIdIn(challengeAchievementIds);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeAchievementPercentageRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeAchievementPercentageRepository.java
@@ -3,5 +3,9 @@ package com.dnd.runus.infrastructure.persistence.jpa.challenge;
 import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementPercentageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface JpaChallengeAchievementPercentageRepository
-        extends JpaRepository<ChallengeAchievementPercentageEntity, Long> {}
+        extends JpaRepository<ChallengeAchievementPercentageEntity, Long> {
+    void deleteAllByChallengeAchievementIdIn(List<Long> ids);
+}

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
@@ -1,0 +1,125 @@
+package com.dnd.runus.infrastructure.persistence.domain.challenge;
+
+import com.dnd.runus.domain.challenge.Challenge;
+import com.dnd.runus.domain.challenge.ChallengeType;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.PercentageValues;
+import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementPercentageEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@RepositoryTest
+class ChallengeAchievementPercentageRepositoryImplTest {
+
+    @Autowired
+    private ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RunningRecordRepository runningRecordRepository;
+
+    @Autowired
+    private ChallengeAchievementRepository challengeAchievementRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private List<ChallengeAchievement> savedChallengeAchievements;
+
+    @BeforeEach
+    void setUp() {
+        // ChallengeAchievement, running
+        Member savedMember = memberRepository.save(new Member(MemberRole.USER, "nickname"));
+
+        List<RunningRecord> savedRunningRecords = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            savedRunningRecords.add(runningRecordRepository.save(new RunningRecord(
+                    0,
+                    savedMember,
+                    1,
+                    Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now(),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO)));
+        }
+
+        Challenge challenge = new Challenge(1, "name", 60, "imageUrl", ChallengeType.DEFEAT_YESTERDAY);
+
+        savedChallengeAchievements = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            ChallengeAchievement saved = challengeAchievementRepository.save(
+                    new ChallengeAchievement(challenge, savedRunningRecords.get(i), true));
+            savedChallengeAchievements.add(saved);
+        }
+    }
+
+    @DisplayName("save percentage")
+    @Test
+    void savePercentage() {
+        // when
+        PercentageValues savedPercentage = challengeAchievementPercentageRepository.save(
+                new ChallengeAchievementRecord(savedChallengeAchievements.get(0), new PercentageValues(0, 0, 0)));
+
+        // then
+        assertNotNull(savedPercentage);
+    }
+
+    @DisplayName("delete percentage by challengeAchievementId list")
+    @Test
+    void deletePercentageByChallengeAchievementIdList() {
+        // given
+        for (int i = 0; i < 2; i++) {
+            challengeAchievementPercentageRepository.save(
+                    new ChallengeAchievementRecord(savedChallengeAchievements.get(i), new PercentageValues(0, 0, 0)));
+        }
+        List<Long> idList = savedChallengeAchievements.stream()
+                .map(ChallengeAchievement::ChallengeAchievementId)
+                .toList();
+
+        // when
+        challengeAchievementPercentageRepository.deleteByChallengeAchievementIds(idList);
+
+        // then
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+
+        CriteriaQuery<ChallengeAchievementPercentageEntity> query =
+                criteriaBuilder.createQuery(ChallengeAchievementPercentageEntity.class);
+        List<ChallengeAchievementPercentageEntity> selectAll = em.createQuery(
+                        query.select(query.from(ChallengeAchievementPercentageEntity.class)))
+                .getResultList();
+
+        assertThat(selectAll.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원 탈퇴를 위해 ChallengeAchievementPercentageRepository에 삭제 메서드를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
