### PR TITLE
Test: OauthService sign in, up 메서드 테스트 추가

### DIFF
--- a/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
@@ -2,6 +2,8 @@ package com.dnd.runus.application.oauth;
 
 import com.dnd.runus.auth.oidc.provider.OidcProvider;
 import com.dnd.runus.auth.oidc.provider.OidcProviderRegistry;
+import com.dnd.runus.auth.token.TokenProviderModule;
+import com.dnd.runus.auth.token.dto.AuthTokenDto;
 import com.dnd.runus.domain.badge.BadgeAchievementRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
@@ -19,8 +21,13 @@ import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.constant.SocialType;
+import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.NotFoundException;
+import com.dnd.runus.global.exception.type.ErrorType;
+import com.dnd.runus.presentation.v1.oauth.dto.request.SignInRequest;
+import com.dnd.runus.presentation.v1.oauth.dto.request.SignUpRequest;
 import com.dnd.runus.presentation.v1.oauth.dto.request.WithdrawRequest;
+import com.dnd.runus.presentation.v1.oauth.dto.response.SignResponse;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,10 +46,47 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class OauthServiceTest {
+    @InjectMocks
+    private OauthService oauthService;
+
+    @Mock
+    private OidcProviderRegistry oidcProviderRegistry;
+
+    @Mock
+    private OidcProvider oidcProvider;
+
+    @Mock
+    private SocialProfileRepository socialProfileRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TokenProviderModule tokenProviderModule;
+
+    @Mock
+    private MemberLevelRepository memberLevelRepository;
+
+    @Mock
+    private BadgeAchievementRepository badgeAchievementRepository;
+
+    @Mock
+    private RunningRecordRepository runningRecordRepository;
+
+    @Mock
+    private ChallengeAchievementRepository challengeAchievementRepository;
+
+    @Mock
+    private GoalAchievementRepository goalAchievementRepository;
+
+    @Mock
+    private ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+
+    @Mock
+    private ScaleAchievementRepository scaleAchievementRepository;
 
     private Member member;
 
@@ -55,39 +99,123 @@ class OauthServiceTest {
     @ExtendWith(MockitoExtension.class)
     @DisplayName("oauth관련 테스트: 회원가입, 로그인, 탈퇴 관련")
     class OauthTest {
-        @InjectMocks
-        private OauthService oauthService;
-
-        @Mock
-        private OidcProviderRegistry oidcProviderRegistry;
-
-        @Mock
-        private OidcProvider oidcProvider;
-
-        @Mock
-        private MemberRepository memberRepository;
-
-        @Mock
-        private SocialProfileRepository socialProfileRepository;
-
         private SocialType socialType;
         private String idToken;
         private String authorizationCode;
         private String oauthId;
         private String email;
 
+        @Mock
         private Claims claims;
 
         @BeforeEach
         void setUp() {
-
-            claims = mock(Claims.class);
-
             socialType = SocialType.APPLE;
             idToken = "idToken";
             authorizationCode = "authorizationCode";
             oauthId = "oauthId";
             email = "oauthEmail@email.com";
+        }
+
+        @Test
+        @DisplayName("sign-in 시 socialProfile이 있다면 성공")
+        void socialProfile_exist_then_signIn_success() {
+            // given
+            SignInRequest request = new SignInRequest(socialType, idToken);
+            given(oidcProviderRegistry.getOidcProviderBy(socialType)).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(idToken)).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(claims.get("email")).willReturn(email);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(socialType, oauthId))
+                    .willReturn(Optional.of(new SocialProfile(1L, member, socialType, oauthId, email)));
+            AuthTokenDto tokenDto = new AuthTokenDto("access-token", "bearer");
+            given(tokenProviderModule.generate(String.valueOf(member.memberId())))
+                    .willReturn(tokenDto);
+
+            // when
+            SignResponse signResponse = oauthService.signIn(request);
+
+            // then
+            assertNotNull(signResponse);
+            assertEquals(member.nickname(), signResponse.nickname());
+            assertEquals(email, signResponse.email());
+            assertEquals(tokenDto.accessToken(), signResponse.accessToken());
+        }
+
+        @Test
+        @DisplayName("sign-in 시 socialProfile이 없다면 에러 타입이 USER_NOT_FOUND인 BusinessException 에러 발생")
+        void socialProfile_not_exist_then_signIn_fail() {
+            // given
+            SignInRequest request = new SignInRequest(socialType, idToken);
+            given(oidcProviderRegistry.getOidcProviderBy(socialType)).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(idToken)).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(claims.get("email")).willReturn(email);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(socialType, oauthId))
+                    .willReturn(Optional.empty());
+
+            // when, then
+            BusinessException exception = assertThrows(BusinessException.class, () -> oauthService.signIn(request));
+            assertEquals(ErrorType.USER_NOT_FOUND, exception.getType());
+        }
+
+        @Test
+        @DisplayName("sign-up 시 socialProfile이 있다면 해당 socialProfile을 사용")
+        void socialProfile_not_exist_then_signUp_success() {
+            // given
+            SignUpRequest request = new SignUpRequest(socialType, idToken, "nickname");
+            given(oidcProviderRegistry.getOidcProviderBy(socialType)).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(idToken)).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(claims.get("email")).willReturn(email);
+            SocialProfile socialProfile = new SocialProfile(1L, member, socialType, oauthId, email);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(socialType, oauthId))
+                    .willReturn(Optional.of(socialProfile));
+            AuthTokenDto tokenDto = new AuthTokenDto("access-token", "bearer");
+            given(tokenProviderModule.generate(String.valueOf(member.memberId())))
+                    .willReturn(tokenDto);
+
+            // when
+            SignResponse signResponse = oauthService.signUp(request);
+
+            // then
+            assertNotNull(signResponse);
+            assertEquals(member.nickname(), signResponse.nickname());
+            assertEquals(email, signResponse.email());
+            assertEquals(tokenDto.accessToken(), signResponse.accessToken());
+        }
+
+        @Test
+        @DisplayName("sign-up 시 socialProfile이 없다면 socialProfileRepository.save() 호출")
+        void socialProfile_not_exist_then_signUp_save_social_profile() {
+            // given
+            SignUpRequest request = new SignUpRequest(socialType, idToken, "nickname");
+            given(oidcProviderRegistry.getOidcProviderBy(socialType)).willReturn(oidcProvider);
+            given(oidcProvider.getClaimsBy(idToken)).willReturn(claims);
+            given(claims.getSubject()).willReturn(oauthId);
+            given(claims.get("email")).willReturn(email);
+            given(socialProfileRepository.findBySocialTypeAndOauthId(socialType, oauthId))
+                    .willReturn(Optional.empty());
+
+            Member newMember =
+                    new Member(2L, MemberRole.USER, request.nickname(), OffsetDateTime.now(), OffsetDateTime.now());
+            SocialProfile socialProfile = new SocialProfile(1L, newMember, socialType, oauthId, email);
+            given(socialProfileRepository.save(any(SocialProfile.class))).willReturn(socialProfile);
+
+            AuthTokenDto tokenDto = new AuthTokenDto("access-token", "bearer");
+            given(tokenProviderModule.generate(String.valueOf(newMember.memberId())))
+                    .willReturn(tokenDto);
+
+            // when
+            SignResponse signResponse = oauthService.signUp(request);
+
+            // then
+            assertNotNull(signResponse);
+            assertEquals(newMember.nickname(), signResponse.nickname());
+            assertEquals(email, signResponse.email());
+            assertEquals(tokenDto.accessToken(), signResponse.accessToken());
+
+            then(socialProfileRepository).should().save(any(SocialProfile.class));
         }
 
         @DisplayName("소셜 로그인 연동 해제: 성공")
