### PR TITLE
Fix: running record 조회 시 challenge나 goal 성취도 같이 조회하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievement.java
@@ -15,4 +15,6 @@ public record ChallengeAchievement(
     public String description() {
         return isSuccess ? SUCCESS.getComment() : FAILURE.getComment();
     }
+
+    public record Status(long challengeAchievementId, Challenge challenge, boolean isSuccess) {}
 }

--- a/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/achievement/ChallengeAchievementRepository.java
@@ -3,12 +3,15 @@ package com.dnd.runus.domain.challenge.achievement;
 import com.dnd.runus.domain.running.RunningRecord;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChallengeAchievementRepository {
 
     ChallengeAchievement save(ChallengeAchievement challengeAchievement);
 
     List<Long> findIdsByRunningRecords(List<RunningRecord> runningRecords);
+
+    Optional<ChallengeAchievement.Status> findByRunningRecordId(long runningRecordId);
 
     void deleteByIds(List<Long> ids);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImpl.java
@@ -3,18 +3,21 @@ package com.dnd.runus.infrastructure.persistence.domain.challenge;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
 import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.infrastructure.persistence.jooq.challenge.JooqChallengeAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.challenge.JpaChallengeAchievementRepository;
 import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeAchievementEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class ChallengeAchievementRepositoryImpl implements ChallengeAchievementRepository {
 
     private final JpaChallengeAchievementRepository jpaChallengeAchievementRepository;
+    private final JooqChallengeAchievementRepository jooqChallengeAchievementRepository;
 
     @Override
     public ChallengeAchievement save(ChallengeAchievement challengeAchievement) {
@@ -31,6 +34,11 @@ public class ChallengeAchievementRepositoryImpl implements ChallengeAchievementR
                 .stream()
                 .map(ChallengeAchievementEntity::getId)
                 .toList();
+    }
+
+    @Override
+    public Optional<ChallengeAchievement.Status> findByRunningRecordId(long runningRecordId) {
+        return Optional.ofNullable(jooqChallengeAchievementRepository.findStatusByRunningRecordId(runningRecordId));
     }
 
     @Override

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeAchievementRepository.java
@@ -1,0 +1,41 @@
+package com.dnd.runus.infrastructure.persistence.jooq.challenge;
+
+import com.dnd.runus.domain.challenge.Challenge;
+import com.dnd.runus.domain.challenge.ChallengeType;
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import static com.dnd.runus.jooq.Tables.CHALLENGE;
+import static com.dnd.runus.jooq.Tables.CHALLENGE_ACHIEVEMENT;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqChallengeAchievementRepository {
+    private final DSLContext dsl;
+
+    public ChallengeAchievement.Status findStatusByRunningRecordId(long runningRecordId) {
+        return dsl.select(
+                        CHALLENGE_ACHIEVEMENT.ID,
+                        CHALLENGE_ACHIEVEMENT.SUCCESS_STATUS,
+                        CHALLENGE.ID,
+                        CHALLENGE.NAME,
+                        CHALLENGE.EXPECTED_TIME,
+                        CHALLENGE.IMAGE_URL,
+                        CHALLENGE.CHALLENGE_TYPE)
+                .from(CHALLENGE_ACHIEVEMENT)
+                .join(CHALLENGE)
+                .on(CHALLENGE_ACHIEVEMENT.CHALLENGE_ID.eq(CHALLENGE.ID))
+                .where(CHALLENGE_ACHIEVEMENT.RUNNING_RECORD_ID.eq(runningRecordId))
+                .fetchOne(record -> new ChallengeAchievement.Status(
+                        record.get(CHALLENGE_ACHIEVEMENT.ID, Long.class),
+                        new Challenge(
+                                record.get(CHALLENGE.ID, Long.class),
+                                record.get(CHALLENGE.NAME, String.class),
+                                record.get(CHALLENGE.EXPECTED_TIME, Integer.class),
+                                record.get(CHALLENGE.IMAGE_URL, String.class),
+                                ChallengeType.valueOf(record.get(CHALLENGE.CHALLENGE_TYPE, String.class))),
+                        record.get(CHALLENGE_ACHIEVEMENT.SUCCESS_STATUS)));
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeEntity.java
@@ -39,7 +39,7 @@ public class ChallengeEntity {
 
     public static ChallengeEntity from(Challenge challenge) {
         return ChallengeEntity.builder()
-                .id(challenge.challengeId())
+                .id(challenge.challengeId() == 0 ? null : challenge.challengeId())
                 .name(challenge.name())
                 .expectedTime(challenge.expectedTime())
                 .challengeType(challenge.challengeType())

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
@@ -63,6 +63,15 @@ public record RunningRecordQueryResponse(
         );
     }
 
+    public static RunningRecordQueryResponse of(RunningRecord runningRecord, ChallengeAchievement challengeAchievement, GoalAchievement goalAchievement) {
+        if (challengeAchievement != null) {
+            return of(runningRecord, challengeAchievement);
+        } else if (goalAchievement != null) {
+            return of(runningRecord, goalAchievement);
+        }
+        return from(runningRecord);
+    }
+
     private static RunningRecordQueryResponse buildResponse(RunningRecord runningRecord, ChallengeDto challenge, GoalResultDto goal, RunningAchievementMode achievementMode) {
         return new RunningRecordQueryResponse(
                 runningRecord.runningId(),

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -156,6 +156,46 @@ class RunningRecordServiceTest {
     }
 
     @Test
+    @DisplayName("러닝 기록 조회 - Challenge 모드의 러닝 기록 조회")
+    void getRunningRecord_challenge() {
+        // given
+        long memberId = 1;
+        long runningRecordId = 1;
+        Member member = new Member(memberId, MemberRole.USER, "nickname1", OffsetDateTime.now(), OffsetDateTime.now());
+        RunningRecord runningRecord = new RunningRecord(
+                1L,
+                member,
+                10_000,
+                Duration.ofSeconds(10_000),
+                500,
+                new Pace(5, 30),
+                OffsetDateTime.now(),
+                OffsetDateTime.now(),
+                List.of(new Coordinate(0, 0, 0), new Coordinate(0, 0, 0)),
+                "start location",
+                "end location",
+                RunningEmoji.VERY_GOOD);
+
+        ChallengeAchievement.Status challengeAchievementStatus =
+                new ChallengeAchievement.Status(1L, new Challenge(1L, "challenge", "image", ChallengeType.TODAY), true);
+
+        given(runningRecordRepository.findById(runningRecordId)).willReturn(Optional.of(runningRecord));
+        given(challengeAchievementRepository.findByRunningRecordId(runningRecordId))
+                .willReturn(Optional.of(challengeAchievementStatus));
+
+        // when
+        RunningRecordQueryResponse result = runningRecordService.getRunningRecord(memberId, runningRecordId);
+
+        // then
+        assertEquals(runningRecordId, result.runningRecordId());
+        assertEquals(runningRecord.emoji(), result.emotion());
+        assertEquals(
+                challengeAchievementStatus.challenge().name(),
+                result.challenge().title());
+        assertEquals(RunningAchievementMode.CHALLENGE, result.achievementMode());
+    }
+
+    @Test
     @DisplayName("CHALLENGE 모드의 러닝 기록 추가 요청시, challengeId에 해당하는 챌린지가 있을 경우, 정상적으로 러닝 기록이 추가된다.")
     void addRunningRecord_challenge() {
         // given


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #225 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- id로 running record 조회 시 challenge나 goal 성취도 같이 조회하도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- running_record, challenge, challenge_achievement, goal_achievement 테이블들을 Left Join으로 묶어 데이터를 가져오려고 했으나, challenge_achivement와 goal_achivement은 양립할 수 없는 옵셔널 관계에요
  - challenge가 있을 때 goal이 없고, goal이 있을 때는 challenge가 없는 구조
- 새로운 메서드를 추가하기 애매해서 기존 코드와 로직을 활용하여 필요한 데이터를 일관되게 가져오는 방식으로 구현했어요
  1. running_record 찾기
  2. challenge_achivement + challenge
    a. 챌린지 정보가 있다면 바로 반환
    b. 챌린지 정보가 없다면 goal_achivement를 찾기

left join 대신 이 방식이 적절할까요?
