### PR TITLE
Refactor: OauthService.revokeOauth 메서드에서 revoke 호출을 가상 스레드를 이용한 비동기 호출로 변경

### DIFF
--- a/src/main/java/com/dnd/runus/auth/oidc/client/RestClientConfig.java
+++ b/src/main/java/com/dnd/runus/auth/oidc/client/RestClientConfig.java
@@ -6,21 +6,38 @@ import org.springframework.boot.web.client.ClientHttpRequestFactorySettings;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
+import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.concurrent.Executors;
 
 @Configuration
 public class RestClientConfig {
 
+    @Value("${spring.threads.virtual.enabled}")
+    private boolean isVirtualThreadEnabled;
+
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(1);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+
     @Bean
     AppleAuthClient appleAuthClient(@Value("${oauth.apple.base-auth-url}") String baseAuthUrl) {
-        ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
-                .withReadTimeout(Duration.ofSeconds(5))
-                .withConnectTimeout(Duration.ofSeconds(10));
-        ClientHttpRequestFactory requestFactory = ClientHttpRequestFactories.get(settings);
+        ClientHttpRequestFactory requestFactory;
+
+        if (isVirtualThreadEnabled) {
+            requestFactory = new JdkClientHttpRequestFactory(HttpClient.newBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .executor(Executors.newVirtualThreadPerTaskExecutor())
+                    .build());
+        } else {
+            requestFactory = ClientHttpRequestFactories.get(ClientHttpRequestFactorySettings.DEFAULTS
+                    .withReadTimeout(READ_TIMEOUT)
+                    .withConnectTimeout(CONNECT_TIMEOUT));
+        }
 
         RestClient restClient = RestClient.builder()
                 .baseUrl(baseAuthUrl)

--- a/src/main/java/com/dnd/runus/auth/oidc/provider/apple/AppleOidcProvider.java
+++ b/src/main/java/com/dnd/runus/auth/oidc/provider/apple/AppleOidcProvider.java
@@ -1,5 +1,6 @@
 package com.dnd.runus.auth.oidc.provider.apple;
 
+import com.dnd.runus.auth.exception.AuthException;
 import com.dnd.runus.auth.oidc.client.AppleAuthClient;
 import com.dnd.runus.auth.oidc.provider.OidcProvider;
 import com.dnd.runus.auth.oidc.provider.apple.dto.AppleAuthRevokeRequest;
@@ -77,7 +78,7 @@ public class AppleOidcProvider implements OidcProvider {
                     .build();
             return appleAuthClient.getAuthToken(request.toMultiValueMap()).accessToken();
         } catch (HttpClientErrorException e) {
-            throw new BusinessException(ErrorType.FAILED_AUTHENTICATION, e.getMessage());
+            throw new AuthException(ErrorType.FAILED_AUTHENTICATION, e.getMessage());
         }
     }
 
@@ -92,8 +93,7 @@ public class AppleOidcProvider implements OidcProvider {
                     .build();
             appleAuthClient.revoke(request.toMultiValueMap());
         } catch (HttpClientErrorException e) {
-            log.warn("failed token revoke :{}", e.getMessage());
-            throw new BusinessException(ErrorType.FAILED_AUTHENTICATION, e.getMessage());
+            throw new AuthException(ErrorType.FAILED_AUTHENTICATION, e.getMessage());
         }
     }
 

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -28,6 +28,7 @@ public enum ErrorType {
     TAMPERED_ACCESS_TOKEN(UNAUTHORIZED, "AUTH_005", "변조된 토큰입니다"),
     UNSUPPORTED_JWT_TOKEN(UNAUTHORIZED, "AUTH_006", "지원하지 않는 JWT 토큰입니다"),
     UNSUPPORTED_SOCIAL_TYPE(UNAUTHORIZED, "AUTH_007", "지원하지 않는 소셜 타입입니다."),
+    INVALID_CREDENTIALS(UNAUTHORIZED, "AUTH_008", "해당 사용자의 정보가 없거나 일치하지 않아 처리할 수 없습니다."),
 
     // OauthErrorType
     USER_NOT_FOUND(NOT_FOUND, "OAUTH_001", "존재하지 않은 사용자 입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,10 @@ spring:
     enabled: true
     baseline-on-migrate: true
 
+  threads:
+    virtual:
+      enabled: false
+
 app:
   api:
     allow-origins: ${ALLOW_ORIGINS}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,6 +14,10 @@ spring:
     enabled: true
     baseline-on-migrate: true # Baseline 생성이 필요한 상황에서 migration 작업 실행시, Baseline 생성부터 하겠다는 설정
 
+  threads:
+    virtual:
+      enabled: false
+
 app:
   api:
     allow-origins: "*"


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #56 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에는 oidcProvider에서 access token과 revoke api 호출을 기다리고 `revokeOauth` 메서드를 종료합니다.
  - access token을 얻는 api와 revoke api 호출을 비동기로 변경합니다.
  - 이렇게 함으로 트랜잭션은 바로 종료되고 revoke api 호출은 다른 가상 스레드에서 실행됩니다.
- revoke api가 실패한 경우 로그를 남기도록 했습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
