### PR TITLE
Feat: 외부 weather api 캐싱 어노테이션을 WeatherClientProxy.getWeatherInfo 메서드에 추가

### DIFF
--- a/src/main/java/com/dnd/runus/global/constant/CacheType.java
+++ b/src/main/java/com/dnd/runus/global/constant/CacheType.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 
 @Getter
 public enum CacheType {
+    WEATHER(Name.WEATHER, Duration.ofMinutes(10), 100),
     ;
     private final String cacheName;
     private final Duration expireAfterWrite;
@@ -15,5 +16,9 @@ public enum CacheType {
         this.cacheName = cacheName;
         this.expireAfterWrite = expireAfterWrite;
         this.maximumSize = maximumSize;
+    }
+
+    public static class Name {
+        public static final String WEATHER = "weather";
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/weather/WeatherClientProxy.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/WeatherClientProxy.java
@@ -6,8 +6,11 @@ import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
+
+import static com.dnd.runus.global.constant.CacheType.Name.WEATHER;
 
 @Slf4j
 @Primary
@@ -25,6 +28,7 @@ public class WeatherClientProxy implements WeatherClient {
     }
 
     @Override
+    @Cacheable(cacheNames = WEATHER, key = "#longitude + ':' + #latitude")
     @CircuitBreaker(name = "weatherClient", fallbackMethod = "fallback")
     public WeatherInfo getWeatherInfo(double longitude, double latitude) {
         return mainWeatherClient.getWeatherInfo(longitude, latitude);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #214 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 외부 weather api 캐싱 어노테이션을 `WeatherClientProxy`.`getWeatherInfo` 메서드에 추가합니다.
- 캐싱 key는 `경도:위도`를 사용합니다.
- 캐싱 유지 기간은 날씨 api 특성 상, 오래 유지할 필요가 없으므로 10분으로 설정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
