### PR TITLE
Fix: WEATHER_API_ERROR의 http status code를 500에서 503으로 수정

### DIFF
--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -46,7 +46,7 @@ public enum ErrorType {
     GOAL_TIME_AND_DISTANCE_BOTH_EXIST(BAD_REQUEST, "RUNNING_004", "개인 목표 시간과 거리 중 하나만 설정해야 합니다."),
 
     // WeatherErrorType
-    WEATHER_API_ERROR(INTERNAL_SERVER_ERROR, "WEATHER_001", "날씨 API 호출 중 오류가 발생했습니다"),
+    WEATHER_API_ERROR(SERVICE_UNAVAILABLE, "WEATHER_001", "날씨 API 호출 중 오류가 발생했습니다"),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/dnd/runus/presentation/v1/weather/WeatherController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/weather/WeatherController.java
@@ -1,6 +1,8 @@
 package com.dnd.runus.presentation.v1.weather;
 
 import com.dnd.runus.application.weather.WeatherService;
+import com.dnd.runus.global.exception.type.ApiErrorType;
+import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.weather.dto.WeatherResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +19,7 @@ public class WeatherController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
+    @ApiErrorType({ErrorType.WEATHER_API_ERROR})
     @Operation(summary = "날씨 정보 조회", description = "경도와 위도를 입력받아 날씨 정보를 조회합니다.")
     public WeatherResponse getWeather(@RequestParam double longitude, @RequestParam double latitude) {
         return weatherService.getWeather(longitude, latitude);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #205 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- GET `api/v1/weathers` API에서 에러가 발생하는 경우, 500 에러에서 503 에러로 변경합니다.
- 해당 API docs `ApiErrorType`에 `ErrorType.WEATHER_API_ERROR`를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
