### PR TITLE
Feat: 회원 탈퇴를 위한 GoalAchievementRepository 삭제 메서드 구현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievementRepository.java
@@ -1,9 +1,14 @@
 package com.dnd.runus.domain.goalAchievement;
 
+import com.dnd.runus.domain.running.RunningRecord;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface GoalAchievementRepository {
     GoalAchievement save(GoalAchievement goalAchievement);
 
     Optional<GoalAchievement> findByRunningRecordId(Long runningRecordId);
+
+    void deleteByRunningRecords(List<RunningRecord> runningRecords);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/goalAchievement/GoalAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/goalAchievement/GoalAchievementRepositoryImpl.java
@@ -2,11 +2,13 @@ package com.dnd.runus.infrastructure.persistence.domain.goalAchievement;
 
 import com.dnd.runus.domain.goalAchievement.GoalAchievement;
 import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
+import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.infrastructure.persistence.jpa.goalAchievement.JpaGoalAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.goalAchievement.entity.GoalAchievementEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -27,5 +29,11 @@ public class GoalAchievementRepositoryImpl implements GoalAchievementRepository 
         return jpaGoalAchievementRepository
                 .findByRunningRecordId(runningRecordId)
                 .map(GoalAchievementEntity::toDomain);
+    }
+
+    @Override
+    public void deleteByRunningRecords(List<RunningRecord> runningRecords) {
+        jpaGoalAchievementRepository.deleteAllByRunningRecordIdIn(
+                runningRecords.stream().map(RunningRecord::runningId).toList());
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/goalAchievement/JpaGoalAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/goalAchievement/JpaGoalAchievementRepository.java
@@ -3,9 +3,12 @@ package com.dnd.runus.infrastructure.persistence.jpa.goalAchievement;
 import com.dnd.runus.infrastructure.persistence.jpa.goalAchievement.entity.GoalAchievementEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JpaGoalAchievementRepository extends JpaRepository<GoalAchievementEntity, Long> {
 
     Optional<GoalAchievementEntity> findByRunningRecordId(Long runningRecordId);
+
+    void deleteAllByRunningRecordIdIn(List<Long> runningRecordIds);
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- 

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원 탈퇴를 위해 GoalAchievementRepository에 삭제 메서드를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
