### PR TITLE
Rename: config 파일들을 global config 패키지 대신 jooq, jpa, swagger 패키지 사용

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/JooqConfig.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/JooqConfig.java
@@ -1,4 +1,4 @@
-package com.dnd.runus.global.config;
+package com.dnd.runus.infrastructure.persistence.jooq;
 
 import org.jooq.conf.ExecuteWithoutWhere;
 import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer;

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/JpaConfig.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.dnd.runus.global.config;
+package com.dnd.runus.infrastructure.persistence.jpa;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/dnd/runus/presentation/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/runus/presentation/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.dnd.runus.global.config;
+package com.dnd.runus.presentation.config;
 
 import com.dnd.runus.global.constant.AuthConstant;
 import com.dnd.runus.global.exception.type.ApiErrorType;

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/annotation/RepositoryTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/annotation/RepositoryTest.java
@@ -2,9 +2,9 @@ package com.dnd.runus.infrastructure.persistence.annotation;
 
 import com.dnd.runus.config.TestJooqConfig;
 import com.dnd.runus.config.TestcontainersConfig;
-import com.dnd.runus.global.config.JooqConfig;
-import com.dnd.runus.global.config.JpaConfig;
 import com.dnd.runus.infrastructure.persistence.InfrastructurePersistencePackage;
+import com.dnd.runus.infrastructure.persistence.jooq.JooqConfig;
+import com.dnd.runus.infrastructure.persistence.jpa.JpaConfig;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 파일 위치가 불분명한 `global.config` 패키지 대신 역할에 맞는 패키지로 config 파일들을 옮깁니다.
  - JooqConfig: `infrastructure.persistence.jooq`
  - JpaConfig: `infrastructure.persistence.jpa`
  - SwaggerConfig: `presentation.config`

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
