### PR TITLE
Fix: daily 러닝 기록 조회 api 문서 오류 수정

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordSummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordSummaryResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 public record RunningRecordSummaryResponse(
         List<Info> records
 ) {
+    @Schema(name = "RunningRecordSummaryResponse Info", description = "달리기 기록 요약 정보")
     public record Info(
             long runningRecordId,
             RunningEmoji emoji,

--- a/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleCoursesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/scale/dto/ScaleCoursesResponse.java
@@ -16,6 +16,7 @@ public record ScaleCoursesResponse(
 
     private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.#km");
 
+    @Schema(name = "course Info", description = "코스 정보")
     public record Info(
             @Schema(description = "총 코스 수 (공개되지 않은 코스 포함)", example = "18")
             int totalCourses,


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- X

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 인너 클래스 네임이 같은 문제로 스웨거에 RunningRecordSummaryResponse의 Info가 ScaleCoursesResponse Info로 표시되는 문제 해결합니다.
- RunningRecordSummaryResponse의 Info와 ScaleCoursesResponse의 Info에 각각 스키마 네임을 지정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
