### PR TITLE
Feat: 밤 버전 날씨 아이콘 추가

### DIFF
--- a/src/main/java/com/dnd/runus/global/constant/WeatherType.java
+++ b/src/main/java/com/dnd/runus/global/constant/WeatherType.java
@@ -8,27 +8,41 @@ import static lombok.AccessLevel.PACKAGE;
 @Getter
 @RequiredArgsConstructor(access = PACKAGE)
 public enum WeatherType {
-    CLEAR("매우 맑은 날", "러닝하기 최적의 날씨입니다! 적절한 수분섭취와 함께 달려보세요.", "https://d27big3ufowabi.cloudfront.net/weather/A1.png"),
+    CLEAR("매우 맑은 날", "러닝하기 최적의 날씨입니다! 적절한 수분섭취와 함께 달려보세요.", "https://d27big3ufowabi.cloudfront.net/weather/clear.png"),
+    CLEAR_NIGHT(
+            "매우 맑은 밤",
+            "러닝하기 최적의 날씨입니다! 적절한 수분섭취와 함께 달려보세요.",
+            "https://d27big3ufowabi.cloudfront.net/weather/clear-night.png"),
     CLOUDY(
             "조금 흐린 날",
             "러닝하기에 좋은 환경입니다. 적당한 속도로 천천히 몸을 풀며 달려보세요.",
-            "https://d27big3ufowabi.cloudfront.net/weather/A2.png"),
+            "https://d27big3ufowabi.cloudfront.net/weather/cloudy.png"),
+    CLOUDY_NIGHT(
+            "조금 흐린 밤",
+            "러닝하기에 좋은 환경입니다. 적당한 속도로 천천히 몸을 풀며 달려보세요.",
+            "https://d27big3ufowabi.cloudfront.net/weather/cloudy-night.png"),
     CLOUDY_MORE(
             "흐린 날",
             "기온이 낮아질 수 있으니 몸을 충분히 워밍업하고 체온유지에 신경써야해요. ",
-            "https://d27big3ufowabi.cloudfront.net/weather/A3.png"),
-    RAIN("비내리는 날", "빗물이 고인 곳이 많을 수 있으니 달리며 미끄러지지 않도록 조심하세요", "https://d27big3ufowabi.cloudfront.net/weather/A4.png"),
-    SNOW("눈 오는 날", "도로가 미끄러울 수 있으니, 러닝 시 주변 환경을 잘 살피고 조심하세요.", "https://d27big3ufowabi.cloudfront.net/weather/B1.png"),
-    FOG("안개 낀 날", "시야가 제한되므로 주의가 필요합니다. 익숙한 코스를 선택하세요.", "https://d27big3ufowabi.cloudfront.net/weather/B2.png"),
-    STORM("폭풍우 오는 날", "매우 위험하므로 야외 러닝은 피하고 실내에서의 대체 운동을 권장해요.", "https://d27big3ufowabi.cloudfront.net/weather/B3.png"),
+            "https://d27big3ufowabi.cloudfront.net/weather/cloudy-more.png"),
+    RAIN("비내리는 날", "빗물이 고인 곳이 많을 수 있으니 달리며 미끄러지지 않도록 조심하세요", "https://d27big3ufowabi.cloudfront.net/weather/rain.png"),
+    SNOW(
+            "눈 오는 날",
+            "도로가 미끄러울 수 있으니, 러닝 시 주변 환경을 잘 살피고 조심하세요.",
+            "https://d27big3ufowabi.cloudfront.net/weather/snow.png"),
+    FOG("안개 낀 날", "시야가 제한되므로 주의가 필요합니다. 익숙한 코스를 선택하세요.", "https://d27big3ufowabi.cloudfront.net/weather/fog.png"),
+    STORM(
+            "폭풍우 오는 날",
+            "매우 위험하므로 야외 러닝은 피하고 실내에서의 대체 운동을 권장해요.",
+            "https://d27big3ufowabi.cloudfront.net/weather/storm.png"),
     HEAT_WAVE(
             "매우 더운 날",
             "폭염주의보가 발효 중입니다.충분한 수분 섭취와, 열사병 증상이 느껴지면 즉시 러닝을 중단하세요.",
-            "https://d27big3ufowabi.cloudfront.net/weather/C1.png"),
+            "https://d27big3ufowabi.cloudfront.net/weather/heat-wave.png"),
     COLD_WAVE(
             "매우 추운 날",
             "한파주의보가 발효 중입니다. 러닝 전에 충분한 워밍업으로 근육을 풀어주세요. ",
-            "https://d27big3ufowabi.cloudfront.net/weather/C2.png"),
+            "https://d27big3ufowabi.cloudfront.net/weather/cold-wave.png"),
     ;
     private final String koreanName;
     private final String koreanDescription;

