### PR TITLE
Feat: 주간, 요일별 러닝 거리 데이터 조회 리파지토리 함수 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -21,4 +21,6 @@ public interface RunningRecordRepository {
     int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 
     List<RunningRecord> findByMember(Member member);
+
+    List<RunningRecordWeeklySummary> findWeeklyDistanceSummaryMeter(long memberId, OffsetDateTime today);
 }

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordWeeklySummary.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordWeeklySummary.java
@@ -1,0 +1,17 @@
+package com.dnd.runus.domain.running;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+public record RunningRecordWeeklySummary(@NotNull LocalDate date, Integer sumDistanceMeter, Duration sumDuration) {
+
+    public RunningRecordWeeklySummary(LocalDate date, Integer sumDistanceMeter) {
+        this(date, sumDistanceMeter, null);
+    }
+
+    public RunningRecordWeeklySummary(LocalDate date, Duration sumDuration) {
+        this(date, null, sumDuration);
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.dnd.runus.infrastructure.persistence.domain.running;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.running.RunningRecordWeeklySummary;
 import com.dnd.runus.infrastructure.persistence.jooq.running.JooqRunningRecordRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.running.JpaRunningRecordRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.running.entity.RunningRecordEntity;
@@ -61,5 +62,10 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
         return jpaRunningRecordRepository.findByMemberId(member.memberId()).stream()
                 .map(RunningRecordEntity::toDomain)
                 .toList();
+    }
+
+    @Override
+    public List<RunningRecordWeeklySummary> findWeeklyDistanceSummaryMeter(long memberId, OffsetDateTime today) {
+        return jooqRunningRecordRepository.findWeeklyDistanceSummaryMeter(memberId, today);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -1,13 +1,26 @@
 package com.dnd.runus.infrastructure.persistence.jooq.running;
 
+import com.dnd.runus.domain.running.RunningRecordWeeklySummary;
 import lombok.RequiredArgsConstructor;
+import org.jooq.CommonTableExpression;
 import org.jooq.DSLContext;
+import org.jooq.Record;
 import org.jooq.Record1;
+import org.jooq.RecordMapper;
+import org.jooq.impl.SQLDataType;
 import org.springframework.stereotype.Repository;
 
+import java.sql.Date;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import static com.dnd.runus.jooq.Tables.RUNNING_RECORD;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import static org.jooq.impl.DSL.cast;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.sum;
 
 @Repository
@@ -26,5 +39,39 @@ public class JooqRunningRecordRepository {
             return result.value1();
         }
         return 0;
+    }
+
+    public List<RunningRecordWeeklySummary> findWeeklyDistanceSummaryMeter(long memberId, OffsetDateTime today) {
+
+        int day = today.get(DAY_OF_WEEK) - 1;
+        LocalDate startDate = today.minusDays(day).toLocalDate();
+
+        CommonTableExpression<Record1<Date>> dateRange = name("date_range")
+                .fields("start_date")
+                .as(select(field(
+                        "generate_series(?, ?, interval '1 day')",
+                        SQLDataType.DATE,
+                        startDate,
+                        startDate.plusDays(6))));
+
+        return dsl.with(dateRange)
+                .select(
+                        dateRange.field("start_date", SQLDataType.DATE),
+                        sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class).as("sum_distance"))
+                .from(dateRange)
+                .leftJoin(RUNNING_RECORD)
+                .on(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE).eq(dateRange.field("start_date", SQLDataType.DATE)))
+                .and(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .groupBy(dateRange.field("start_date"))
+                .orderBy(dateRange.field("start_date"))
+                .fetch(new RunningWeeklyDistanceSummary());
+    }
+
+    private static class RunningWeeklyDistanceSummary implements RecordMapper<Record, RunningRecordWeeklySummary> {
+        @Override
+        public RunningRecordWeeklySummary map(Record record) {
+            return new RunningRecordWeeklySummary(
+                    record.get("start_date", LocalDate.class), record.get("sum_distance", Integer.class));
+        }
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -6,6 +6,7 @@ import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.running.RunningRecordWeeklySummary;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
@@ -26,6 +27,7 @@ import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RepositoryTest
@@ -216,5 +218,60 @@ class RunningRecordRepositoryImplTest {
         // then
         assertNotNull(results);
         assertThat(results.size()).isEqualTo(2);
+    }
+
+    @DisplayName("러닝 주간 서머리 조회(거리) : 러닝 데이터가 없을 경우, sumDistanceMeter는 null를 반환한다.")
+    @Test
+    void getWeeklyDistanceSummary_WithOutRunningRecords() {
+        // given
+        OffsetDateTime today = OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE));
+
+        // when
+        List<RunningRecordWeeklySummary> result =
+                runningRecordRepository.findWeeklyDistanceSummaryMeter(savedMember.memberId(), today);
+
+        // then
+        assertThat(result.size()).isEqualTo(7);
+        result.forEach(v -> assertNull(v.sumDistanceMeter()));
+    }
+
+    @DisplayName("러닝 주간 서머리 조회(거리) : 러닝 데이터 있을 경우, 해당 요일에 러닝 데이터는 sum한 값이 리턴된다.")
+    @Test
+    void getWeeklyDistanceSummary_WithRunningRecords() {
+        // given
+        OffsetDateTime today = OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE));
+
+        int distance = 5000;
+        for (int i = 0; i < 2; i++) {
+            runningRecordRepository.save(new RunningRecord(
+                    0,
+                    savedMember,
+                    distance,
+                    Duration.ofHours(1),
+                    1,
+                    new Pace(5, 11),
+                    OffsetDateTime.now(),
+                    OffsetDateTime.now(),
+                    List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO));
+        }
+
+        int expectedDistance = distance * 2;
+
+        // when
+        List<RunningRecordWeeklySummary> result =
+                runningRecordRepository.findWeeklyDistanceSummaryMeter(savedMember.memberId(), today);
+
+        // then
+        assertThat(result.size()).isEqualTo(7);
+        result.forEach(v -> {
+            if (v.date().equals(today.toLocalDate())) {
+                assertThat(v.sumDistanceMeter()).isEqualTo(expectedDistance);
+            } else {
+                assertNull(v.sumDistanceMeter());
+            }
+        });
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #180 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 주간, 요일별 러닝 거리 데이터를 조회하는 함수를 `RunningRecordRepository`에 추가 합니다.
- 오늘 날짜 기준으로 월~일요일의 러닝 거리 데이터를조회 합니다.
- 한 요일(하루)의 러닝 데이터가 2개 이상일 경우, 거리의 합을 리턴합니다.
  - ex)화요일에 300m뛴 기록1개, 500m뛴 기록 1개가 있으면 화요일 날짜의 거리는 800으로 리턴합니다.
- 러닝 데이터가 없는 날짜는 거리를 null로 리턴합니다. 

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
