### PR TITLE
Feat: 회원 탈퇴를 위한 멤버 아이디로 러닝 데이터 찾는 메서드 구현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -1,5 +1,7 @@
 package com.dnd.runus.domain.running;
 
+import com.dnd.runus.domain.member.Member;
+
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +19,6 @@ public interface RunningRecordRepository {
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
     int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
+
+    List<RunningRecord> findByMember(Member member);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dnd.runus.infrastructure.persistence.domain.running;
 
+import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.infrastructure.persistence.jooq.running.JooqRunningRecordRepository;
@@ -53,5 +54,12 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     @Override
     public int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endtDate) {
         return jooqRunningRecordRepository.findTotalDistanceMeterByMemberId(memberId, startDate, endtDate);
+    }
+
+    @Override
+    public List<RunningRecord> findByMember(Member member) {
+        return jpaRunningRecordRepository.findByMemberId(member.memberId()).stream()
+                .map(RunningRecordEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/JpaRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/JpaRunningRecordRepository.java
@@ -14,4 +14,6 @@ public interface JpaRunningRecordRepository extends JpaRepository<RunningRecordE
             long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
     boolean existsByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
+
+    List<RunningRecordEntity> findByMemberId(long memberId);
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -25,6 +25,7 @@ import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RepositoryTest
@@ -187,5 +188,33 @@ class RunningRecordRepositoryImplTest {
 
         // than
         assertThat(totalDistanceMeterByMemberId).isEqualTo(3000);
+    }
+
+    @DisplayName("러닝 기록 조회 : memberId의 러닝 기록을 조회")
+    @Test
+    void getAllRunningRecordsByMemberId() {
+        // given
+        for (int i = 0; i < 2; i++) {
+            runningRecordRepository.save(new RunningRecord(
+                    0,
+                    savedMember,
+                    5000,
+                    Duration.ofHours(1),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now(),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO));
+        }
+
+        // when
+        List<RunningRecord> results = runningRecordRepository.findByMember(savedMember);
+
+        // then
+        assertNotNull(results);
+        assertThat(results.size()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원 탈퇴를 위해 멤버 아이디로 모든 러닝 기록을 찾는 메서드를 RunningRecordRepository에 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
