### PR TITLE
Refactor: km 단위 문자열로 변환하는 로직을 DecimalFormat을 사용하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
@@ -3,12 +3,17 @@ package com.dnd.runus.domain.goalAchievement;
 import com.dnd.runus.domain.challenge.GoalMetricType;
 import com.dnd.runus.domain.running.RunningRecord;
 
+import java.text.DecimalFormat;
+
 import static com.dnd.runus.domain.challenge.GoalMetricType.DISTANCE;
 import static com.dnd.runus.global.constant.RunningResultComment.FAILURE;
 import static com.dnd.runus.global.constant.RunningResultComment.SUCCESS;
 
 public record GoalAchievement(
         RunningRecord runningRecord, GoalMetricType goalMetricType, int achievementValue, boolean isAchieved) {
+
+    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.##km");
+
     public GoalAchievement(RunningRecord runningRecord, GoalMetricType goalMetricType, int achievementValue) {
         this(
                 runningRecord,
@@ -19,8 +24,7 @@ public record GoalAchievement(
 
     public String getTitle() {
         if (goalMetricType == DISTANCE) {
-            String km = formatMeterToKm(achievementValue);
-            return km + " 달성";
+            return KILO_METER_FORMATTER.format(achievementValue / 1000.0) + " 달성";
         }
 
         return formatSecondToKoreanHHMM(achievementValue) + " 달성";
@@ -28,20 +32,6 @@ public record GoalAchievement(
 
     public String getDescription() {
         return isAchieved ? SUCCESS.getComment() : FAILURE.getComment();
-    }
-
-    private String formatMeterToKm(int meter) {
-        String formatted = String.format("%.2f", (meter / 1000.0));
-
-        if (formatted.contains(".")) {
-            formatted = formatted.replaceAll("0*$", "");
-        }
-
-        if (formatted.endsWith(".")) {
-            formatted = formatted.substring(0, formatted.length() - 1);
-        }
-
-        return formatted + "KM";
     }
 
     private String formatSecondToKoreanHHMM(int second) {

--- a/src/main/java/com/dnd/runus/domain/level/Level.java
+++ b/src/main/java/com/dnd/runus/domain/level/Level.java
@@ -1,19 +1,12 @@
 package com.dnd.runus.domain.level;
 
+import java.text.DecimalFormat;
+
 public record Level(long levelId, int expRangeStart, int expRangeEnd, String imageUrl) {
+    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.##km");
+
     public static String formatExp(int exp) {
-        double km = exp / 1000.0;
-        String formatted = String.format("%.2f", km);
-
-        if (formatted.contains(".")) {
-            formatted = formatted.replaceAll("0*$", "");
-        }
-
-        if (formatted.endsWith(".")) {
-            formatted = formatted.substring(0, formatted.length() - 1);
-        }
-
-        return formatted + "km";
+        return KILO_METER_FORMATTER.format(exp / 1000.0);
     }
 
     public static String formatLevelName(long level) {

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
@@ -1,33 +1,22 @@
 package com.dnd.runus.presentation.v1.running.dto.response;
 
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.text.DecimalFormat;
+
 public record RunningRecordMonthlySummaryResponse(
-    @Schema(description = "이번 달", example = "8월")
-    String month,
-    @Schema(description = "이번 달에 달린 키로 수", example = "2.55km")
-    String monthlyKm,
-    @Schema(description = "다음 레벨", example = "Leve 2")
-    String nextLevelName,
-    @Schema(description = "다음 레벨까지 남은 키로 수", example = "2.55km")
-    String nextLevelKm
+        @Schema(description = "이번 달", example = "8월")
+        String month,
+        @Schema(description = "이번 달에 달린 키로 수", example = "2.55km")
+        String monthlyKm,
+        @Schema(description = "다음 레벨", example = "Level 2")
+        String nextLevelName,
+        @Schema(description = "다음 레벨까지 남은 키로 수", example = "2.55km")
+        String nextLevelKm
 ) {
+    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.##km");
+
     public RunningRecordMonthlySummaryResponse(int monthValue, int monthlyTotalMeter, String nextLevelName, String nextLevelKm) {
-        this(monthValue+"월", formatMeterToKm(monthlyTotalMeter), nextLevelName, nextLevelKm);
-    }
-
-    private static String formatMeterToKm(int meter) {
-        String formatted = String.format("%.2f", Math.floor(meter / 1000.0 * 100) / 100);
-
-        if (formatted.contains(".")) {
-            formatted = formatted.replaceAll("0*$", "");
-        }
-
-        if (formatted.endsWith(".")) {
-            formatted = formatted.substring(0, formatted.length() - 1);
-        }
-
-        return formatted + "km";
+        this(monthValue + "월", KILO_METER_FORMATTER.format(monthlyTotalMeter / 1000.0), nextLevelName, nextLevelKm);
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 코드 로직 변경없이 km 단위 문자열로 변환하는 로직을 DecimalFormat을 사용하도록 수정
- `GoalAchievement`에서 문자열로 변환시 대문자인 `KM`를 사용했는데 소문자인 `km`로 변경합니다. 
- `RunningRecordMonthlySummaryResponse`의 스웨거 문서 오타를 수정합니다.
  - `Leve 2` -> `Level 2`

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
