### PR TITLE
Fix: apple token 파싱 로직 base64, kid, alg 불일치 로그 메세지 구체화

### DIFF
--- a/src/main/java/com/dnd/runus/auth/oidc/provider/JwtParser.java
+++ b/src/main/java/com/dnd/runus/auth/oidc/provider/JwtParser.java
@@ -25,7 +25,7 @@ public final class JwtParser {
         try {
             return objectMapper.readValue(Base64.getUrlDecoder().decode(header), new TypeReference<>() {});
         } catch (IOException e) {
-            throw new BusinessException(ErrorType.FAILED_PARSING, e.getMessage());
+            throw new BusinessException(ErrorType.INVALID_BASE64, "OIDC header를 디코딩하는데 실패했습니다.");
         }
     }
 

--- a/src/main/java/com/dnd/runus/auth/oidc/vo/OidcPublicKeys.java
+++ b/src/main/java/com/dnd/runus/auth/oidc/vo/OidcPublicKeys.java
@@ -25,7 +25,8 @@ public record OidcPublicKeys(List<OidcPublicKey> keys) {
         return keys.stream()
                 .filter(key -> Objects.equals(kid, key.kid()) && Objects.equals(alg, key.alg()))
                 .findAny()
-                .orElseThrow(() -> new BusinessException(ErrorType.MALFORMED_ACCESS_TOKEN, "검증할 수 없는 토큰입니다."));
+                .orElseThrow(
+                        () -> new BusinessException(ErrorType.MALFORMED_ACCESS_TOKEN, "kid, alg 일치하는 퍼블릭 키가 없습니다."));
     }
 
     private record OidcPublicKey(String kty, String kid, String use, String alg, String n, String e) {

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -18,6 +18,7 @@ public enum ErrorType {
     FAILED_PARSING(BAD_REQUEST, "WEB_003", "Request JSON body를 파싱하지 못했습니다"),
     UNSUPPORTED_API(BAD_REQUEST, "WEB_004", "지원하지 않는 API입니다"),
     COOKIE_NOT_FOND(BAD_REQUEST, "WEB_005", "요청에 쿠키가 필요합니다"),
+    INVALID_BASE64(BAD_REQUEST, "WEB_006", "잘못된 Base64 문자열입니다"),
 
     // AuthErrorType
     FAILED_AUTHENTICATION(UNAUTHORIZED, "AUTH_001", "인증에 실패하였습니다"),


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #195 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- oidc jwt token parser에서 `FAILED_PARSING` 대신 `INVALID_BASE64` 에러 타입을 사용합니다.
- kid, alg이 일치하는 경우가 없는 경우, 에러 메세지에 이 내용을 포함하도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
