### PR TITLE
Feat: 나의 뱃지 목록 조회 리파지토리 구현

### DIFF
--- a/src/main/java/com/dnd/runus/domain/badge/Badge.java
+++ b/src/main/java/com/dnd/runus/domain/badge/Badge.java
@@ -2,5 +2,8 @@ package com.dnd.runus.domain.badge;
 
 import com.dnd.runus.global.constant.BadgeType;
 
-public record Badge(
-        long badgeId, String name, String description, String imageUrl, BadgeType type, int requiredValue) {}
+public record Badge(long badgeId, String name, String description, String imageUrl, BadgeType type, int requiredValue) {
+    public Badge(long badgeId, String name, String imageUrl, BadgeType type) {
+        this(badgeId, name, null, imageUrl, type, 0);
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeRepository.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.runus.domain.badge;
+
+import java.util.List;
+
+public interface BadgeRepository {
+    List<BadgeWithAchieveStatusAndAchievedAt> findAllBadgesWithAchieveStatusByMemberId(long memberId);
+}

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeWithAchieveStatusAndAchievedAt.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeWithAchieveStatusAndAchievedAt.java
@@ -4,5 +4,8 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.OffsetDateTime;
 
-public record BadgeWithAchieveStatusAndAchievedAt(
-        @NotNull Badge badge, boolean isAchieved, OffsetDateTime achievedAt) {}
+public record BadgeWithAchieveStatusAndAchievedAt(@NotNull Badge badge, boolean isAchieved, OffsetDateTime achievedAt) {
+    public BadgeWithAchieveStatusAndAchievedAt(Badge badge, OffsetDateTime achievedAt) {
+        this(badge, achievedAt != null, achievedAt);
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeWithAchieveStatusAndAchievedAt.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeWithAchieveStatusAndAchievedAt.java
@@ -1,0 +1,8 @@
+package com.dnd.runus.domain.badge;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.OffsetDateTime;
+
+public record BadgeWithAchieveStatusAndAchievedAt(
+        @NotNull Badge badge, boolean isAchieved, OffsetDateTime achievedAt) {}

--- a/src/main/java/com/dnd/runus/global/constant/BadgeType.java
+++ b/src/main/java/com/dnd/runus/global/constant/BadgeType.java
@@ -1,6 +1,9 @@
 package com.dnd.runus.global.constant;
 
 public enum BadgeType {
-    RUNNING_COUNT,
+    STREAK,
     DISTANCE_METER,
+    PERSONAL_RECORD,
+    DURATION_SECONDS,
+    LEVEL,
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.dnd.runus.infrastructure.persistence.domain.badge;
+
+import com.dnd.runus.domain.badge.BadgeRepository;
+import com.dnd.runus.domain.badge.BadgeWithAchieveStatusAndAchievedAt;
+import com.dnd.runus.infrastructure.persistence.jooq.badge.JooqBadgeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BadgeRepositoryImpl implements BadgeRepository {
+    private final JooqBadgeRepository jooqBadgeRepository;
+
+    @Override
+    public List<BadgeWithAchieveStatusAndAchievedAt> findAllBadgesWithAchieveStatusByMemberId(long memberId) {
+        return jooqBadgeRepository.findAllBadgesWithAchieveStatusByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeRepository.java
@@ -1,0 +1,46 @@
+package com.dnd.runus.infrastructure.persistence.jooq.badge;
+
+import com.dnd.runus.domain.badge.Badge;
+import com.dnd.runus.domain.badge.BadgeWithAchieveStatusAndAchievedAt;
+import com.dnd.runus.global.constant.BadgeType;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static com.dnd.runus.jooq.Tables.BADGE;
+import static com.dnd.runus.jooq.Tables.BADGE_ACHIEVEMENT;
+
+@Repository
+@RequiredArgsConstructor
+public class JooqBadgeRepository {
+    private final DSLContext dsl;
+
+    public List<BadgeWithAchieveStatusAndAchievedAt> findAllBadgesWithAchieveStatusByMemberId(long memberId) {
+        return dsl.select(BADGE.ID, BADGE.NAME, BADGE.IMAGE_URL, BADGE.TYPE, BADGE_ACHIEVEMENT.CREATED_AT)
+                .from(BADGE)
+                .leftJoin(BADGE_ACHIEVEMENT)
+                .on(BADGE.ID.eq(BADGE_ACHIEVEMENT.BADGE_ID))
+                .and(BADGE_ACHIEVEMENT.MEMBER_ID.eq(memberId))
+                .fetch(new AllBadgesMapper());
+    }
+
+    private static class AllBadgesMapper implements RecordMapper<Record, BadgeWithAchieveStatusAndAchievedAt> {
+        @Override
+        public BadgeWithAchieveStatusAndAchievedAt map(Record record) {
+            OffsetDateTime achievedTime = record.get(BADGE_ACHIEVEMENT.CREATED_AT);
+            return new BadgeWithAchieveStatusAndAchievedAt(
+                    new Badge(
+                            record.get(BADGE.ID),
+                            record.get(BADGE.NAME),
+                            record.get(BADGE.IMAGE_URL),
+                            BadgeType.valueOf(record.get(BADGE.TYPE))),
+                    achievedTime != null,
+                    achievedTime);
+        }
+    }
+}

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeRepository.java
@@ -39,7 +39,6 @@ public class JooqBadgeRepository {
                             record.get(BADGE.NAME),
                             record.get(BADGE.IMAGE_URL),
                             BadgeType.valueOf(record.get(BADGE.TYPE))),
-                    achievedTime != null,
                     achievedTime);
         }
     }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeEntity.java
@@ -40,7 +40,7 @@ public class BadgeEntity {
 
     public static BadgeEntity from(Badge badge) {
         BadgeEntity badgeEntity = new BadgeEntity();
-        badgeEntity.id = badge.badgeId();
+        badgeEntity.id = badge.badgeId() == 0 ? null : badge.badgeId();
         badgeEntity.name = badge.name();
         badgeEntity.description = badge.description();
         badgeEntity.imageUrl = badge.imageUrl();

--- a/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
@@ -30,7 +30,7 @@ class BadgeServiceTest {
     @DisplayName("자신이 획득한 뱃지 전체 조회에 성공")
     void getAchievedBadges() {
         // given
-        Badge badge1 = new Badge(1L, "badge1", "description", "imageUrl1", BadgeType.RUNNING_COUNT, 100);
+        Badge badge1 = new Badge(1L, "badge1", "description", "imageUrl1", BadgeType.STREAK, 100);
         Badge badge2 = new Badge(2L, "badge2", "description", "imageUrl2", BadgeType.DISTANCE_METER, 1000);
 
         given(badgeAchievementRepository.findByMemberIdWithBadge(1L))

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeRepositoryTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.dnd.runus.infrastructure.persistence.domain.badge;
+
+import com.dnd.runus.domain.badge.Badge;
+import com.dnd.runus.domain.badge.BadgeAchievement;
+import com.dnd.runus.domain.badge.BadgeAchievementRepository;
+import com.dnd.runus.domain.badge.BadgeRepository;
+import com.dnd.runus.domain.badge.BadgeWithAchieveStatusAndAchievedAt;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.member.MemberRepository;
+import com.dnd.runus.global.constant.BadgeType;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
+import com.dnd.runus.infrastructure.persistence.jpa.badge.entity.BadgeEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+@RepositoryTest
+class BadgeRepositoryTest {
+    @Autowired
+    private BadgeRepository badgeRepository;
+
+    @Autowired
+    private BadgeAchievementRepository badgeAchievementRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Badge badge1;
+    private Badge badge2;
+
+    @BeforeEach
+    void setUp() {
+
+        // insert Badge test data
+        em.persist(BadgeEntity.from(new Badge(0, "badge1", "description1", "imageUrl", BadgeType.STREAK, 0)));
+        em.persist(BadgeEntity.from(new Badge(0, "badge2", "description2", "imageUrl", BadgeType.STREAK, 0)));
+        em.flush();
+
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+
+        CriteriaQuery<BadgeEntity> query = criteriaBuilder.createQuery(BadgeEntity.class);
+        List<BadgeEntity> selectAll =
+                em.createQuery(query.select(query.from(BadgeEntity.class))).getResultList();
+
+        for (BadgeEntity badgeEntity : selectAll) {
+            if (badgeEntity.getName().equals("badge1")) {
+                badge1 = badgeEntity.toDomain();
+            } else {
+                badge2 = badgeEntity.toDomain();
+            }
+        }
+    }
+
+    @DisplayName("모든 배지 리스트를 조회 한다. 사용자가 해당 배지를 성취했을 경우 isAchieved는 true를 반환한다.")
+    @Test
+    void findAllBadges() {
+        // given
+        Member member = memberRepository.save(new Member(MemberRole.USER, "member1"));
+        badgeAchievementRepository.save(new BadgeAchievement(badge1, member));
+
+        // when
+        List<BadgeWithAchieveStatusAndAchievedAt> allBadges =
+                badgeRepository.findAllBadgesWithAchieveStatusByMemberId(member.memberId());
+
+        // then
+        assertThat(allBadges.size()).isEqualTo(2);
+        assertThat(allBadges)
+                .extracting(o -> o.badge().badgeId(), BadgeWithAchieveStatusAndAchievedAt::isAchieved)
+                .containsExactlyInAnyOrder(tuple(badge1.badgeId(), true), tuple(badge2.badgeId(), false));
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #236 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 나의 뱃지 목록 조회 API를 위한 리파지토리를 구현합니다.
- 사용자의 뱃지 성취 여부, 뱃지의 카테고리 분류(배지 타입, 최신 획득한 배지)를 위해 left join을 사용해서 조회합니다.
- `BadgeType`의 `RUNNING_COUNT` 값을 연속이라는 의미를 명확하게 하기 위해 `STREAK`로 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
