### PR TITLE
Fix: 프로필 조회 API의 반환값에 현재 레벨 이름 필드를 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/member/MemberService.java
+++ b/src/main/java/com/dnd/runus/application/member/MemberService.java
@@ -22,6 +22,7 @@ public class MemberService {
 
         return new MyProfileResponse(
                 memberCurrentLevel.level().imageUrl(),
+                Level.formatLevelName(currentLevel),
                 Level.formatExp(memberCurrentLevel.currentExp()),
                 Level.formatLevelName(nextLevel),
                 Level.formatExp(memberCurrentLevel.level().expRangeEnd() - memberCurrentLevel.currentExp()));

--- a/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponse.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MyProfileResponse(
         @Schema(description = "현재 프로필 이미지")
         String profileImageUrl,
+        @Schema(description = "현재 레벨 이름")
+        String currentLevelName,
         @Schema(description = "지금까지 달린 거리")
         String currentKm,
         @Schema(description = "다음 레벨 이름")

--- a/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
@@ -35,6 +35,7 @@ class MemberServiceTest {
 
         // then
         assertEquals("imageUrl", myProfileResponse.profileImageUrl());
+        assertEquals("Level 1", myProfileResponse.currentLevelName());
         assertEquals("0.5km", myProfileResponse.currentKm());
         assertEquals("Level 2", myProfileResponse.nextLevelName());
     }
@@ -52,6 +53,7 @@ class MemberServiceTest {
 
         // then
         assertEquals("imageUrl", myProfileResponse.profileImageUrl());
+        assertEquals("Level 2", myProfileResponse.currentLevelName());
         assertEquals("1.5km", myProfileResponse.currentKm());
         assertEquals("Level 3", myProfileResponse.nextLevelName());
     }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #174 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `api/v1/profiles/me` API의 반환값에 현재 레벨 이름 필드를 추가하여 반환합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
