### PR TITLE
Fix: running record 조회 api에서 잘못된 uri 매핑 수정

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/handler/ExceptionRestHandler.java
+++ b/src/main/java/com/dnd/runus/presentation/handler/ExceptionRestHandler.java
@@ -4,6 +4,7 @@ import com.dnd.runus.auth.exception.AuthException;
 import com.dnd.runus.global.exception.BaseException;
 import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.dto.response.ApiErrorDto;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -35,13 +37,24 @@ public class ExceptionRestHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiErrorDto> handleException(Exception e) {
-        log.error("Unhandled exception: ", e);
+    public ResponseEntity<ApiErrorDto> handleException(Exception e, HttpServletRequest request) {
+        log.error(
+                "Unhandled exception[{}]: {}, method: {}, uri: {}",
+                e.getClass(),
+                e.getMessage(),
+                request.getMethod(),
+                request.getRequestURI());
         return toResponseEntity(ErrorType.UNHANDLED_EXCEPTION, e.getMessage());
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ApiErrorDto> handleNoResourceFoundException(NoResourceFoundException e) {
+        return toResponseEntity(ErrorType.UNSUPPORTED_API, e.getMessage());
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiErrorDto> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
         return toResponseEntity(ErrorType.UNSUPPORTED_API, e.getMessage());
     }
 

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class RunningRecordController {
     private final RunningRecordService runningRecordService;
 
-    @GetMapping("{runningRecordId}")
+    @GetMapping("/{runningRecordId}")
     @Operation(summary = "러닝 기록 상세 조회", description = "RunngingRecord id로 러닝 상세 기록을 조회합니다.")
     public RunningRecordQueryResponse getRunningRecord(@MemberId long memberId, @PathVariable long runningRecordId) {
         return runningRecordService.getRunningRecord(memberId, runningRecordId);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에 `{runningRecordId}`에서 `/{runningRecordId}`으로 수정합니다.
  - uri 경로에 `/`가 빠져 Get 요청으로 인식하지 못하는 버그를 수정합니다.
- `InsufficientAuthenticationException` 예외 처리를 `ExceptionRestHandler`에 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
