### PR TITLE
Refactor: WeatherApiComWeatherClient.getWeatherInfo 메서드 내 API 2개 동기 호출을 비동기로 전환

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClient.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClient.java
@@ -6,50 +6,68 @@ import com.dnd.runus.infrastructure.weather.WeatherClient;
 import com.dnd.runus.infrastructure.weather.WeatherInfo;
 import com.dnd.runus.infrastructure.weather.weatherapicom.dto.WeatherapicomCurrent;
 import com.dnd.runus.infrastructure.weather.weatherapicom.dto.WeatherapicomHistory;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import static com.dnd.runus.global.exception.type.ErrorType.WEATHER_API_ERROR;
-import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 
+@Slf4j
 @Component
-@RequiredArgsConstructor
 public class WeatherApiComWeatherClient implements WeatherClient {
     private final WeatherapicomWeatherHttpClient weatherapicomWeatherHttpClient;
+    private final String apiKey;
+    private final ExecutorService executorService;
 
-    @Value("${weather.weatherapicom.api-key}")
-    private String apiKey;
+    public WeatherApiComWeatherClient(
+            WeatherapicomWeatherHttpClient weatherapicomWeatherHttpClient,
+            @Value("${weather.weatherapicom.api-key}") String apiKey,
+            @Qualifier("virtualExecutorService") ExecutorService executorService) {
+        this.weatherapicomWeatherHttpClient = weatherapicomWeatherHttpClient;
+        this.apiKey = apiKey;
+        this.executorService = executorService;
+    }
 
     @Override
     public WeatherInfo getWeatherInfo(double longitude, double latitude) {
         String query = String.format("%f,%f", latitude, longitude);
 
-        WeatherapicomCurrent currentInfo = weatherapicomWeatherHttpClient.getWeatherInfo(query, apiKey);
-        if (currentInfo == null || currentInfo.current() == null) {
-            throw new BusinessException(WEATHER_API_ERROR, "[weatherapicom] 현재 날씨 정보를 가져올 수 없습니다.");
+        Future<WeatherapicomCurrent> currentFuture =
+                executorService.submit(() -> weatherapicomWeatherHttpClient.getWeatherInfo(query, apiKey));
+
+        Future<WeatherapicomHistory> historyFuture = executorService.submit(() -> {
+            int hour = 0;
+            String datetime = LocalDate.now().format(ISO_LOCAL_DATE);
+            return weatherapicomWeatherHttpClient.getWeatherHistory(query, datetime, hour, apiKey);
+        });
+
+        try {
+            WeatherapicomCurrent current = currentFuture.get();
+            WeatherapicomHistory history = historyFuture.get();
+
+            double mphToMs = 0.44704;
+
+            WeatherapicomHistory.Forecast.ForecaseDay.DayInfo today =
+                    history.forecast().forecastday().getFirst().day();
+
+            return new WeatherInfo(
+                    mapWeatherType(current.current().condition().code()),
+                    current.current().feelslikeC(),
+                    today.mintempC(),
+                    today.maxtempC(),
+                    current.current().humidity(),
+                    current.current().windMph() * mphToMs);
+        } catch (Exception e) {
+            throw new BusinessException(
+                    WEATHER_API_ERROR,
+                    String.format("[weatherapicom] lon: %f, lat: %f, %s", longitude, latitude, e.getMessage()));
         }
-
-        String datetime = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
-        WeatherapicomHistory historyInfo = weatherapicomWeatherHttpClient.getWeatherHistory(query, datetime, 0, apiKey);
-
-        if (historyInfo == null
-                || historyInfo.forecast() == null
-                || isEmpty(historyInfo.forecast().forecastday())) {
-            throw new BusinessException(WEATHER_API_ERROR, "[weatherapicom] 과거 날씨 정보를 가져올 수 없습니다.");
-        }
-
-        double mphToMs = 0.44704;
-        return new WeatherInfo(
-                mapWeatherType(currentInfo.current().condition().code()),
-                currentInfo.current().feelslikeC(),
-                historyInfo.forecast().forecastday().get(0).day().mintempC(),
-                historyInfo.forecast().forecastday().get(0).day().maxtempC(),
-                currentInfo.current().humidity(),
-                currentInfo.current().windMph() * mphToMs);
     }
 
     private WeatherType mapWeatherType(int weatherCode) {

--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/dto/WeatherapicomCurrent.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/dto/WeatherapicomCurrent.java
@@ -18,4 +18,10 @@ public record WeatherapicomCurrent(Current current) {
             double feelslikeC) {
         public record Condition(int code) {}
     }
+
+    public WeatherapicomCurrent {
+        if (current == null) {
+            throw new IllegalStateException("현재 날씨 정보를 가져올 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/dto/WeatherapicomHistory.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/dto/WeatherapicomHistory.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.List;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record WeatherapicomHistory(Location location, Forecast forecast) {
     public record Location(String name, String region, String country) {}
@@ -23,6 +25,15 @@ public record WeatherapicomHistory(Location location, Forecast forecast) {
                     int dailyChanceOfRain,
                     int dailyWillItSnow,
                     int dailyChanceOfSnow) {}
+        }
+    }
+
+    public WeatherapicomHistory {
+        if (location == null
+                || forecast == null
+                || isEmpty(forecast.forecastday())
+                || forecast.forecastday().getFirst() == null) {
+            throw new IllegalStateException("과거 날씨 정보를 가져올 수 없습니다.");
         }
     }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClientTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClientTest.java
@@ -1,0 +1,91 @@
+package com.dnd.runus.infrastructure.weather.weatherapicom;
+
+import com.dnd.runus.global.constant.WeatherType;
+import com.dnd.runus.global.exception.BusinessException;
+import com.dnd.runus.infrastructure.weather.WeatherInfo;
+import com.dnd.runus.infrastructure.weather.weatherapicom.dto.WeatherapicomCurrent;
+import com.dnd.runus.infrastructure.weather.weatherapicom.dto.WeatherapicomHistory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WeatherApiComWeatherClientTest {
+    private WeatherApiComWeatherClient weatherApiComWeatherClient;
+
+    @Mock
+    private WeatherapicomWeatherHttpClient weatherapicomWeatherHttpClient;
+
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+
+    private final String apkKey = "test";
+
+    @BeforeEach
+    void setUp() {
+        weatherApiComWeatherClient =
+                new WeatherApiComWeatherClient(weatherapicomWeatherHttpClient, apkKey, executorService);
+    }
+
+    @Test
+    @DisplayName("getWeatherInfo()는 current와 history 날씨 정보를 가져온다.")
+    void getWeatherInfo_success() {
+        // given
+        double longitude = 10.10;
+        double latitude = 34.10;
+
+        String query = String.format("%f,%f", latitude, longitude);
+
+        given(weatherapicomWeatherHttpClient.getWeatherInfo(query, apkKey))
+                .willReturn(new WeatherapicomCurrent(new WeatherapicomCurrent.Current(
+                        10.0, 50.0, 1, new WeatherapicomCurrent.Current.Condition(1000), 10.0, 50, 10, 10.0)));
+
+        String datetime = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        given(weatherapicomWeatherHttpClient.getWeatherHistory(query, datetime, 0, apkKey))
+                .willReturn(new WeatherapicomHistory(
+                        new WeatherapicomHistory.Location("Seoul", "Seoul", "Korea"),
+                        new WeatherapicomHistory.Forecast(List.of(new WeatherapicomHistory.Forecast.ForecaseDay(
+                                datetime,
+                                new WeatherapicomHistory.Forecast.ForecaseDay.DayInfo(
+                                        15.0, 41.0, 5.0, 32.0, 0.0, 0, 0, 0, 0))))));
+
+        // when
+        WeatherInfo result = weatherApiComWeatherClient.getWeatherInfo(longitude, latitude);
+
+        // then
+        assertNotNull(result);
+        assertEquals(new WeatherInfo(WeatherType.CLEAR, 10.0, 5.0, 15.0, 50, 4.4704), result);
+    }
+
+    @Test
+    @DisplayName("getWeatherInfo()는 current나 history 날씨 정보를 가져오지 못할 경우 BusinessException을 던진다.")
+    void getWeatherInfo_history_api_fail() {
+        // given
+        double longitude = 10.10;
+        double latitude = 34.10;
+
+        String query = String.format("%f,%f", latitude, longitude);
+
+        given(weatherapicomWeatherHttpClient.getWeatherInfo(query, apkKey))
+                .willReturn(new WeatherapicomCurrent(new WeatherapicomCurrent.Current(
+                        10.0, 50.0, 1, new WeatherapicomCurrent.Current.Condition(1000), 10.0, 50, 10, 10.0)));
+
+        String datetime = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        given(weatherapicomWeatherHttpClient.getWeatherHistory(query, datetime, 0, apkKey))
+                .willThrow(new IllegalStateException());
+
+        // when & then
+        assertThrows(BusinessException.class, () -> weatherApiComWeatherClient.getWeatherInfo(longitude, latitude));
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #237 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에는 `현재 기온` API, `일일 최고/최저 기온` API를 순차적으로 요청합니다.
  - 2개의 API를 비동기로 호출한 다음, 2개의 응답들을 기다리도록 변경합니다.
- 기존에는 `getWeatherInfo()` 메서드에서 weatherapicom API dto값에 null이 있는지 검증합니다.
  - 응답 dto 생성자에서 응답값에 null이 있는지 검증하도록 합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
