### PR TITLE
Fix: openweathermap api 요청 시 unit을 units로 오타 수정

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClient.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClient.java
@@ -8,8 +8,8 @@ import org.springframework.web.service.annotation.HttpExchange;
 public interface OpenweathermapWeatherHttpClient {
     @GetExchange("/data/2.5/weather")
     OpenweathermapWeatherInfo getWeatherInfo(
-            @RequestParam("lon") double lon,
-            @RequestParam("lat") double lat,
-            @RequestParam String unit,
+            @RequestParam("lon") double longitude,
+            @RequestParam("lat") double latitude,
+            @RequestParam("units") String unit,
             @RequestParam("appid") String appId);
 }

--- a/src/test/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientTest.java
@@ -81,7 +81,7 @@ class OpenweathermapWeatherHttpClientTest {
                 + "  \"name\": \"Seoul\","
                 + "  \"cod\": 200"
                 + "}");
-        stubFor(get(urlEqualTo("/data/2.5/weather?lon=126.978&lat=37.5665&unit=metric&appid=test"))
+        stubFor(get(urlEqualTo("/data/2.5/weather?lon=126.978&lat=37.5665&units=metric&appid=test"))
                 .willReturn(aResponse()
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
                         .withResponseBody(body)));


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- unit에서 units로 오타를 수정합니다.
  - #129 에서 해결된 줄 알았으나 `units`이 아닌 `unit`으로 잘못 작성했습니다.
- java 코드 상에서 사용하는 param 이름을 현재 프로젝트에서 사용중인 것과 동일한 이름으로 통일합니다.
  - lon -> longitude
  - lat -> latitude

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
