### PR TITLE
Feat: 회원 탈퇴를 위한 ScaleAchievementRepository에 삭제 메서드 구현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/scale/ScaleAchievementRepository.java
@@ -6,4 +6,6 @@ public interface ScaleAchievementRepository {
     List<ScaleAchievementLog> findScaleAchievementLogs(long memberId);
 
     List<ScaleAchievement> saveAll(List<ScaleAchievement> scaleAchievements);
+
+    void deleteByMemberId(long memberId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImpl.java
@@ -33,4 +33,9 @@ public class ScaleAchievementRepositoryImpl implements ScaleAchievementRepositor
                 .map(ScaleAchievementEntity::toDomain)
                 .toList();
     }
+
+    @Override
+    public void deleteByMemberId(long memberId) {
+        jpaScaleAchievementRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/JpaScaleAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/scale/JpaScaleAchievementRepository.java
@@ -3,4 +3,6 @@ package com.dnd.runus.infrastructure.persistence.jpa.scale;
 import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleAchievementEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaScaleAchievementRepository extends JpaRepository<ScaleAchievementEntity, Long> {}
+public interface JpaScaleAchievementRepository extends JpaRepository<ScaleAchievementEntity, Long> {
+    void deleteByMemberId(long memberId);
+}

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImplTest.java
@@ -8,8 +8,11 @@ import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
 import com.dnd.runus.infrastructure.persistence.jpa.member.entity.MemberEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleAchievementEntity;
 import com.dnd.runus.infrastructure.persistence.jpa.scale.entity.ScaleEntity;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RepositoryTest
-public class ScaleAchievementRepositoryTest {
+public class ScaleAchievementRepositoryImplTest {
 
     @Autowired
     private ScaleAchievementRepository scaleAchievementRepository;
@@ -77,5 +80,26 @@ public class ScaleAchievementRepositoryTest {
         assertNotNull(saved.get(1));
         assertNotNull(saved.get(0).achievedDate());
         assertNotNull(saved.get(1).achievedDate());
+    }
+
+    @Test
+    @DisplayName("코스 성취 기록을 삭제 한다. : memberId로 삭제한다.")
+    void deleteByMemberId() {
+        // given
+        List<ScaleAchievement> saved = scaleAchievementRepository.saveAll(List.of(
+                new ScaleAchievement(member, new Scale(scale1.scaleId()), OffsetDateTime.now()),
+                new ScaleAchievement(member, new Scale(scale2.scaleId()), OffsetDateTime.now())));
+
+        // when
+        scaleAchievementRepository.deleteByMemberId(member.memberId());
+
+        // then
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+
+        CriteriaQuery<ScaleAchievementEntity> query = criteriaBuilder.createQuery(ScaleAchievementEntity.class);
+        List<ScaleAchievementEntity> result = em.createQuery(query.select(query.from(ScaleAchievementEntity.class)))
+                .getResultList();
+
+        assertThat(result.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원 탈퇴를 위해 ScaleAchievementRepository에 삭제 메서드를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
