### PR TITLE
Fix: int 타입의 meter 대신 string 타입으로 반환하도록 달성 코스 기록 API 수정

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleCoursesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleCoursesResponse.java
@@ -2,6 +2,7 @@ package com.dnd.runus.presentation.v1.scale.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -10,33 +11,57 @@ public record ScaleCoursesResponse(
         List<AchievedCourse> achievedCourses,
         CurrentCourse currentCourse
 ) {
+
+    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.#km");
+
     public record Info(
             @Schema(description = "총 코스 수 (공개되지 않은 코스 포함)", example = "18")
             int totalCourses,
-            @Schema(description = "총 런어스 거리 (미터)", example = "43800000")
-            int totalMeter
+            @Schema(description = "총 코스 거리 (공개되지 않은 코스 포함)", example = "1000km")
+            String totalDistance
     ) {
+        public Info(
+                int totalCourses,
+                int totalMeter
+        ) {
+            this(totalCourses, KILO_METER_FORMATTER.format(totalMeter / 1000.0));
+        }
     }
 
     public record AchievedCourse(
-            @Schema(description = "코스 이름", example = "서울에서 부산")
+            @Schema(description = "코스 이름", example = "서울에서 인천")
             String name,
-            @Schema(description = "코스 총 거리 (미터)", example = "300000")
-            int meter,
+            @Schema(description = "코스 총 거리", example = "30km")
+            String totalDistance,
             @Schema(description = "달성 일자")
             LocalDate achievedAt
     ) {
+        public AchievedCourse(
+                String name,
+                int totalMeter,
+                LocalDate achievedAt
+        ) {
+            this(name, KILO_METER_FORMATTER.format(totalMeter / 1000.0), achievedAt);
+        }
     }
 
     public record CurrentCourse(
             @Schema(description = "현재 코스 이름", example = "서울에서 부산")
             String name,
-            @Schema(description = "현재 코스 총 거리 (미터)", example = "300000")
-            int totalMeter,
-            @Schema(description = "현재 달성한 거리 (미터), 현재 50m 달성", example = "50")
-            int achievedMeter,
+            @Schema(description = "현재 코스 총 거리", example = "200km")
+            String totalDistance,
+            @Schema(description = "현재 달성한 거리, 현재 50m 달성", example = "50m")
+            String achievedDistance,
             @Schema(description = "현재 코스 설명 메시지", example = "대전까지 100km 남았어요!")
             String message
     ) {
+        public CurrentCourse(
+                String name,
+                int totalMeter,
+                int achievedMeter,
+                String message
+        ) {
+            this(name, KILO_METER_FORMATTER.format(totalMeter / 1000.0), achievedMeter + "m", message);
+        }
     }
 }

--- a/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
@@ -65,7 +65,8 @@ class ScaleServiceTest {
         // then
         assertNotNull(response);
         assertTrue(response.achievedCourses().isEmpty());
-        assertEquals(runningMeterSum, response.currentCourse().achievedMeter());
+        assertEquals(scale1.name(), response.currentCourse().name());
+        assertEquals(runningMeterSum + "m", response.currentCourse().achievedDistance());
     }
 
     @DisplayName("달성한 코스가 있는 경우, 달성한 코스, 현재 진행중인 코스 정보를 반환한다.")
@@ -88,9 +89,9 @@ class ScaleServiceTest {
         assertEquals(1, response.achievedCourses().size());
 
         assertEquals(scale1.name(), response.achievedCourses().get(0).name());
-        assertEquals(200, response.achievedCourses().get(0).meter());
+        assertEquals("0.2km", response.achievedCourses().get(0).totalDistance());
 
         assertEquals(scale2.name(), response.currentCourse().name());
-        assertEquals(800, response.currentCourse().achievedMeter());
+        assertEquals("800m", response.currentCourse().achievedDistance());
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #172 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `api/v1/scale/courses` API에서 달성 기록 목록 조회 시 반환하는 meter 단위 int 타입을 string으로 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
