### PR TITLE
Fix: openweathermap api 요청 시 반환 dto 필드를 camel case로 수정

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherClient.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherClient.java
@@ -30,9 +30,9 @@ public class OpenweathermapWeatherClient implements WeatherClient {
 
         return new WeatherInfo(
                 mapWeatherType(info.weather()[0].id()),
-                info.main().feels_like(),
-                info.main().temp_min(),
-                info.main().temp_max(),
+                info.main().feelsLike(),
+                info.main().tempMin(),
+                info.main().tempMax(),
                 info.main().humidity(),
                 info.wind().speed());
     }

--- a/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherInfo.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherInfo.java
@@ -1,12 +1,15 @@
 package com.dnd.runus.infrastructure.weather.openweathermap;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record OpenweathermapWeatherInfo(Weather[] weather, Main main, Wind wind) {
     record Weather(int id, String main, String description, String icon) {}
 
-    record Main(double temp, double feels_like, double temp_min, double temp_max, double pressure, double humidity) {}
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    record Main(double temp, double feelsLike, double tempMin, double tempMax, double pressure, double humidity) {}
 
     record Wind(double speed, double deg, double gust) {}
 }

--- a/src/test/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientTest.java
@@ -93,7 +93,7 @@ class OpenweathermapWeatherHttpClientTest {
         // then
         assertNotNull(weatherInfo);
         assertEquals(800, weatherInfo.weather()[0].id());
-        assertEquals(10.0, weatherInfo.main().feels_like());
-        assertEquals(10.0, weatherInfo.main().temp_min());
+        assertEquals(10.0, weatherInfo.main().feelsLike());
+        assertEquals(10.0, weatherInfo.main().tempMin());
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #204

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- openweathermap api 요청 시 반환 dto 필드를 camel case로 수정합니다.
  - feels_like -> feelsLike
  - temp_min -> tempMin
  - temp_max -> tempMax

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
