### PR TITLE
Feat: RunningRecord startAt과 endAt 필드를 OffsetDateTime에서 ZonedDateTime으로 변경

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -107,7 +107,7 @@ public class RunningRecordService {
 
         return records.stream()
                 .map(RunningRecord::startAt)
-                .map(OffsetDateTime::toLocalDate)
+                .map(ZonedDateTime::toLocalDate)
                 .distinct()
                 .sorted()
                 .toList();
@@ -171,8 +171,8 @@ public class RunningRecordService {
 
         RunningRecord record = runningRecordRepository.save(RunningRecord.builder()
                 .member(member)
-                .startAt(request.startAt().atOffset(defaultZoneOffset))
-                .endAt(request.endAt().atOffset(defaultZoneOffset))
+                .startAt(request.startAt().atZone(defaultZoneOffset))
+                .endAt(request.endAt().atZone(defaultZoneOffset))
                 .emoji(request.emotion())
                 .startLocation(request.startLocation())
                 .endLocation(request.endLocation())

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecord.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecord.java
@@ -7,7 +7,7 @@ import com.dnd.runus.global.constant.RunningEmoji;
 import lombok.Builder;
 
 import java.time.Duration;
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Builder
@@ -18,8 +18,8 @@ public record RunningRecord(
         Duration duration,
         double calorie,
         Pace averagePace,
-        OffsetDateTime startAt,
-        OffsetDateTime endAt,
+        ZonedDateTime startAt,
+        ZonedDateTime endAt,
         List<Coordinate> route,
         String startLocation,
         String endLocation,

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -14,9 +14,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static com.dnd.runus.jooq.Tables.RUNNING_RECORD;
-import static org.jooq.impl.DSL.avg;
-import static org.jooq.impl.DSL.cast;
-import static org.jooq.impl.DSL.sum;
+import static org.jooq.impl.DSL.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -68,10 +66,10 @@ public class JooqRunningRecordRepository {
     /**
      * 기간 안의 일별 달린 거리을 리턴합니다.
      *
-     * @param startDate 시작 날짜 (정각)
+     * @param startDate         시작 날짜 (정각)
      * @param nextDateOfEndDate 종료 날짜의 다음 날 (정각)
      * @return 기간 내 각 날짜별 달린 거리 합계를 포함한 리스트.
-     *          각 요소는 날짜와 해당 날짜의 거리 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
+     * 각 요소는 날짜와 해당 날짜의 거리 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
      */
     public List<DailyRunningRecordSummary> findDailyDistancesMeterByDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
@@ -91,10 +89,10 @@ public class JooqRunningRecordRepository {
     /**
      * 기간 안의 일별 달린 시간을 리턴합니다.
      *
-     * @param startDate 시작 날짜 (정각)
+     * @param startDate         시작 날짜 (정각)
      * @param nextDateOfEndDate 종료 날짜의 다음 날 (정각)
      * @return 기간 내 각 날짜별 달린 시간 합계를 포함한 리스트.
-     *          각 요소는 날짜와 해당 날짜의 달린 시간 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
+     * 각 요소는 날짜와 해당 날짜의 달린 시간 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
      */
     public List<DailyRunningRecordSummary> findDailyDurationsSecMeterByDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntity.java
@@ -17,6 +17,7 @@ import org.locationtech.jts.geom.LineString;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 import static com.dnd.runus.global.constant.GeometryConstant.SRID;
 import static jakarta.persistence.EnumType.STRING;
@@ -57,6 +58,10 @@ public class RunningRecordEntity extends BaseTimeEntity {
     @NotNull
     private OffsetDateTime endAt;
 
+    @NotNull
+    @Size(max = 50)
+    private String timezoneName;
+
     @Column(columnDefinition = "geometry(LineStringZ, " + SRID + ")")
     private LineString route;
 
@@ -80,8 +85,9 @@ public class RunningRecordEntity extends BaseTimeEntity {
                 .durationSeconds((int) runningRecord.duration().toSeconds())
                 .calorie(runningRecord.calorie())
                 .averagePace(runningRecord.averagePace().toSeconds())
-                .startAt(runningRecord.startAt())
-                .endAt(runningRecord.endAt())
+                .startAt(runningRecord.startAt().toOffsetDateTime())
+                .endAt(runningRecord.endAt().toOffsetDateTime())
+                .timezoneName(runningRecord.startAt().getZone().getId())
                 .route(GeometryMapper.toLineString(runningRecord.route()))
                 .startLocation(runningRecord.startLocation())
                 .endLocation(runningRecord.endLocation())
@@ -90,6 +96,8 @@ public class RunningRecordEntity extends BaseTimeEntity {
     }
 
     public RunningRecord toDomain() {
+        ZoneId zoneId = ZoneId.of(timezoneName);
+
         return RunningRecord.builder()
                 .runningId(id)
                 .member(member.toDomain())
@@ -97,8 +105,8 @@ public class RunningRecordEntity extends BaseTimeEntity {
                 .duration(Duration.ofSeconds(durationSeconds))
                 .calorie(calorie)
                 .averagePace(Pace.ofSeconds(averagePace))
-                .startAt(startAt)
-                .endAt(endAt)
+                .startAt(startAt.atZoneSameInstant(zoneId))
+                .endAt(endAt.atZoneSameInstant(zoneId))
                 .route(GeometryMapper.toDomain(route))
                 .startLocation(startLocation)
                 .endLocation(endLocation)

--- a/src/main/resources/db/migration/V5.0.12__running_record_add_timezone_name.sql
+++ b/src/main/resources/db/migration/V5.0.12__running_record_add_timezone_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE running_record ADD COLUMN timezone_name VARCHAR(50);

--- a/src/test/java/com/dnd/runus/application/member/MemberWithdrawServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/member/MemberWithdrawServiceTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -111,8 +111,8 @@ class MemberWithdrawServiceTest {
                 Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now().plusHours(1),
+                ZonedDateTime.now(),
+                ZonedDateTime.now().plusHours(1),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",
@@ -147,8 +147,8 @@ class MemberWithdrawServiceTest {
                 Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now().plusHours(1),
+                ZonedDateTime.now(),
+                ZonedDateTime.now().plusHours(1),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -112,8 +112,8 @@ class RunningRecordServiceTest {
                 Duration.ofSeconds(10_000),
                 500,
                 new Pace(5, 30),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(0, 0, 0), new Coordinate(0, 0, 0)),
                 "start location",
                 "end location",
@@ -169,8 +169,8 @@ class RunningRecordServiceTest {
                 Duration.ofSeconds(10_000),
                 500,
                 new Pace(5, 30),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(0, 0, 0), new Coordinate(0, 0, 0)),
                 "start location",
                 "end location",
@@ -496,8 +496,8 @@ class RunningRecordServiceTest {
     private RunningRecord createRunningRecord(RunningRecordRequest request, Member member) {
         return RunningRecord.builder()
                 .member(member)
-                .startAt(request.startAt().atOffset(defaultZoneOffset))
-                .endAt(request.endAt().atOffset(defaultZoneOffset))
+                .startAt(request.startAt().atZone(defaultZoneOffset))
+                .endAt(request.endAt().atZone(defaultZoneOffset))
                 .emoji(request.emotion())
                 .startLocation(request.startLocation())
                 .endLocation(request.endLocation())

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Duration;
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,8 +67,8 @@ class ChallengeAchievementPercentageRepositoryImplTest {
                     Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                     1,
                     new Pace(5, 11),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now(),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now(),
                     List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                     "start location",
                     "end location",

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Duration;
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,8 +61,8 @@ public class ChallengeAchievementRepositoryImplTest {
                 Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/goalAchievement/GoalAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/goalAchievement/GoalAchievementRepositoryImplTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Duration;
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,8 +52,8 @@ public class GoalAchievementRepositoryImplTest {
                 runningDuration,
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",
@@ -126,8 +126,8 @@ public class GoalAchievementRepositoryImplTest {
                 runningDuration,
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",
@@ -139,8 +139,8 @@ public class GoalAchievementRepositoryImplTest {
                 runningDuration,
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -15,12 +15,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.time.*;
 import java.util.List;
 
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
@@ -59,8 +55,8 @@ class RunningRecordRepositoryImplTest {
                 Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",
@@ -83,7 +79,7 @@ class RunningRecordRepositoryImplTest {
                 .atStartOfDay(SERVER_TIMEZONE_ID)
                 .toOffsetDateTime();
         OffsetDateTime yesterday = todayMidnight.minusDays(1);
-        OffsetDateTime dayBeforeYesterday = yesterday.minusHours(1);
+        ZonedDateTime dayBeforeYesterday = yesterday.minusHours(1).toZonedDateTime();
         // 그제:2, 어제:4, 오늘:1개
         for (int i = 0; i < 7; i++) {
             RunningRecord runningRecord = new RunningRecord(
@@ -117,7 +113,7 @@ class RunningRecordRepositoryImplTest {
                 .atStartOfDay(SERVER_TIMEZONE_ID)
                 .toOffsetDateTime();
         OffsetDateTime yesterday = todayMidnight.minusDays(1);
-        OffsetDateTime dayBeforeYesterday = yesterday.minusHours(1);
+        ZonedDateTime dayBeforeYesterday = yesterday.minusHours(1).toZonedDateTime();
         // 그제:2, 어제:4, 오늘:1개
         for (int i = 0; i < 7; i++) {
             RunningRecord runningRecord = new RunningRecord(
@@ -161,9 +157,8 @@ class RunningRecordRepositoryImplTest {
     @Test
     void getTotalDistanceWithRunningRecords() {
         // given
-        OffsetDateTime todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
-                .atStartOfDay(SERVER_TIMEZONE_ID)
-                .toOffsetDateTime();
+        ZonedDateTime todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID).atStartOfDay(SERVER_TIMEZONE_ID);
+
         // 러닝 기록 저장
         for (int i = 0; i < 3; i++) {
             RunningRecord runningRecord = new RunningRecord(
@@ -205,8 +200,8 @@ class RunningRecordRepositoryImplTest {
                     Duration.ofHours(1),
                     1,
                     new Pace(5, 11),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now(),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now(),
                     List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                     "start location",
                     "end location",
@@ -260,8 +255,8 @@ class RunningRecordRepositoryImplTest {
                     Duration.ofHours(1),
                     1,
                     new Pace(5, 11),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now(),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now(),
                     List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                     "start location",
                     "end location",
@@ -316,8 +311,8 @@ class RunningRecordRepositoryImplTest {
                     Duration.ofHours(1),
                     1,
                     new Pace(5, 11),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now(),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now(),
                     List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                     "start location",
                     "end location",
@@ -357,11 +352,11 @@ class RunningRecordRepositoryImplTest {
     void getAvgDistance_WithRunningRecords() {
         // given
         ZoneOffset defaultZoneOffset = ZoneOffset.of("+09:00");
-        OffsetDateTime today = OffsetDateTime.now().toLocalDate().atStartOfDay().atOffset(defaultZoneOffset);
+        ZonedDateTime today = ZonedDateTime.now(defaultZoneOffset).toLocalDate().atStartOfDay(defaultZoneOffset);
 
         int day = today.get(DAY_OF_WEEK) - 1;
-        OffsetDateTime startDate = today.minusDays(day);
-        OffsetDateTime nextOfDndDate = startDate.plusDays(7);
+        ZonedDateTime startDate = today.minusDays(day);
+        ZonedDateTime nextOfDndDate = startDate.plusDays(7);
 
         // 러닝 기록 경계 값 위주로 저장(시작일 전날 1개, 시작일 1개, 종료일자로 1개, nextOfDndDate로 1개)
         // 시작일 전날 - 1km
@@ -423,7 +418,7 @@ class RunningRecordRepositoryImplTest {
 
         // when
         int avgResult = runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
-                savedMember.memberId(), startDate, nextOfDndDate);
+                savedMember.memberId(), startDate.toOffsetDateTime(), nextOfDndDate.toOffsetDateTime());
 
         // then
         assertThat(avgResult).isEqualTo(2000);
@@ -453,11 +448,11 @@ class RunningRecordRepositoryImplTest {
     void getAvgDuration_WithRunningRecords() {
         // given
         ZoneOffset defaultZoneOffset = ZoneOffset.of("+09:00");
-        OffsetDateTime today = OffsetDateTime.now().toLocalDate().atStartOfDay().atOffset(defaultZoneOffset);
+        ZonedDateTime today = ZonedDateTime.now(defaultZoneOffset).toLocalDate().atStartOfDay(defaultZoneOffset);
 
         int day = today.get(DAY_OF_WEEK) - 1;
-        OffsetDateTime startDate = today.minusDays(day);
-        OffsetDateTime nextOfDndDate = startDate.plusDays(7);
+        ZonedDateTime startDate = today.minusDays(day);
+        ZonedDateTime nextOfDndDate = startDate.plusDays(7);
 
         // 러닝 기록 경계 값 위주로 저장(시작일 전날 1개, 시작일 1개, 종료일자로 1개, nextOfDndDate로 1개)
         // 시작일 전날 - 1시간
@@ -519,7 +514,7 @@ class RunningRecordRepositoryImplTest {
 
         // when
         int avgResult = runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
-                savedMember.memberId(), startDate, nextOfDndDate);
+                savedMember.memberId(), startDate.toOffsetDateTime(), nextOfDndDate.toOffsetDateTime());
 
         // then
         assertThat(avgResult).isEqualTo(Duration.ofHours(2).toSeconds());

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,8 +92,8 @@ public class ScaleRepositoryImplTest {
                     Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                     1,
                     new Pace(5, 11),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now().plusHours(1),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now().plusHours(1),
                     List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                     "start location",
                     "end location",
@@ -123,8 +124,8 @@ public class ScaleRepositoryImplTest {
                 Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                 1,
                 new Pace(5, 11),
-                OffsetDateTime.now(),
-                OffsetDateTime.now().plusHours(1),
+                ZonedDateTime.now(),
+                ZonedDateTime.now().plusHours(1),
                 List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                 "start location",
                 "end location",
@@ -141,8 +142,8 @@ public class ScaleRepositoryImplTest {
                     Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
                     1,
                     new Pace(5, 11),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now().plusHours(1),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now().plusHours(1),
                     List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
                     "start location",
                     "end location",

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntityTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/jpa/running/entity/RunningRecordEntityTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,8 +29,8 @@ class RunningRecordEntityTest {
                 .duration(Duration.ofSeconds(100))
                 .calorie(1.0)
                 .averagePace(Pace.ofSeconds(100))
-                .startAt(OffsetDateTime.now())
-                .endAt(OffsetDateTime.now())
+                .startAt(ZonedDateTime.now())
+                .endAt(ZonedDateTime.now())
                 .route(List.of(new Coordinate(128.0, 36.0), new Coordinate(128.0, 37.0)))
                 .startLocation("start location")
                 .endLocation("end location")


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #242

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- RunningRecord startAt과 endAt 필드를 `OffsetDateTime`에서 `ZonedDateTime`으로 변경합니다.
- running_record 테이블에 timezone을 의미하는 `timezone_name` VARCHAR 컬럼을 추가합니다.
  - `+09:00`이나 `Asia/Seoul`을 저장해 timezone 정보에 맞게 시간을 ZonedDateTime 객체로 불러옵니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
