### PR TITLE
Refactor: OauthService.deleteAllDataAboutMember 메서드를 MemberWithdrawService 클래스로 분리

### DIFF
--- a/src/main/java/com/dnd/runus/application/member/MemberWithdrawService.java
+++ b/src/main/java/com/dnd/runus/application/member/MemberWithdrawService.java
@@ -1,0 +1,73 @@
+package com.dnd.runus.application.member;
+
+import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.member.SocialProfileRepository;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawService {
+
+    private final MemberRepository memberRepository;
+    private final SocialProfileRepository socialProfileRepository;
+    private final MemberLevelRepository memberLevelRepository;
+    private final BadgeAchievementRepository badgeAchievementRepository;
+    private final RunningRecordRepository runningRecordRepository;
+    private final ChallengeAchievementRepository challengeAchievementRepository;
+    private final GoalAchievementRepository goalAchievementRepository;
+    private final ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+    private final ScaleAchievementRepository scaleAchievementRepository;
+
+    @Transactional
+    public void deleteAllDataAboutMember(long memberId) {
+        Member member =
+                memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(Member.class, memberId));
+
+        memberLevelRepository.deleteByMemberId(member.memberId());
+        badgeAchievementRepository.deleteByMemberId(member.memberId());
+        scaleAchievementRepository.deleteByMemberId(member.memberId());
+        socialProfileRepository.deleteByMemberId(member.memberId());
+
+        // running_record 조회
+        List<RunningRecord> runningRecords = runningRecordRepository.findByMember(member);
+        if (runningRecords.isEmpty()) {
+            // running_record가 없으면 멤버 삭제 후 리턴
+            memberRepository.deleteById(member.memberId());
+            return;
+        }
+
+        // goal_achievement 삭제
+        goalAchievementRepository.deleteByRunningRecords(runningRecords);
+
+        // running_record로 challenge_achievement 조회
+        List<Long> challengeAchievementIds = challengeAchievementRepository.findIdsByRunningRecords(runningRecords);
+        // challenge_achievement가 존재하면 challenge_achievement_percentage, challenge_achievement 삭제
+        if (!challengeAchievementIds.isEmpty()) {
+            challengeAchievementPercentageRepository.deleteByChallengeAchievementIds(challengeAchievementIds);
+            challengeAchievementRepository.deleteByIds(challengeAchievementIds);
+        }
+
+        // running_record 삭제
+        runningRecordRepository.deleteByMemberId(member.memberId());
+
+        memberRepository.deleteById(member.memberId());
+
+        log.info("멤버 삭제 완료: memberId={}", member.memberId());
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
@@ -78,6 +78,5 @@ public class OauthController {
     @ResponseStatus(HttpStatus.OK)
     public void withdraw(@MemberId long memberId, @Valid @RequestBody WithdrawRequest request) {
         oauthService.revokeOauth(memberId, request);
-        oauthService.deleteAllDataAboutMember(memberId);
     }
 }

--- a/src/test/java/com/dnd/runus/application/member/MemberWithdrawServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/member/MemberWithdrawServiceTest.java
@@ -1,0 +1,180 @@
+package com.dnd.runus.application.member;
+
+import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentageRepository;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
+import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberLevelRepository;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.domain.member.SocialProfileRepository;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.global.constant.RunningEmoji;
+import com.dnd.runus.global.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class MemberWithdrawServiceTest {
+
+    @InjectMocks
+    private MemberWithdrawService memberWithdrawService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SocialProfileRepository socialProfileRepository;
+
+    @Mock
+    private MemberLevelRepository memberLevelRepository;
+
+    @Mock
+    private BadgeAchievementRepository badgeAchievementRepository;
+
+    @Mock
+    private RunningRecordRepository runningRecordRepository;
+
+    @Mock
+    private ChallengeAchievementRepository challengeAchievementRepository;
+
+    @Mock
+    private GoalAchievementRepository goalAchievementRepository;
+
+    @Mock
+    private ChallengeAchievementPercentageRepository challengeAchievementPercentageRepository;
+
+    @Mock
+    private ScaleAchievementRepository scaleAchievementRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member(MemberRole.USER, "nickname");
+    }
+
+    @DisplayName("회원 삭제: 회원이 존재하지 않으면 NotFoundException을 발생하한다.")
+    @Test
+    public void testDeleteAllDataAboutMember_MemberNotFound() {
+        given(memberRepository.findById(member.memberId())).willReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> memberWithdrawService.deleteAllDataAboutMember(member.memberId()));
+    }
+
+    @DisplayName("회원 삭제 : running_record 존재 X")
+    @Test
+    void testDeleteAllDataAboutMember_NoRunningRecords() {
+        // given
+        given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+        given(runningRecordRepository.findByMember(member)).willReturn(Collections.emptyList());
+
+        // when
+        memberWithdrawService.deleteAllDataAboutMember(member.memberId());
+
+        // then
+        then(memberLevelRepository).should().deleteByMemberId(member.memberId());
+        then(badgeAchievementRepository).should().deleteByMemberId(member.memberId());
+        then(scaleAchievementRepository).should().deleteByMemberId(member.memberId());
+        then(socialProfileRepository).should().deleteByMemberId(member.memberId());
+        then(memberRepository).should().deleteById(member.memberId());
+    }
+
+    @DisplayName("회원 삭제 : running_record 존재, challenge_achievement 존재 X")
+    @Test
+    void testDeleteAllDataAboutMember_WithRunningRecords_NoChallengeAchievement() {
+        // given
+        List<RunningRecord> runningRecords = List.of(new RunningRecord(
+                1L,
+                member,
+                1_100_000,
+                Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                1,
+                new Pace(5, 11),
+                OffsetDateTime.now(),
+                OffsetDateTime.now().plusHours(1),
+                List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                "start location",
+                "end location",
+                RunningEmoji.SOSO));
+
+        given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+        given(runningRecordRepository.findByMember(member)).willReturn(runningRecords);
+        given(challengeAchievementRepository.findIdsByRunningRecords(runningRecords))
+                .willReturn(Collections.emptyList());
+
+        // when
+        memberWithdrawService.deleteAllDataAboutMember(member.memberId());
+
+        // then
+        then(memberLevelRepository).should().deleteByMemberId(member.memberId());
+        then(badgeAchievementRepository).should().deleteByMemberId(member.memberId());
+        then(scaleAchievementRepository).should().deleteByMemberId(member.memberId());
+        then(socialProfileRepository).should().deleteByMemberId(member.memberId());
+        then(goalAchievementRepository).should().deleteByRunningRecords(runningRecords);
+        then(runningRecordRepository).should().deleteByMemberId(member.memberId());
+        then(memberRepository).should().deleteById(member.memberId());
+    }
+
+    @DisplayName("회원 삭제 : running_record, challenge_achievement 존재")
+    @Test
+    void testDeleteAllDataAboutMember_WithRunningRecords_WithChallengeAchievement() {
+        // given
+        List<RunningRecord> runningRecords = List.of(new RunningRecord(
+                1L,
+                member,
+                1_100_000,
+                Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                1,
+                new Pace(5, 11),
+                OffsetDateTime.now(),
+                OffsetDateTime.now().plusHours(1),
+                List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                "start location",
+                "end location",
+                RunningEmoji.SOSO));
+
+        List<Long> challengeAchievementIds = List.of(1L);
+
+        given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+        given(runningRecordRepository.findByMember(member)).willReturn(runningRecords);
+        given(challengeAchievementRepository.findIdsByRunningRecords(runningRecords))
+                .willReturn(challengeAchievementIds);
+
+        // when
+        memberWithdrawService.deleteAllDataAboutMember(member.memberId());
+
+        // then
+        then(memberLevelRepository).should().deleteByMemberId(member.memberId());
+        then(badgeAchievementRepository).should().deleteByMemberId(member.memberId());
+        then(scaleAchievementRepository).should().deleteByMemberId(member.memberId());
+        then(socialProfileRepository).should().deleteByMemberId(member.memberId());
+        then(goalAchievementRepository).should().deleteByRunningRecords(runningRecords);
+        then(challengeAchievementPercentageRepository)
+                .should()
+                .deleteByChallengeAchievementIds(challengeAchievementIds);
+        then(challengeAchievementRepository).should().deleteByIds(challengeAchievementIds);
+        then(runningRecordRepository).should().deleteByMemberId(member.memberId());
+        then(memberRepository).should().deleteById(member.memberId());
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #56 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `OauthService.deleteAllDataAboutMember()` 메서드를 `MemberWithdrawService` 클래스로 분리합니다.
- 기존에는 OauthController에서 revokeOauth() 메서드와 `deleteAllDataAboutMember()` 메서드를 호출합니다.
  - 트랜잭션을 분리하기 위함인데, 이를 spring event를 발생하도록 수정합니다.
- 테스트 코드 내부 변경 없이 테스트 파일만 분리합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
