### PR TITLE
Feat: Hibernate 로그 레벨 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,16 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
+    show-sql: false
     open-in-view: false
     defer-datasource-initialization: false
+
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        generate_statistics: true
+        session.events.log.LOG_QUERIES_SLOWER_THAN_MS: 300
 
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -22,6 +29,13 @@ spring:
   threads:
     virtual:
       enabled: false
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.SQL_SLOW: INFO
+    org.hibernate.stat: DEBUG
 
 app:
   api:
@@ -64,4 +78,10 @@ management:
 spring.config.activate.on-profile: local
 
 ---
+
+logging:
+  level:
+    org.hibernate: ERROR
+    org.hibernate.SQL_SLOW: WARN
+
 spring.config.activate.on-profile: prod

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,9 +2,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
+    show-sql: false
     open-in-view: false
     defer-datasource-initialization: false
+
+    properties:
+      hibernate:
+        format_sql: true
+        generate_statistics: true
+        session.events.log.LOG_QUERIES_SLOWER_THAN_MS: 300
 
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
@@ -17,6 +23,13 @@ spring:
   threads:
     virtual:
       enabled: false
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.SQL_SLOW: INFO
+    org.hibernate.stat: DEBUG
 
 app:
   api:


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #198 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기본 hibernate 로그는 다음과 같습니다. (색상 x)
  ```sql
  Hibernate: select me1_0.id,me1_0.created_at,me1_0.nickname,me1_0.role,me1_0.updated_at from member me1_0 where me1_0.id=?
  ```
  - SQL 쿼리를 포매팅하여 Logback을 사용해 로그로 출력하고, 세션 정보도 출력하도록 합니다.
  ```jsonc
  Session Metrics {
    0 nanoseconds spent acquiring 0 JDBC connections;
    0 nanoseconds spent releasing 0 JDBC connections;
    0 nanoseconds spent preparing 0 JDBC statements;
    0 nanoseconds spent executing 0 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    0 nanoseconds spent executing 0 flushes (flushing a total of 0 entities and 0 collections);
    0 nanoseconds spent executing 0 pre-partial-flushes;
    0 nanoseconds spent executing 0 partial-flushes (flushing a total of 0 entities and 0 collections)
  }
  ```
- 테스트 환경에서는 `highlight_sql` 설정이 false인 것을 제외하면 로컬 환경과 동일합니다.
- 운영 환경에서는 일반 SQL은 출력하지 않도록 합니다.
  - ERROR 레벨만 로그를 남기도록 했습니다.
  - 혹시나 모를 slow 쿼리는 WARN 레벨 로그로 남기도록 합니다.

Slow 쿼리 출력 예시
```ruby
2024-09-28T08:21:59.476+09:00  INFO 83170 --- [run-us] [nio-8080-exec-1] org.hibernate.SQL_SLOW                   : Slow query took 2 milliseconds [select me1_0.id,me1_0.created_at,me1_0.nickname,me1_0.role,me1_0.updated_at from member me1_0 where me1_0.id=?]
```

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
