### PR TITLE
Refactor: 회원탈퇴 로직 리팩터링(hard delete)

### DIFF
--- a/src/main/java/com/dnd/runus/application/oauth/OauthService.java
+++ b/src/main/java/com/dnd/runus/application/oauth/OauthService.java
@@ -6,8 +6,13 @@ import com.dnd.runus.auth.oidc.provider.OidcProviderRegistry;
 import com.dnd.runus.auth.token.TokenProviderModule;
 import com.dnd.runus.auth.token.dto.AuthTokenDto;
 import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
 import com.dnd.runus.domain.member.*;
+import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.SocialType;
 import com.dnd.runus.global.exception.BusinessException;
@@ -24,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -34,9 +41,13 @@ public class OauthService {
 
     private final MemberRepository memberRepository;
     private final SocialProfileRepository socialProfileRepository;
+    private final MemberLevelRepository memberLevelRepository;
     private final BadgeAchievementRepository badgeAchievementRepository;
     private final RunningRecordRepository runningRecordRepository;
-    private final MemberLevelRepository memberLevelRepository;
+    private final ChallengeAchievementRepository challengeAchievementRepository;
+    private final GoalAchievementRepository goalAchievementRepository;
+    private final ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+    private final ScaleAchievementRepository scaleAchievementRepository;
 
     @Transactional
     public SignResponse signIn(SignInRequest request) {
@@ -97,10 +108,11 @@ public class OauthService {
         return SignResponse.from(member.nickname(), email, tokenDto);
     }
 
-    @Transactional
-    public void withdraw(long memberId, WithdrawRequest request) {
+    @Transactional(readOnly = true)
+    public void revokeOauth(long memberId, WithdrawRequest request) {
 
         memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(Member.class, memberId));
+
         OidcProvider oidcProvider = oidcProviderRegistry.getOidcProviderBy(request.socialType());
 
         Claims claim = oidcProvider.getClaimsBy(request.idToken());
@@ -108,11 +120,17 @@ public class OauthService {
 
         SocialProfile socialProfile = socialProfileRepository
                 .findBySocialTypeAndOauthId(request.socialType(), oauthId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않은 SocialProfile"));
+                .orElseThrow(() -> {
+                    log.error(
+                            "data conflict: 존재하지 않은 SocialProfile입니다. socialType: {}, oauthId: {}",
+                            request.socialType(),
+                            oauthId);
+                    return new NotFoundException("존재하지 않은 SocialProfile");
+                });
 
         if (memberId != socialProfile.member().memberId()) {
             log.error(
-                    "MemberId and MemberId find by SocialProfile oauthId do not match each other! memberId: {}, socialProfileId: {}",
+                    "DATA CONFLICT: MemberId and MemberId find by SocialProfile oauthId do not match each other! memberId: {}, socialProfileId: {}",
                     memberId,
                     socialProfile.socialProfileId());
             throw new NotFoundException("잘못된 데이터: Member and SocialProfile do not match each other");
@@ -121,8 +139,41 @@ public class OauthService {
         // 탈퇴를 위한 access token 발급
         String accessToken = oidcProvider.getAccessToken(request.authorizationCode());
         oidcProvider.revoke(accessToken);
+    }
 
-        deleteMember(memberId);
+    @Transactional
+    public void deleteAllDataAboutMember(long memberId) {
+        Member member =
+                memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(Member.class, memberId));
+
+        memberLevelRepository.deleteByMemberId(member.memberId());
+        badgeAchievementRepository.deleteByMemberId(member.memberId());
+        scaleAchievementRepository.deleteByMemberId(member.memberId());
+        socialProfileRepository.deleteByMemberId(member.memberId());
+
+        // running_record 조회
+        List<RunningRecord> runningRecords = runningRecordRepository.findByMember(member);
+        if (runningRecords.isEmpty()) {
+            // running_record가 없으면 멤버 삭제 후 리턴
+            memberRepository.deleteById(member.memberId());
+            return;
+        }
+
+        // goal_achievement 삭제
+        goalAchievementRepository.deleteByRunningRecords(runningRecords);
+
+        // running_record로 challenge_achievement 조회
+        List<Long> challengeAchievementIds = challengeAchievementRepository.findIdsByRunningRecords(runningRecords);
+        // challenge_achievement가 존재하면 challenge_achievement_percentage, challenge_achievement 삭제
+        if (!challengeAchievementIds.isEmpty()) {
+            challengeAchievementPercentageRepository.deleteByChallengeAchievementIds(challengeAchievementIds);
+            challengeAchievementRepository.deleteByIds(challengeAchievementIds);
+        }
+
+        // running_record 삭제
+        runningRecordRepository.deleteByMemberId(member.memberId());
+
+        memberRepository.deleteById(member.memberId());
     }
 
     private SocialProfile createMember(String oauthId, String email, SocialType socialType, String nickname) {
@@ -137,14 +188,5 @@ public class OauthService {
                 .oauthId(oauthId)
                 .oauthEmail(email)
                 .build());
-    }
-
-    private void deleteMember(long memberId) {
-        badgeAchievementRepository.deleteByMemberId(memberId);
-        // todo 챌린지 삭제(챌린지 기능 구현 완료 후)
-        runningRecordRepository.deleteByMemberId(memberId);
-        memberLevelRepository.deleteByMemberId(memberId);
-        socialProfileRepository.deleteByMemberId(memberId);
-        memberRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/com/dnd/runus/auth/oidc/provider/OidcProvider.java
+++ b/src/main/java/com/dnd/runus/auth/oidc/provider/OidcProvider.java
@@ -2,7 +2,9 @@ package com.dnd.runus.auth.oidc.provider;
 
 import com.dnd.runus.global.constant.SocialType;
 import io.jsonwebtoken.Claims;
+import org.springframework.stereotype.Component;
 
+@Component
 public interface OidcProvider {
 
     SocialType getSocialType();

--- a/src/main/java/com/dnd/runus/auth/oidc/provider/OidcProvider.java
+++ b/src/main/java/com/dnd/runus/auth/oidc/provider/OidcProvider.java
@@ -2,9 +2,7 @@ package com.dnd.runus.auth.oidc.provider;
 
 import com.dnd.runus.global.constant.SocialType;
 import io.jsonwebtoken.Claims;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface OidcProvider {
 
     SocialType getSocialType();

--- a/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
@@ -73,13 +73,11 @@ public class OauthController {
             발급 받은 토큰으로 사용자의 서비스 해제 요청을 합니다.<br>
             사용자의 모든 데이터를 삭제합니다.
             """)
-    @ApiErrorType({
-        ErrorType.UNSUPPORTED_SOCIAL_TYPE,
-        ErrorType.FAILED_AUTHENTICATION,
-    })
+    @ApiErrorType({ErrorType.UNSUPPORTED_SOCIAL_TYPE, ErrorType.FAILED_AUTHENTICATION})
     @PostMapping("/withdraw")
     @ResponseStatus(HttpStatus.OK)
     public void withdraw(@MemberId long memberId, @Valid @RequestBody WithdrawRequest request) {
-        oauthService.withdraw(memberId, request);
+        oauthService.revokeOauth(memberId, request);
+        oauthService.deleteAllDataAboutMember(memberId);
     }
 }

--- a/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
@@ -1,0 +1,315 @@
+package com.dnd.runus.application.oauth;
+
+import com.dnd.runus.auth.oidc.provider.OidcProvider;
+import com.dnd.runus.auth.oidc.provider.OidcProviderRegistry;
+import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.member.SocialProfile;
+import com.dnd.runus.domain.member.SocialProfileRepository;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.global.constant.SocialType;
+import com.dnd.runus.global.exception.NotFoundException;
+import com.dnd.runus.presentation.v1.oauth.dto.request.WithdrawRequest;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class OauthServiceTest {
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now());
+    }
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("oauth관련 테스트: 회원가입, 로그인, 탈퇴 관련")
+    class OauthTest {
+        @InjectMocks
+        private OauthService oauthService;
+
+        @Mock
+        private OidcProviderRegistry oidcProviderRegistry;
+
+        @Mock
+        private OidcProvider oidcProvider;
+
+        @Mock
+        private MemberRepository memberRepository;
+
+        @Mock
+        private SocialProfileRepository socialProfileRepository;
+
+        private SocialType socialType;
+        private String idToken;
+        private String authorizationCode;
+        private String oauthId;
+        private String email;
+
+        private Claims claims;
+
+        @BeforeEach
+        void setUp() {
+
+            claims = mock(Claims.class);
+
+            socialType = SocialType.APPLE;
+            idToken = "idToken";
+            authorizationCode = "authorizationCode";
+            oauthId = "oauthId";
+            email = "oauthEmail@email.com";
+        }
+
+        @DisplayName("소셜 로그인 연동 해제: 성공")
+        @Test
+        void revokeOauth_Success() {
+
+            // given
+            WithdrawRequest request = new WithdrawRequest(socialType, authorizationCode, idToken);
+            SocialProfile socialProfileMock = new SocialProfile(1L, member, request.socialType(), oauthId, email);
+
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(oidcProviderRegistry.getOidcProviderBy(request.socialType())).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(request.idToken())).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(request.socialType(), oauthId))
+                    .willReturn(Optional.of(socialProfileMock));
+
+            String accessToken = "accessToken";
+            given(oidcProvider.getAccessToken(request.authorizationCode())).willReturn(accessToken);
+
+            // when
+            oauthService.revokeOauth(member.memberId(), request);
+
+            // then
+            then(oidcProvider).should().revoke(accessToken);
+        }
+
+        @DisplayName("소셜 로그인 연동 해제: member_id가 없을 경우 NotFoundException을 발생한다.")
+        @Test
+        void revokeOauth_NotFound_MemberID() {
+            // given
+            WithdrawRequest request = new WithdrawRequest(socialType, authorizationCode, idToken);
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.empty());
+
+            // when, then
+            assertThrows(NotFoundException.class, () -> {
+                oauthService.revokeOauth(member.memberId(), request);
+            });
+        }
+
+        @DisplayName("소셜 로그인 연동 해제: oauthId와 socialType에 해당하는 socialProfile 없을 경우 NotFoundException을 발생한다.")
+        @Test
+        void revokeOauth_NotFound_SocialProfile() {
+            // given
+            WithdrawRequest request = new WithdrawRequest(socialType, authorizationCode, idToken);
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(oidcProviderRegistry.getOidcProviderBy(request.socialType())).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(request.idToken())).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(request.socialType(), oauthId))
+                    .willReturn(Optional.empty());
+
+            // when, then
+            assertThrows(NotFoundException.class, () -> {
+                oauthService.revokeOauth(member.memberId(), request);
+            });
+        }
+
+        @DisplayName("소셜 로그인 연동 해제: socialProfile의 memberId와 member의 id가 다를 경우 NotFoundException을 발생한다.")
+        @Test
+        void revokeOauth_MissMatch_socialProfileAndMemberId() {
+            // given
+            WithdrawRequest request = new WithdrawRequest(socialType, authorizationCode, idToken);
+            SocialProfile socialProfileMock = new SocialProfile(
+                    1L,
+                    new Member(2L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now()),
+                    request.socialType(),
+                    oauthId,
+                    email);
+
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(oidcProviderRegistry.getOidcProviderBy(request.socialType())).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(request.idToken())).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(request.socialType(), oauthId))
+                    .willReturn(Optional.of(socialProfileMock));
+
+            // when, then
+            assertThrows(NotFoundException.class, () -> {
+                oauthService.revokeOauth(member.memberId(), request);
+            });
+        }
+    }
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("회원 탈퇴를 위한 멤버 데이터 삭제")
+    class DeleteAllMemberTest {
+        @InjectMocks
+        private OauthService oauthService;
+
+        @Mock
+        private MemberRepository memberRepository;
+
+        @Mock
+        private SocialProfileRepository socialProfileRepository;
+
+        @Mock
+        private MemberLevelRepository memberLevelRepository;
+
+        @Mock
+        private BadgeAchievementRepository badgeAchievementRepository;
+
+        @Mock
+        private RunningRecordRepository runningRecordRepository;
+
+        @Mock
+        private ChallengeAchievementRepository challengeAchievementRepository;
+
+        @Mock
+        private GoalAchievementRepository goalAchievementRepository;
+
+        @Mock
+        private ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+
+        @Mock
+        private ScaleAchievementRepository scaleAchievementRepository;
+
+        @DisplayName("회원 삭제: 회원이 존재하지 않으면 NotFoundException을 발생하한다.")
+        @Test
+        public void testDeleteAllDataAboutMember_MemberNotFound() {
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> {
+                oauthService.deleteAllDataAboutMember(member.memberId());
+            });
+        }
+
+        @DisplayName("회원 삭제 : running_record 존재 X")
+        @Test
+        void testDeleteAllDataAboutMember_NoRunningRecords() {
+            // given
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.findByMember(member)).willReturn(Collections.emptyList());
+
+            // when
+            oauthService.deleteAllDataAboutMember(member.memberId());
+
+            // then
+            then(memberLevelRepository).should().deleteByMemberId(member.memberId());
+            then(badgeAchievementRepository).should().deleteByMemberId(member.memberId());
+            then(scaleAchievementRepository).should().deleteByMemberId(member.memberId());
+            then(socialProfileRepository).should().deleteByMemberId(member.memberId());
+            then(memberRepository).should().deleteById(member.memberId());
+        }
+
+        @DisplayName("회원 삭제 : running_record 존재, challenge_achievement 존재 X")
+        @Test
+        void testDeleteAllDataAboutMember_WithRunningRecords_NoChallengeAchievement() {
+            // given
+            List<RunningRecord> runningRecords = List.of(new RunningRecord(
+                    1L,
+                    member,
+                    1_100_000,
+                    Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now().plusHours(1),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO));
+
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.findByMember(member)).willReturn(runningRecords);
+            given(challengeAchievementRepository.findIdsByRunningRecords(runningRecords))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            oauthService.deleteAllDataAboutMember(member.memberId());
+
+            // then
+            then(memberLevelRepository).should().deleteByMemberId(member.memberId());
+            then(badgeAchievementRepository).should().deleteByMemberId(member.memberId());
+            then(scaleAchievementRepository).should().deleteByMemberId(member.memberId());
+            then(socialProfileRepository).should().deleteByMemberId(member.memberId());
+            then(goalAchievementRepository).should().deleteByRunningRecords(runningRecords);
+            then(runningRecordRepository).should().deleteByMemberId(member.memberId());
+            then(memberRepository).should().deleteById(member.memberId());
+        }
+
+        @DisplayName("회원 삭제 : running_record, challenge_achievement 존재")
+        @Test
+        void testDeleteAllDataAboutMember_WithRunningRecords_WithChallengeAchievement() {
+            // given
+            List<RunningRecord> runningRecords = List.of(new RunningRecord(
+                    1L,
+                    member,
+                    1_100_000,
+                    Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now().plusHours(1),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO));
+
+            List<Long> challengeAchievementIds = List.of(1L);
+
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.findByMember(member)).willReturn(runningRecords);
+            given(challengeAchievementRepository.findIdsByRunningRecords(runningRecords))
+                    .willReturn(challengeAchievementIds);
+
+            // when
+            oauthService.deleteAllDataAboutMember(member.memberId());
+
+            // then
+            then(memberLevelRepository).should().deleteByMemberId(member.memberId());
+            then(badgeAchievementRepository).should().deleteByMemberId(member.memberId());
+            then(scaleAchievementRepository).should().deleteByMemberId(member.memberId());
+            then(socialProfileRepository).should().deleteByMemberId(member.memberId());
+            then(goalAchievementRepository).should().deleteByRunningRecords(runningRecords);
+            then(challengeAchievementPercentageRepository)
+                    .should()
+                    .deleteByChallengeAchievementIds(challengeAchievementIds);
+            then(challengeAchievementRepository).should().deleteByIds(challengeAchievementIds);
+            then(runningRecordRepository).should().deleteByMemberId(member.memberId());
+            then(memberRepository).should().deleteById(member.memberId());
+        }
+    }
+}

--- a/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
@@ -123,9 +123,7 @@ class OauthServiceTest {
             given(memberRepository.findById(member.memberId())).willReturn(Optional.empty());
 
             // when, then
-            assertThrows(NotFoundException.class, () -> {
-                oauthService.revokeOauth(member.memberId(), request);
-            });
+            assertThrows(NotFoundException.class, () -> oauthService.revokeOauth(member.memberId(), request));
         }
 
         @DisplayName("소셜 로그인 연동 해제: oauthId와 socialType에 해당하는 socialProfile 없을 경우 NotFoundException을 발생한다.")
@@ -141,9 +139,7 @@ class OauthServiceTest {
                     .willReturn(Optional.empty());
 
             // when, then
-            assertThrows(NotFoundException.class, () -> {
-                oauthService.revokeOauth(member.memberId(), request);
-            });
+            assertThrows(NotFoundException.class, () -> oauthService.revokeOauth(member.memberId(), request));
         }
 
         @DisplayName("소셜 로그인 연동 해제: socialProfile의 memberId와 member의 id가 다를 경우 NotFoundException을 발생한다.")
@@ -166,9 +162,7 @@ class OauthServiceTest {
                     .willReturn(Optional.of(socialProfileMock));
 
             // when, then
-            assertThrows(NotFoundException.class, () -> {
-                oauthService.revokeOauth(member.memberId(), request);
-            });
+            assertThrows(NotFoundException.class, () -> oauthService.revokeOauth(member.memberId(), request));
         }
     }
 
@@ -211,9 +205,7 @@ class OauthServiceTest {
         public void testDeleteAllDataAboutMember_MemberNotFound() {
             given(memberRepository.findById(member.memberId())).willReturn(Optional.empty());
 
-            assertThrows(NotFoundException.class, () -> {
-                oauthService.deleteAllDataAboutMember(member.memberId());
-            });
+            assertThrows(NotFoundException.class, () -> oauthService.deleteAllDataAboutMember(member.memberId()));
         }
 
         @DisplayName("회원 삭제 : running_record 존재 X")

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
@@ -30,8 +30,8 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RepositoryTest
 class ChallengeAchievementPercentageRepositoryImplTest {
@@ -120,6 +120,6 @@ class ChallengeAchievementPercentageRepositoryImplTest {
                         query.select(query.from(ChallengeAchievementPercentageEntity.class)))
                 .getResultList();
 
-        assertThat(selectAll.isEmpty());
+        assertTrue(selectAll.isEmpty());
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
@@ -120,6 +120,6 @@ class ChallengeAchievementPercentageRepositoryImplTest {
                         query.select(query.from(ChallengeAchievementPercentageEntity.class)))
                 .getResultList();
 
-        assertThat(selectAll.size()).isEqualTo(0);
+        assertThat(selectAll.isEmpty());
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
@@ -131,6 +131,6 @@ public class ChallengeAchievementRepositoryImplTest {
                         query.select(query.from(ChallengeAchievementEntity.class)))
                 .getResultList();
 
-        assertThat(selectAll.size()).isEqualTo(0);
+        assertThat(selectAll.isEmpty());
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
@@ -131,6 +131,6 @@ public class ChallengeAchievementRepositoryImplTest {
                         query.select(query.from(ChallengeAchievementEntity.class)))
                 .getResultList();
 
-        assertThat(selectAll.isEmpty());
+        assertTrue(selectAll.isEmpty());
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImplTest.java
@@ -86,7 +86,7 @@ public class ScaleAchievementRepositoryImplTest {
     @DisplayName("코스 성취 기록을 삭제 한다. : memberId로 삭제한다.")
     void deleteByMemberId() {
         // given
-        List<ScaleAchievement> saved = scaleAchievementRepository.saveAll(List.of(
+        scaleAchievementRepository.saveAll(List.of(
                 new ScaleAchievement(member, new Scale(scale1.scaleId()), OffsetDateTime.now()),
                 new ScaleAchievement(member, new Scale(scale2.scaleId()), OffsetDateTime.now())));
 
@@ -100,6 +100,6 @@ public class ScaleAchievementRepositoryImplTest {
         List<ScaleAchievementEntity> result = em.createQuery(query.select(query.from(ScaleAchievementEntity.class)))
                 .getResultList();
 
-        assertThat(result.isEmpty());
+        assertTrue(result.isEmpty());
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleAchievementRepositoryImplTest.java
@@ -100,6 +100,6 @@ public class ScaleAchievementRepositoryImplTest {
         List<ScaleAchievementEntity> result = em.createQuery(query.select(query.from(ScaleAchievementEntity.class)))
                 .getResultList();
 
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result.isEmpty());
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #162 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- POST `/api/v1/auth/oauth/withdraw`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에 하나의 트랜젝션으로 존재했던 소셜 회원 연결 해제(네트워크 연결) + 회원 데이터 삭제 로직을 분리합니다.
- 소셜 회원 연결 해제는 revokeOauth 메서드를 호출해 회원이 로그인한 3rd party 연동을 해제합니다.
-  소셜 회원 연결 해제가 완료 되었으면 회원의 데이터를 삭제(hard delete)을 위해 deleteAllDataAboutMember메서드를 호출합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- https://github.com/dnd-side-project/dnd-11th-2-backend/pull/167#discussion_r1751633667 에서 PR 수정 사항을 [10ac56c](https://github.com/dnd-side-project/dnd-11th-2-backend/pull/179/commits/10ac56c68568ef4b2bec4883cda549fd28060811)에서 수정했습니다.
