### PR TITLE
Feat: 활동 요약 조회 API

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -45,7 +45,6 @@ import java.util.List;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_HOUR;
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
-import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 
 @Service
 public class RunningRecordService {
@@ -135,9 +134,9 @@ public class RunningRecordService {
         }
 
         double[] weeklyValues = new double[7];
-        for (DailyRunningRecordSummary Summary : weekSummaries) {
-            OffsetDateTime dateTime = Summary.date().atStartOfDay().atOffset(defaultZoneOffset);
-            weeklyValues[dateTime.get(DAY_OF_WEEK) - 1] = Summary.sumValue() / conversionFactor;
+        for (DailyRunningRecordSummary summary : weekSummaries) {
+            int dayOfWeek = summary.date().getDayOfWeek().getValue() - 1;
+            weeklyValues[dayOfWeek] = summary.sumValue() / conversionFactor;
         }
 
         return new RunningRecordWeeklySummaryResponse(

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -16,6 +16,7 @@ import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.member.MemberLevel;
 import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.running.DailyRunningRecordSummary;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import com.dnd.runus.domain.scale.Scale;
@@ -24,9 +25,11 @@ import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.exception.NotFoundException;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
+import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordSummaryResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordWeeklySummaryResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +42,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 
 @Service
 public class RunningRecordService {
@@ -99,6 +103,33 @@ public class RunningRecordService {
 
         List<RunningRecord> records = runningRecordRepository.findByMemberIdAndStartAtBetween(memberId, from, to);
         return RunningRecordSummaryResponse.from(records);
+    }
+
+    @Transactional(readOnly = true)
+    public RunningRecordWeeklySummaryResponse getWeeklySummary(
+            long memberId, RunningRecordWeeklySummaryType summaryType) {
+
+        OffsetDateTime today = OffsetDateTime.now().toLocalDate().atStartOfDay().atOffset(defaultZoneOffset);
+
+        int day = today.get(DAY_OF_WEEK) - 1;
+        OffsetDateTime startWeekDate = today.minusDays(day);
+        OffsetDateTime nextOfEndWeekDate = startWeekDate.plusDays(7);
+
+        return summaryType.equals(RunningRecordWeeklySummaryType.DISTANCE)
+                ? createWeeklySummaryResponse(
+                        runningRecordRepository.findDailyDistancesMeterByDateRange(
+                                memberId, startWeekDate, nextOfEndWeekDate),
+                        runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
+                                memberId, startWeekDate, nextOfEndWeekDate),
+                        1000,
+                        startWeekDate.toLocalDate())
+                : createWeeklySummaryResponse(
+                        runningRecordRepository.findDailyDurationsSecByDateRange(
+                                memberId, startWeekDate, nextOfEndWeekDate),
+                        runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
+                                memberId, startWeekDate, nextOfEndWeekDate),
+                        3600,
+                        startWeekDate.toLocalDate());
     }
 
     @Transactional
@@ -219,5 +250,18 @@ public class RunningRecordService {
 
         GoalAchievement goalAchievement = new GoalAchievement(runningRecord, goalMetricType, goalValue, isAchieved);
         return goalAchievementRepository.save(goalAchievement);
+    }
+
+    private RunningRecordWeeklySummaryResponse createWeeklySummaryResponse(
+            List<DailyRunningRecordSummary> summaries, int avgValue, double conversionFactor, LocalDate startWeekDate) {
+
+        double[] weeklyValues = new double[7];
+        for (DailyRunningRecordSummary Summary : summaries) {
+            OffsetDateTime dateTime = Summary.date().atStartOfDay().atOffset(defaultZoneOffset);
+            weeklyValues[dateTime.get(DAY_OF_WEEK) - 1] = Summary.sumValue() / conversionFactor;
+        }
+
+        return new RunningRecordWeeklySummaryResponse(
+                startWeekDate, startWeekDate.plusDays(6), weeklyValues, avgValue / conversionFactor);
     }
 }

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -40,7 +40,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
@@ -117,9 +116,9 @@ public class RunningRecordService {
         OffsetDateTime startWeekDate = today.with(DayOfWeek.MONDAY);
         OffsetDateTime nextOfEndWeekDate = startWeekDate.plusWeeks(1);
 
-        List<DailyRunningRecordSummary> weekSummaries = new ArrayList<>();
-        int avgValue = 0;
-        double conversionFactor = 1.0;
+        List<DailyRunningRecordSummary> weekSummaries;
+        int avgValue;
+        double conversionFactor;
 
         if (summaryType.equals(RunningRecordWeeklySummaryType.DISTANCE)) {
             weekSummaries = runningRecordRepository.findDailyDistancesMeterByDateRange(

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -125,13 +125,13 @@ public class RunningRecordService {
                     memberId, startWeekDate, nextOfEndWeekDate);
             avgValue = runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
-            conversionFactor = SECONDS_PER_HOUR;
+            conversionFactor = METERS_IN_A_KILOMETER;
         } else {
             weekSummaries = runningRecordRepository.findDailyDurationsSecByDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
             avgValue = runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
-            conversionFactor = METERS_IN_A_KILOMETER;
+            conversionFactor = SECONDS_PER_HOUR;
         }
 
         double[] weeklyValues = new double[7];

--- a/src/main/java/com/dnd/runus/global/constant/MetricsConversionFactor.java
+++ b/src/main/java/com/dnd/runus/global/constant/MetricsConversionFactor.java
@@ -1,0 +1,12 @@
+package com.dnd.runus.global.constant;
+
+public final class MetricsConversionFactor {
+
+    private MetricsConversionFactor() {}
+
+    public static final int SECONDS_PER_HOUR = 3600;
+    public static final int SECONDS_PER_MINUTE = 60;
+    public static final int MINUTE_PER_HOUR = 60;
+
+    public static final double METERS_IN_A_KILOMETER = 1000.0;
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -5,10 +5,12 @@ import com.dnd.runus.global.exception.type.ApiErrorType;
 import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.annotation.MemberId;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
+import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlyDatesResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
 import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordSummaryResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordWeeklySummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -74,5 +76,24 @@ public class RunningRecordController {
     @GetMapping("monthly-summary")
     public RunningRecordMonthlySummaryResponse getMonthlyRunningSummary(@MemberId long memberId) {
         return runningRecordService.getMonthlyRunningSummery(memberId);
+    }
+
+    @Operation(
+            summary = "활동 요약 조회",
+            description =
+                    """
+    활동 요약은 주간 거리 기록 또는 주간 달린 기록을 조회합니다.<br>
+    - request 값이 DISTANCE 이면 이번주 요일별 달린 거리와, 지난주 달린 거리의 평균 값을 리턴합니다.<br>
+    - request 값이 TIME 이면 이번주 요일별 달린 시간과, 지난주 달린 시간의 평균 값을 리턴합니다.<br>
+    - request값과 상관 없이 공통의로 이번주 날짜(월요일 날짜 ~ 일요일 날짜)를 리턴합니다.<br>
+
+    이번 주 기록은 리스트형식으로(weeklyValues)로 리턴 되며 인덱스 값에 따른 데이터는 다음과 같습니다.<br>
+    - weeklyValues = [월요일 기록, 화요일 기록, .... , 일요일 기록]
+    """)
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("weekly-summary")
+    public RunningRecordWeeklySummaryResponse getWeeklySummary(
+            @MemberId long memberId, @RequestParam RunningRecordWeeklySummaryType summaryType) {
+        return runningRecordService.getWeeklySummary(memberId, summaryType);
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordWeeklySummaryType.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordWeeklySummaryType.java
@@ -1,0 +1,6 @@
+package com.dnd.runus.presentation.v1.running.dto.request;
+
+public enum RunningRecordWeeklySummaryType {
+    DISTANCE,
+    TIME,
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
@@ -1,0 +1,34 @@
+package com.dnd.runus.presentation.v1.running.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.format.datetime.DateFormatter;
+
+public record RunningRecordWeeklySummaryResponse(
+    @Schema(description = "이번주 날짜", example = "2024.09.09 ~ 09.15")
+    String date,
+    @Schema(description = "요일 별 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
+        + "월요일(index:0) ~ 일요일(index:6)의 값, 기록없는 날은 0을 리턴")
+    double[] weeklyValues,
+    @Schema(description = "지난주 평균 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
+        + "지난주에 기록이 없으면 0을 리턴")
+    double lastWeekAvgValue
+) {
+    public RunningRecordWeeklySummaryResponse(LocalDate startDate, LocalDate endDate, double[] weeklyValues, double lastWeekAvgValue) {
+        this(dateFormat(startDate, endDate), weeklyValues, lastWeekAvgValue);
+    }
+
+    private static String dateFormat(LocalDate startDate, LocalDate endDate) {
+        DateTimeFormatter yyyyMMddFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        String formattedStartDate = startDate.format(yyyyMMddFormatter);
+        String formattedEndDate = endDate.format(DateTimeFormatter.ofPattern("MM.dd"));
+        if (startDate.getYear() != endDate.getYear()) {
+            //연도가 다를 경우 yyyy.MM.dd ~ yyyy.MM.dd
+            formattedEndDate = endDate.format(yyyyMMddFormatter);
+        }
+        //yyyy.MM.dd ~ MM.dd 로 리턴
+        return formattedStartDate + " ~ " + formattedEndDate;
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
@@ -2,9 +2,7 @@ package com.dnd.runus.presentation.v1.running.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import org.springframework.format.datetime.DateFormatter;
 
 public record RunningRecordWeeklySummaryResponse(
     @Schema(description = "이번주 날짜", example = "2024.09.09 ~ 09.15")


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #180 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `/api/v1/running-records/weekly-summary`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 활동 요약 조회 API을 추가합니다.
- 활동 요약을 조회하는 서비스 단 함수를 추가합니다.
- `@RequestParam`으로 받을 경우, 
타입에 대한 불일치에 관한 예외 처리와
 요청 파라미터 타입이 Enum일 때 Validation에 관한 예외 처리를 위해 `MethodArgumentTypeMismatchException.class`에 관한 ExceptionHandler을 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 해당 기능의 화면이 아직 명확하지 않아 `RunningRecordWeeklySummaryResponse`는 바뀔 가능 성이 있습니다.
   - 현재는 클라이언트분과 상의 하에 임시로 구성해두었습니다.
