### PR TITLE
Feat: circuit breaker로 날씨 API 이중화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,8 @@ dependencies {
 
     implementation(libs.caffeine)
 
+    implementation(libs.resilience4j.spring.boot)
+
     testImplementation(libs.bundles.spring.boot.test)
     testImplementation(libs.bundles.testcontainers)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ spring-boot-devtools = { group = "org.springframework.boot", name = "spring-boot
 spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "spring-boot" }
 spring-boot-testcontainers = { group = "org.springframework.boot", name = "spring-boot-testcontainers", version.ref = "spring-boot" }
 spring-boot-cache = { group = "org.springframework.boot", name = "spring-boot-starter-cache", version.ref = "spring-boot" }
+spring-boot-aop = { group = "org.springframework.boot", name = "spring-boot-starter-aop", version.ref = "spring-boot" }
 
 bcpkix = {group= "org.bouncycastle", name = "bcpkix-jdk18on", version = "1.78.1" }
 
@@ -44,6 +45,8 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 spring-cloud-starter-contract-stub-runner = { group = "org.springframework.cloud", name = "spring-cloud-starter-contract-stub-runner", version = "4.1.4" }
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version = "3.1.8" }
 
+resilience4j-spring-boot = { group = "io.github.resilience4j", name = "resilience4j-spring-boot3", version = "2.2.0" }
+
 [bundles]
 spring-boot = [
     "spring-boot-starter",
@@ -53,6 +56,7 @@ spring-boot = [
     "spring-boot-starter-actuator",
     "spring-boot-starter-data-jpa",
     "spring-boot-cache",
+    "spring-boot-aop",
 ]
 
 spring-boot-test = [

--- a/src/main/java/com/dnd/runus/infrastructure/weather/WeatherClientProxy.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/WeatherClientProxy.java
@@ -1,0 +1,47 @@
+package com.dnd.runus.infrastructure.weather;
+
+import com.dnd.runus.global.constant.WeatherType;
+import com.dnd.runus.global.exception.BusinessException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+public class WeatherClientProxy implements WeatherClient {
+
+    private final WeatherClient mainWeatherClient;
+    private final WeatherClient fallbackWeatherClient;
+
+    public WeatherClientProxy(
+            @Qualifier("openweathermapWeatherClient") WeatherClient openweathermapWeatherClient,
+            @Qualifier("weatherApiComWeatherClient") WeatherClient weatherApiComWeatherClient) {
+        this.mainWeatherClient = openweathermapWeatherClient;
+        this.fallbackWeatherClient = weatherApiComWeatherClient;
+    }
+
+    @Override
+    @CircuitBreaker(name = "weatherClient", fallbackMethod = "fallback")
+    public WeatherInfo getWeatherInfo(double longitude, double latitude) {
+        return mainWeatherClient.getWeatherInfo(longitude, latitude);
+    }
+
+    public WeatherInfo fallback(double longitude, double latitude, BusinessException e) {
+        log.error("Business exception occurred. type: {}, message: {}", e.getType(), e.getMessage());
+        return fallbackWeatherClient.getWeatherInfo(longitude, latitude);
+    }
+
+    public WeatherInfo fallback(double longitude, double latitude, CallNotPermittedException e) {
+        log.error("Circuit breaker is open. {}", e.getMessage());
+        return fallbackWeatherClient.getWeatherInfo(longitude, latitude);
+    }
+
+    public WeatherInfo fallback(Exception e) {
+        log.error("Fallback occurred. {}", e.getMessage());
+        return new WeatherInfo(WeatherType.CLOUDY, 0, 0, 0, 0, 0);
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientConfig.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientConfig.java
@@ -20,8 +20,8 @@ public class OpenweathermapWeatherHttpClientConfig {
     @Bean
     public OpenweathermapWeatherHttpClient openweathermapWeatherHttpClient() {
         ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
-                .withReadTimeout(Duration.ofSeconds(5))
-                .withConnectTimeout(Duration.ofSeconds(10));
+                .withReadTimeout(Duration.ofSeconds(1))
+                .withConnectTimeout(Duration.ofSeconds(3));
         ClientHttpRequestFactory requestFactory = ClientHttpRequestFactories.get(settings);
 
         RestClient restClient =

--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClient.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClient.java
@@ -8,6 +8,7 @@ import com.dnd.runus.infrastructure.weather.weatherapicom.dto.WeatherapicomCurre
 import com.dnd.runus.infrastructure.weather.weatherapicom.dto.WeatherapicomHistory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -15,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 import static com.dnd.runus.global.exception.type.ErrorType.WEATHER_API_ERROR;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
+@Component
 @RequiredArgsConstructor
 public class WeatherApiComWeatherClient implements WeatherClient {
     private final WeatherapicomWeatherHttpClient weatherapicomWeatherHttpClient;

--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherapicomWeatherHttpClientConfig.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherapicomWeatherHttpClientConfig.java
@@ -20,8 +20,8 @@ public class WeatherapicomWeatherHttpClientConfig {
     @Bean
     public WeatherapicomWeatherHttpClient weatherapicomWeatherHttpClient() {
         ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
-                .withReadTimeout(Duration.ofSeconds(5))
-                .withConnectTimeout(Duration.ofSeconds(10));
+                .withReadTimeout(Duration.ofSeconds(1))
+                .withConnectTimeout(Duration.ofSeconds(3));
         ClientHttpRequestFactory requestFactory = ClientHttpRequestFactories.get(settings);
 
         RestClient restClient =

--- a/src/main/java/com/dnd/runus/presentation/v1/weather/WeatherController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/weather/WeatherController.java
@@ -1,8 +1,6 @@
 package com.dnd.runus.presentation.v1.weather;
 
 import com.dnd.runus.application.weather.WeatherService;
-import com.dnd.runus.global.exception.type.ApiErrorType;
-import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.weather.dto.WeatherResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,7 +17,6 @@ public class WeatherController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @ApiErrorType({ErrorType.WEATHER_API_ERROR})
     @Operation(summary = "날씨 정보 조회", description = "경도와 위도를 입력받아 날씨 정보를 조회합니다.")
     public WeatherResponse getWeather(@RequestParam double longitude, @RequestParam double latitude) {
         return weatherService.getWeather(longitude, latitude);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, metrics
+        include: health, info, circuitbreakers
+  health:
+    circuitbreakers:
+      enabled: true
 
 ---
 spring.config.activate.on-profile: local


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #212 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `resilience4j` 의존성을 추가합니다.
- `openweathermap` api를 메인으로 사용하고, 해당 API를 사용할 수 없는 경우 `weatherApiCom` api를 사용합니다.
- resilience4j의 circuit breaker 상태 정보를 actuator에서 확인할 수 있도록 application.yml에 설정합니다.
- 위에서 언급한 날씨 api 2개 모두 timeout 시간을 변경합니다.
  - read timeout: 5초 -> 1초
  - connection timeout: 10초 -> 3초
- main, fallback api 모두 실패한 경우, 에러 로그를 남기고 빈 날씨 응답값을 반환하도록 합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
