### PR TITLE
Feat: running record id로 러닝 기록 조회 api 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -26,20 +26,13 @@ import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.exception.NotFoundException;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordSummaryResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordWeeklySummaryResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.time.*;
 import java.util.List;
 
 import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
@@ -81,6 +74,15 @@ public class RunningRecordService {
         this.scaleRepository = scaleRepository;
         this.scaleAchievementRepository = scaleAchievementRepository;
         this.defaultZoneOffset = defaultZoneOffset;
+    }
+
+    @Transactional(readOnly = true)
+    public RunningRecordQueryResponse getRunningRecord(long memberId, long runningRecordId) {
+        RunningRecord record = runningRecordRepository
+                .findById(runningRecordId)
+                .filter(r -> r.member().memberId() == memberId)
+                .orElseThrow(() -> new NotFoundException(RunningRecord.class, runningRecordId));
+        return RunningRecordQueryResponse.from(record);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -6,11 +6,7 @@ import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.annotation.MemberId;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordAddResultResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlyDatesResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordSummaryResponse;
-import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordWeeklySummaryResponse;
+import com.dnd.runus.presentation.v1.running.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -27,6 +23,12 @@ import java.util.List;
 @RequestMapping("/api/v1/running-records")
 public class RunningRecordController {
     private final RunningRecordService runningRecordService;
+
+    @GetMapping("{runningRecordId}")
+    @Operation(summary = "러닝 기록 상세 조회", description = "RunngingRecord id로 러닝 상세 기록을 조회합니다.")
+    public RunningRecordQueryResponse getRunningRecord(@MemberId long memberId, @PathVariable long runningRecordId) {
+        return runningRecordService.getRunningRecord(memberId, runningRecordId);
+    }
 
     @GetMapping("monthly-dates")
     @Operation(summary = "해당 월의 러닝 기록 조회", description = "해당 월의 러닝 기록을 조회합니다. 해당 월에 러닝 기록이 있는 날짜를 반환합니다.")

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
@@ -1,0 +1,83 @@
+package com.dnd.runus.presentation.v1.running.dto.response;
+
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
+import com.dnd.runus.domain.goalAchievement.GoalAchievement;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.presentation.v1.running.dto.ChallengeDto;
+import com.dnd.runus.presentation.v1.running.dto.GoalResultDto;
+import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDto;
+import com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record RunningRecordQueryResponse(
+        long runningRecordId,
+        @Schema(description = "러닝 시작 시간")
+        LocalDateTime startAt,
+        @Schema(description = "러닝 종료 시간")
+        LocalDateTime endAt,
+        @NotNull
+        @Schema(description = "감정 표현, very-good: 최고, good: 좋음, soso: 보통, bad: 나쁨, very-bad: 최악")
+        RunningEmoji emotion,
+        @NotNull
+        @Schema(description = "달성 모드, normal: 일반(목표 설정 X), challenge: 챌린지, goal: 목표")
+        RunningAchievementMode achievementMode,
+        @Schema(description = "챌린지 정보, achievementMode가 challenge인 경우에만 값이 존재합니다.")
+        ChallengeDto challenge,
+        @Schema(description = "목표 결과 정보, achievementMode가 goal인 경우에만 값이 존재합니다.")
+        GoalResultDto goal,
+        @NotNull
+        RunningRecordMetricsDto runningData
+) {
+    public static RunningRecordQueryResponse from(RunningRecord runningRecord) {
+        return buildResponse(runningRecord, null, null, RunningAchievementMode.NORMAL);
+    }
+
+    public static RunningRecordQueryResponse of(RunningRecord runningRecord, ChallengeAchievement achievement) {
+        return buildResponse(runningRecord,
+                new ChallengeDto(
+                        achievement.challenge().challengeId(),
+                        achievement.challenge().name(),
+                        achievement.description(),
+                        achievement.challenge().imageUrl(),
+                        achievement.isSuccess()
+                ),
+                null,
+                RunningAchievementMode.CHALLENGE
+        );
+    }
+
+    public static RunningRecordQueryResponse of(RunningRecord runningRecord, GoalAchievement achievement) {
+        return buildResponse(runningRecord,
+                null,
+                new GoalResultDto(
+                        achievement.getTitle(),
+                        achievement.getDescription(),
+                        achievement.getIconUrl(),
+                        achievement.isAchieved()
+                ),
+                RunningAchievementMode.GOAL
+        );
+    }
+
+    private static RunningRecordQueryResponse buildResponse(RunningRecord runningRecord, ChallengeDto challenge, GoalResultDto goal, RunningAchievementMode achievementMode) {
+        return new RunningRecordQueryResponse(
+                runningRecord.runningId(),
+                runningRecord.startAt().toLocalDateTime(),
+                runningRecord.endAt().toLocalDateTime(),
+                runningRecord.emoji(),
+                achievementMode,
+                challenge,
+                goal,
+                new RunningRecordMetricsDto(
+                        runningRecord.averagePace(),
+                        runningRecord.duration(),
+                        runningRecord.distanceMeter(),
+                        runningRecord.calorie()
+                )
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #225 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET api/v1/running-records/{runningRecordId} - 러닝 기록 id로 러닝 상세 기록 조회 api

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 위 api를 새롭게 추가합니다.
- 관련 service test를 추가합니다.
- 해당 member가 아닌 다른 member의 러닝 기록을 조회하는 경우 NotFound 예외를 발생하도록 했습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
