### PR TITLE
Fix: Pace getJsonValue 메서드에서 초를 두 자리로 표현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -12,6 +12,12 @@ import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_
  * @param second
  */
 public record Pace(int minute, int second) {
+    public Pace {
+        if (minute < 0 || second < 0 || second >= SECONDS_PER_MINUTE) {
+            throw new IllegalArgumentException("분 또는 초는 0 이상 60 미만의 값이어야 합니다.");
+        }
+    }
+
     public static Pace ofSeconds(int seconds) {
         int minute = seconds / SECONDS_PER_MINUTE;
         int second = seconds % SECONDS_PER_MINUTE;
@@ -26,8 +32,8 @@ public record Pace(int minute, int second) {
     }
 
     @JsonValue
-    public String getPace() {
-        return minute + "’" + second + "”";
+    public String getJsonValue() {
+        return minute + "’" + String.format("%02d", second) + "”";
     }
 
     public int toSeconds() {

--- a/src/test/java/com/dnd/runus/domain/common/PaceTest.java
+++ b/src/test/java/com/dnd/runus/domain/common/PaceTest.java
@@ -1,41 +1,72 @@
 package com.dnd.runus.domain.common;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.stream.Stream;
+
+import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_MINUTE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PaceTest {
-    private Pace pace;
-
-    @BeforeEach
-    void setUp() {
-        pace = new Pace(5, 30);
-    }
-
-    @Test
+    @ParameterizedTest
     @DisplayName("초를 입력받아 Pace 객체를 생성한다.")
-    void ofSeconds() {
-        assertEquals(Pace.ofSeconds(330), pace);
+    @ValueSource(ints = {330, 300})
+    void ofSeconds(int seconds) {
+        int minute = seconds / SECONDS_PER_MINUTE;
+        int second = seconds % SECONDS_PER_MINUTE;
+        Pace pace = new Pace(minute, second);
+        assertEquals(Pace.ofSeconds(seconds), pace);
     }
 
-    @Test
+    @ParameterizedTest
     @DisplayName("올바른 형태의 문자열을 입력받아 Pace 객체를 생성한다.")
-    void from() {
-        assertEquals(Pace.from("5'30''"), pace);
-        assertEquals(Pace.from("5’30”"), pace);
+    @ValueSource(strings = {"5'30''", "5’30”"})
+    void from(String paceString) {
+        Pace pace = new Pace(5, 30);
+        assertEquals(Pace.from(paceString), pace);
     }
 
-    @Test
+    @ParameterizedTest
     @DisplayName("Pace 객체를 올바른 형태의 문자열로 변환한다.")
-    void getPace() {
-        assertEquals("5’30”", pace.getPace());
+    @MethodSource("providePace")
+    void getJsonValue(int minute, int second, String expected) {
+        Pace pace = new Pace(minute, second);
+        assertEquals(expected, pace.getJsonValue());
+    }
+
+    @ParameterizedTest
+    @DisplayName("Pace 객체를 초(60 * 분 + 초)로 변환한다.")
+    @MethodSource("providePace")
+    void toSeconds(int minute, int second) {
+        int seconds = minute * SECONDS_PER_MINUTE + second;
+        Pace pace = new Pace(minute, second);
+        assertEquals(seconds, pace.toSeconds());
+    }
+
+    private static Stream<Arguments> providePace() {
+        return Stream.of(
+                Arguments.of(0, 0, "0’00”"),
+                Arguments.of(0, 30, "0’30”"),
+                Arguments.of(1, 1, "1’01”"),
+                Arguments.of(1, 5, "1’05”"),
+                Arguments.of(5, 0, "5’00”"),
+                Arguments.of(5, 30, "5’30”"),
+                Arguments.of(10, 0, "10’00”"),
+                Arguments.of(10, 10, "10’10”"),
+                Arguments.of(100, 10, "100’10”"));
     }
 
     @Test
-    @DisplayName("Pace 객체를 초(60 * 분 + 초)로 변환한다.")
-    void toSeconds() {
-        assertEquals(330, pace.toSeconds());
+    @DisplayName("음수 또는 60 이상의 값을 입력받으면 IllegalArgumentException을 던진다.")
+    void constructor_exception() {
+        assertThrows(IllegalArgumentException.class, () -> new Pace(-1, 0));
+        assertThrows(IllegalArgumentException.class, () -> new Pace(0, -1));
+        assertThrows(IllegalArgumentException.class, () -> new Pace(0, 60));
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Pace. getPace 메서드에서 기존에는 초 단위가 10 미만이면 한 자리로 표현합니다. (`5’5”`)
  - 초 단위가 10 미만이더라도 두 자리로 표현하도록 수정합니다. (`5’05”`)
  - 검증하는 테스트를 추가합니다.
- 분 또는 초는 0 이상 60 미만의 값이 아닌 경우에 생성자에서 IllegalArgumentException 예외를 던지도록 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
