### PR TITLE
Fix: RunningRecordRequest 클래스에 validation 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -22,9 +22,7 @@ import com.dnd.runus.domain.scale.Scale;
 import com.dnd.runus.domain.scale.ScaleAchievement;
 import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.domain.scale.ScaleRepository;
-import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.NotFoundException;
-import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
@@ -105,9 +103,6 @@ public class RunningRecordService {
 
     @Transactional
     public RunningRecordAddResultResponse addRunningRecord(long memberId, RunningRecordRequest request) {
-        if (request.startAt().isAfter(request.endAt())) {
-            throw new BusinessException(ErrorType.START_AFTER_END, request.startAt() + ", " + request.endAt());
-        }
         Member member =
                 memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(Member.class, memberId));
 

--- a/src/main/java/com/dnd/runus/global/exception/BusinessException.java
+++ b/src/main/java/com/dnd/runus/global/exception/BusinessException.java
@@ -6,4 +6,8 @@ public class BusinessException extends BaseException {
     public BusinessException(ErrorType type, String message) {
         super(type, message);
     }
+
+    public BusinessException(ErrorType type) {
+        super(type, "No message");
+    }
 }

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -40,6 +40,9 @@ public enum ErrorType {
 
     // RunningErrorType
     ROUTE_MUST_HAVE_AT_LEAST_TWO_COORDINATES(BAD_REQUEST, "RUNNING_001", "경로는 최소 2개의 좌표를 가져야 합니다"),
+    CHALLENGE_MODE_WITH_PERSONAL_GOAL(BAD_REQUEST, "RUNNING_002", "챌린지 모드에서는 개인 목표를 설정할 수 없습니다."),
+    GOAL_MODE_WITH_CHALLENGE_ID(BAD_REQUEST, "RUNNING_003", "개인 목표 모드에서는 챌린지 ID를 설정할 수 없습니다."),
+    GOAL_TIME_AND_DISTANCE_BOTH_EXIST(BAD_REQUEST, "RUNNING_004", "개인 목표 시간과 거리 중 하나만 설정해야 합니다."),
 
     // WeatherErrorType
     WEATHER_API_ERROR(INTERNAL_SERVER_ERROR, "WEATHER_001", "날씨 API 호출 중 오류가 발생했습니다"),

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -50,7 +50,12 @@ public class RunningRecordController {
                     러닝 데이터는 위치, 거리, 시간, 칼로리, 평균 페이스로 구성됩니다. <br>
                     러닝 기록 추가에 성공하면 러닝 기록 ID, 기록 정보를 반환합니다. <br>
                     """)
-    @ApiErrorType({ErrorType.START_AFTER_END})
+    @ApiErrorType({
+        ErrorType.START_AFTER_END,
+        ErrorType.CHALLENGE_MODE_WITH_PERSONAL_GOAL,
+        ErrorType.GOAL_MODE_WITH_CHALLENGE_ID,
+        ErrorType.GOAL_TIME_AND_DISTANCE_BOTH_EXIST
+    })
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     public RunningRecordAddResultResponse addRunningRecord(

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordRequest.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordRequest.java
@@ -1,6 +1,8 @@
 package com.dnd.runus.presentation.v1.running.dto.request;
 
 import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.global.exception.BusinessException;
+import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -34,4 +36,22 @@ public record RunningRecordRequest(
         @NotNull
         RunningRecordMetricsDto runningData
 ) {
+    public RunningRecordRequest {
+        if (startAt.isAfter(endAt)) {
+            throw new BusinessException(ErrorType.START_AFTER_END, startAt + " ~ " + endAt);
+        }
+
+        if (achievementMode == RunningAchievementMode.CHALLENGE && (goalDistance != null || goalTime != null)) {
+            throw new BusinessException(ErrorType.CHALLENGE_MODE_WITH_PERSONAL_GOAL);
+        }
+
+        if (achievementMode == RunningAchievementMode.GOAL) {
+            if (challengeId != null) {
+                throw new BusinessException(ErrorType.GOAL_MODE_WITH_CHALLENGE_ID);
+            }
+            if (goalDistance == null && goalTime == null) {
+                throw new BusinessException(ErrorType.GOAL_TIME_AND_DISTANCE_BOTH_EXIST);
+            }
+        }
+    }
 }

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -19,8 +19,6 @@ import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
-import com.dnd.runus.global.exception.BusinessException;
-import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDto;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
@@ -287,28 +285,6 @@ class RunningRecordServiceTest {
         assertFalse(response.goal().title().contains("분"));
 
         assertTrue(response.goal().isSuccess());
-    }
-
-    @Test
-    @DisplayName("시작 시간이 종료 시간보다 늦을 경우, BusinessException이 발생한다.")
-    void addRunningRecord_StartAtAfterEndAt() {
-        // given
-        RunningRecordRequest request = new RunningRecordRequest(
-                LocalDateTime.of(2021, 1, 1, 12, 10, 30),
-                LocalDateTime.of(2021, 1, 1, 11, 12, 10),
-                "start location",
-                "end location",
-                RunningEmoji.VERY_GOOD,
-                1L,
-                null,
-                null,
-                RunningAchievementMode.CHALLENGE,
-                new RunningRecordMetricsDto(new Pace(5, 30), Duration.ofSeconds(10_100), 10_000, 500.0));
-        // when
-        BusinessException exception =
-                assertThrows(BusinessException.class, () -> runningRecordService.addRunningRecord(1L, request));
-        // then
-        assertEquals(ErrorType.START_AFTER_END, exception.getType());
     }
 
     @Test


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #177 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `RunningRecordRequest` 클래스에 잘못된 로직의 경우 예외를 던지도록 합니다.
  - `startAt`이 `endAt`보다 늦은 경우 `START_AFTER_END` 예외를 던집니다.
  - `achievementMode`가 `CHALLENGE`이고 `goalDistance`나 `goalTime`이 존재하는 경우 `CHALLENGE_MODE_WITH_PERSONAL_GOAL` 예외
  - `achievementMode`가 `GOAL`이고 `challengeId`가 존재하는 경우 `GOAL_MODE_WITH_CHALLENGE_ID` 예외
  - `achievementMode`가 `GOAL`이고 `goalDistance`와 `goalTime`이 모두 존재하는 경우 `GOAL_TIME_AND_DISTANCE_BOTH_EXIST` 예외
- startAt, endAt 검증 로직이 request dto 클래스로 옮기므로, 시작 시간이 더 느린지 검증하는 `RunningRecordService` 테스트 케이스는 삭제합니다.
## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