@@ -170,35 +298,6 @@ class OauthServiceTest {
     @ExtendWith(MockitoExtension.class)
     @DisplayName("회원 탈퇴를 위한 멤버 데이터 삭제")
     class DeleteAllMemberTest {
-        @InjectMocks
-        private OauthService oauthService;
-
-        @Mock
-        private MemberRepository memberRepository;
-
-        @Mock
-        private SocialProfileRepository socialProfileRepository;
-
-        @Mock
-        private MemberLevelRepository memberLevelRepository;
-
-        @Mock
-        private BadgeAchievementRepository badgeAchievementRepository;
-
-        @Mock
-        private RunningRecordRepository runningRecordRepository;
-
-        @Mock
-        private ChallengeAchievementRepository challengeAchievementRepository;
-
-        @Mock
-        private GoalAchievementRepository goalAchievementRepository;
-
-        @Mock
-        private ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
-
-        @Mock
-        private ScaleAchievementRepository scaleAchievementRepository;
 
         @DisplayName("회원 삭제: 회원이 존재하지 않으면 NotFoundException을 발생하한다.")
         @Test


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `OauthService`의 `signIn`, `signUp` 메서드에서 `SocialProfile` 조회 후 `member`를 다시 조회하고 있어요
  - `SocialProfile`이 `Member`를 필드로 가지고 있으므로 member id로 조회하는 대신 SocialProfile.Member 필드를 사용하도록 수정합니다.
- `OauthService`의 `signIn`, `signUp` 메서드 성공, 예외 발생 케이스를 추가합니다.
  - sign-in 시 socialProfile이 있다면 성공
  - sign-in 시 socialProfile이 없다면 에러 타입이 USER_NOT_FOUND인 BusinessException 에러 발생
  - sign-up 시 socialProfile이 있다면 해당 socialProfile을 사용
  - sign-up 시 socialProfile이 없다면 socialProfileRepository.save() 호출

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