--- a/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherClient.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherClient.java
@@ -29,7 +29,7 @@ public class OpenweathermapWeatherClient implements WeatherClient {
         }
 
         return new WeatherInfo(
-                mapWeatherType(info.weather()[0].id()),
+                mapWeatherType(info.weather()[0].id(), info.isDay()),
                 info.main().feelsLike(),
                 info.main().tempMin(),
                 info.main().tempMax(),
@@ -37,26 +37,22 @@ public class OpenweathermapWeatherClient implements WeatherClient {
                 info.wind().speed());
     }
 
-    private WeatherType mapWeatherType(int weatherId) {
-        switch (weatherId / 100) {
-            case 2:
-                return WeatherType.STORM;
-            case 3, 5:
-                return WeatherType.RAIN;
-            case 6:
-                return WeatherType.SNOW;
-            case 7:
-                return WeatherType.FOG;
-            case 8:
+    private WeatherType mapWeatherType(int weatherId, boolean isDay) {
+        return switch (weatherId / 100) {
+            case 2 -> WeatherType.STORM;
+            case 3, 5 -> WeatherType.RAIN;
+            case 6 -> WeatherType.SNOW;
+            case 7 -> WeatherType.FOG;
+            case 8 -> {
                 if (weatherId == 800) {
-                    return WeatherType.CLEAR;
+                    yield isDay ? WeatherType.CLEAR : WeatherType.CLEAR_NIGHT;
                 } else if (weatherId == 801) {
-                    return WeatherType.CLOUDY;
+                    yield isDay ? WeatherType.CLOUDY : WeatherType.CLOUDY_NIGHT;
                 } else {
-                    return WeatherType.CLOUDY_MORE;
+                    yield WeatherType.CLOUDY_MORE;
                 }
-            default:
-                return WeatherType.CLOUDY_MORE;
-        }
+            }
+            default -> WeatherType.CLOUDY_MORE;
+        };
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherInfo.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherInfo.java
@@ -5,11 +5,17 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record OpenweathermapWeatherInfo(Weather[] weather, Main main, Wind wind) {
+public record OpenweathermapWeatherInfo(Weather[] weather, Main main, Wind wind, long dt, Sys sys) {
     record Weather(int id, String main, String description, String icon) {}
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     record Main(double temp, double feelsLike, double tempMin, double tempMax, double pressure, double humidity) {}
 
     record Wind(double speed, double deg, double gust) {}
+
+    record Sys(long sunrise, long sunset) {}
+
+    public boolean isDay() {
+        return dt > sys.sunrise && dt < sys.sunset;
+    }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClient.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/WeatherApiComWeatherClient.java
@@ -57,7 +57,7 @@ public class WeatherApiComWeatherClient implements WeatherClient {
                     history.forecast().forecastday().getFirst().day();
 
             return new WeatherInfo(
-                    mapWeatherType(current.current().condition().code()),
+                    mapWeatherType(current.current().condition().code(), current.isDay()),
                     current.current().feelslikeC(),
                     today.mintempC(),
                     today.maxtempC(),
@@ -70,10 +70,10 @@ public class WeatherApiComWeatherClient implements WeatherClient {
         }
     }
 
-    private WeatherType mapWeatherType(int weatherCode) {
+    private WeatherType mapWeatherType(int weatherCode, boolean isDay) {
         return switch (weatherCode) {
-            case 1000 -> WeatherType.CLEAR;
-            case 1003, 1006 -> WeatherType.CLOUDY;
+            case 1000 -> isDay ? WeatherType.CLEAR : WeatherType.CLEAR_NIGHT;
+            case 1003, 1006 -> isDay ? WeatherType.CLOUDY : WeatherType.CLOUDY_NIGHT;
             case 1087, 1273, 1276, 1279, 1282 -> WeatherType.STORM;
             case 1063, 1150, 1153, 1180, 1183, 1186, 1189, 1192, 1195, 1198, 1201, 1240, 1243, 1246 -> WeatherType.RAIN;
             case 1066, 1069, 1072, 1114, 1117, 1210, 1213, 1216, 1219, 1222, 1225, 1255, 1258, 1261, 1264 -> WeatherType

--- a/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/dto/WeatherapicomCurrent.java
+++ b/src/main/java/com/dnd/runus/infrastructure/weather/weatherapicom/dto/WeatherapicomCurrent.java
@@ -24,4 +24,8 @@ public record WeatherapicomCurrent(Current current) {
             throw new IllegalStateException("현재 날씨 정보를 가져올 수 없습니다.");
         }
     }
+
+    public boolean isDay() {
+        return current.isDay() == 1;
+    }
 }

--- a/src/test/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/weather/openweathermap/OpenweathermapWeatherHttpClientTest.java
@@ -1,7 +1,6 @@
 package com.dnd.runus.infrastructure.weather.openweathermap;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.http.Body;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +13,8 @@ import org.springframework.test.context.TestPropertySource;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @AutoConfigureWireMock(port = 0)
 @TestPropertySource(properties = {"weather.openweathermap.url=http://localhost:${wiremock.server.port}"})
@@ -45,46 +45,51 @@ class OpenweathermapWeatherHttpClientTest {
         double longitude = 126.9780;
         double latitude = 37.5665;
 
-        Body body = new Body("{\"weather\": ["
-                + "    {"
-                + "      \"id\": 800,"
-                + "      \"main\": \"Clear\","
-                + "      \"description\": \"clear sky\","
-                + "      \"icon\": \"01n\""
-                + "    }"
-                + "  ],"
-                + "  \"main\": {"
-                + "    \"temp\": 10.0,"
-                + "    \"feels_like\": 10.0,"
-                + "    \"temp_min\": 10.0,"
-                + "    \"temp_max\": 10.0,"
-                + "    \"pressure\": 1022,"
-                + "    \"humidity\": 30"
-                + "  },"
-                + "  \"wind\": {"
-                + "    \"speed\": 1.5,"
-                + "    \"deg\": 350"
-                + "  },"
-                + "  \"clouds\": {"
-                + "    \"all\": 0"
-                + "  },"
-                + "  \"dt\": 1609344000,"
-                + "  \"sys\": {"
-                + "    \"type\": 1,"
-                + "    \"id\": 8105,"
-                + "    \"country\": \"KR\","
-                + "    \"sunrise\": 1609280340,"
-                + "    \"sunset\": 1609314430"
-                + "  },"
-                + "  \"timezone\": 32400,"
-                + "  \"id\": 1835848,"
-                + "  \"name\": \"Seoul\","
-                + "  \"cod\": 200"
-                + "}");
+        String body =
+                """
+                {
+                  "weather": [
+                    {
+                      "id": 800,
+                      "main": "Clear",
+                      "description": "clear sky",
+                      "icon": "01n"
+                    }
+                  ],
+                  "main": {
+                    "temp": 10.0,
+                    "feels_like": 10.0,
+                    "temp_min": 10.0,
+                    "temp_max": 10.0,
+                    "pressure": 1022,
+                    "humidity": 30
+                  },
+                  "wind": {
+                    "speed": 1.5,
+                    "deg": 350
+                  },
+                  "clouds": {
+                    "all": 0
+                  },
+                  "dt": 1609344000,
+                  "sys": {
+                    "type": 1,
+                    "id": 8105,
+                    "country": "KR",
+                    "sunrise": 1609280340,
+                    "sunset": 1609314430
+                  },
+                  "timezone": 32400,
+                  "id": 1835848,
+                  "name": "Seoul",
+                  "cod": 200
+                }
+                """;
+
         stubFor(get(urlEqualTo("/data/2.5/weather?lon=126.978&lat=37.5665&units=metric&appid=test"))
                 .willReturn(aResponse()
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
-                        .withResponseBody(body)));
+                        .withBody(body)));
 
         // when
         OpenweathermapWeatherInfo weatherInfo =


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #251 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 밤 버전 날씨 아이콘을 추가합니다.
  - `CLEAR_NIGHT`, `CLOUDY_NIGHT`
- `WeatherClient` 구현 클래스들에서 `CLEAR`, `CLOUDY`인 경우 밤 버전도 반환하도록 합니다.
- `WeatherType` 이미지 url을 type 이름을 넣도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
