### PR TITLE
Fix: prometheus url post 요청을 허용하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/config/SecurityWebConfig.java
+++ b/src/main/java/com/dnd/runus/presentation/config/SecurityWebConfig.java
@@ -33,7 +33,7 @@ public class SecurityWebConfig {
     private List<String> corsOrigins;
 
     private static final String[] PUBLIC_ENDPOINTS = {
-        "/api/v1/auth/**",
+        "/api/v1/auth/**", "/actuator/prometheus/**",
     };
 
     private static final String[] OPEN_API_ENDPOINTS = {
@@ -41,7 +41,7 @@ public class SecurityWebConfig {
     };
 
     private static final String[] READ_ONLY_ENDPOINTS = {
-        "/api/v1/servers/versions", "/actuator/health", "/actuator/metrics/**", "/actuator/prometheus",
+        "/api/v1/servers/versions", "/actuator/health", "/actuator/metrics/**",
     };
 
     @Bean


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- prometheus url post 요청을 허용하도록 수정합니다.
- `actuator/prometheus` url 요청은 모니터링 서버 ip만 허용하도록 was 서버 nginx에 설정해두었습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
