### PR TITLE
Feat: running record 저장 시 goal 성공과 미달 이미지 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
@@ -13,6 +13,8 @@ public record GoalAchievement(
         RunningRecord runningRecord, GoalMetricType goalMetricType, int achievementValue, boolean isAchieved) {
 
     private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.##km");
+    private static final String SUCCESS_ICON_URL = "https://d27big3ufowabi.cloudfront.net/goal/goal-success.png";
+    private static final String FAILURE_ICON_URL = "https://d27big3ufowabi.cloudfront.net/goal/goal-failure.png";
 
     public GoalAchievement(RunningRecord runningRecord, GoalMetricType goalMetricType, int achievementValue) {
         this(
@@ -32,6 +34,10 @@ public record GoalAchievement(
 
     public String getDescription() {
         return isAchieved ? SUCCESS.getComment() : FAILURE.getComment();
+    }
+
+    public String getIconUrl() {
+        return isAchieved ? SUCCESS_ICON_URL : FAILURE_ICON_URL;
     }
 
     private String formatSecondToKoreanHHMM(int second) {

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/GoalResultDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/GoalResultDto.java
@@ -1,12 +1,16 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 public record GoalResultDto(
         @Schema(description = "설정된 목표 제목", example = "2.5km 달성")
         String title,
         @Schema(description = "설정된 목표 결과 문구", example = "성공했어요!")
         String subTitle,
+        @NotBlank
+        @Schema(description = "챌린지 아이콘 이미지 URL")
+        String iconUrl,
         @Schema(description = "설정된 목표 성공 여부")
         boolean isSuccess
 ) {

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
@@ -56,6 +56,7 @@ public record RunningRecordAddResultResponse(
                 new GoalResultDto(
                         achievement.getTitle(),
                         achievement.getDescription(),
+                        achievement.getIconUrl(),
                         achievement.isAchieved()
                 ),
                 RunningAchievementMode.GOAL


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #185 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- running record 저장 시 목표한 goal에 맞는 성공과 미달 이미지를 반환하도록 합니다.
- S3 버킷에 성공, 미달 이미지 2개를 추가했어요

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
