### PR TITLE
Feat: 일별 달린 시간을 조회하는 함수 리파지토리에 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -24,4 +24,7 @@ public interface RunningRecordRepository {
 
     List<DailyRunningRecordSummary> findDailyDistancesMeterByDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
+
+    List<DailyRunningRecordSummary> findDailyDurationsSecByDateRange(
+            long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -69,4 +69,11 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
         return jooqRunningRecordRepository.findDailyDistancesMeterByDateRange(memberId, startDate, nextDateOfEndDate);
     }
+
+    @Override
+    public List<DailyRunningRecordSummary> findDailyDurationsSecByDateRange(
+            long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
+        return jooqRunningRecordRepository.findDailyDurationsSecMeterByDateRange(
+                memberId, startDate, nextDateOfEndDate);
+    }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -52,7 +52,7 @@ public class JooqRunningRecordRepository {
                 .from(RUNNING_RECORD)
                 .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
                 .and(RUNNING_RECORD.START_AT.ge(startDate))
-                .and(RUNNING_RECORD.START_AT.le(nextDateOfEndDate))
+                .and(RUNNING_RECORD.START_AT.lt(nextDateOfEndDate))
                 .groupBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
                 .orderBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
                 .fetch(new DailyRunningSummary());
@@ -75,7 +75,7 @@ public class JooqRunningRecordRepository {
                 .from(RUNNING_RECORD)
                 .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
                 .and(RUNNING_RECORD.START_AT.ge(startDate))
-                .and(RUNNING_RECORD.START_AT.le(nextDateOfEndDate))
+                .and(RUNNING_RECORD.START_AT.lt(nextDateOfEndDate))
                 .groupBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
                 .orderBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
                 .fetch(new DailyRunningSummary());

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -58,6 +58,29 @@ public class JooqRunningRecordRepository {
                 .fetch(new DailyRunningSummary());
     }
 
+    /**
+     * 기간 안의 일별 달린 시간을 리턴합니다.
+     *
+     * @param startDate 시작 날짜 (정각)
+     * @param nextDateOfEndDate 종료 날짜의 다음 날 (정각)
+     * @return 기간 내 각 날짜별 달린 시간 합계를 포함한 리스트.
+     *          각 요소는 날짜와 해당 날짜의 달린 시간 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
+     */
+    public List<DailyRunningRecordSummary> findDailyDurationsSecMeterByDateRange(
+            long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
+
+        return dsl.select(
+                        cast(RUNNING_RECORD.START_AT, SQLDataType.DATE).as("date"),
+                        sum(RUNNING_RECORD.DURATION_SECONDS).cast(Integer.class).as("sum_value"))
+                .from(RUNNING_RECORD)
+                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .and(RUNNING_RECORD.START_AT.ge(startDate))
+                .and(RUNNING_RECORD.START_AT.le(nextDateOfEndDate))
+                .groupBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
+                .orderBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
+                .fetch(new DailyRunningSummary());
+    }
+
     private static class DailyRunningSummary implements RecordMapper<Record, DailyRunningRecordSummary> {
         @Override
         public DailyRunningRecordSummary map(Record record) {


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #180 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 활동요약 API을 위해, 기간 안에 일별로 달린 시간을 조회하는 함수를 러닝 리파지토리에 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
