### PR TITLE
Fix: 0초인 Pace를 파싱이나 직렬화 할 때 0 대신 -를 사용하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -12,6 +12,8 @@ import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_
  * @param second
  */
 public record Pace(int minute, int second) {
+    private static final String EMPTY_PACE = "-’--”";
+
     public Pace {
         if (minute < 0 || second < 0 || second >= SECONDS_PER_MINUTE) {
             throw new IllegalArgumentException("분 또는 초는 0 이상 60 미만의 값이어야 합니다.");
@@ -27,12 +29,18 @@ public record Pace(int minute, int second) {
     @JsonCreator
     public static Pace from(String pace) {
         // e.g. 5'30" or 5’30”
+        if (pace.equals(EMPTY_PACE)) {
+            return new Pace(0, 0);
+        }
         String[] paceArr = pace.split("[’']|”");
         return new Pace(Integer.parseInt(paceArr[0]), Integer.parseInt(paceArr[1]));
     }
 
     @JsonValue
     public String getJsonValue() {
+        if (minute == 0 && second == 0) {
+            return EMPTY_PACE;
+        }
         return minute + "’" + String.format("%02d", second) + "”";
     }
 

--- a/src/test/java/com/dnd/runus/domain/common/PaceTest.java
+++ b/src/test/java/com/dnd/runus/domain/common/PaceTest.java
@@ -51,7 +51,7 @@ class PaceTest {
 
     private static Stream<Arguments> providePace() {
         return Stream.of(
-                Arguments.of(0, 0, "0’00”"),
+                Arguments.of(0, 0, "-’--”"),
                 Arguments.of(0, 30, "0’30”"),
                 Arguments.of(1, 1, "1’01”"),
                 Arguments.of(1, 5, "1’05”"),


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #255


## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Pace 객체를 파싱이나 직렬화할 때, `0’00”` 대신 `-’--”`을 사용하도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
