### PR TITLE
Fix: 평균페이스를 서버에서 계산하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_HOUR;
-import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_MINUTE;
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
 
 @Service
@@ -181,7 +180,7 @@ public class RunningRecordService {
                 .distanceMeter(request.runningData().distanceMeter())
                 .duration(request.runningData().runningTime())
                 .calorie(request.runningData().calorie())
-                .averagePace(calAvgPace(
+                .averagePace(Pace.from(
                         request.runningData().distanceMeter(),
                         request.runningData().runningTime()))
                 .route(route)
@@ -283,14 +282,5 @@ public class RunningRecordService {
 
         GoalAchievement goalAchievement = new GoalAchievement(runningRecord, goalMetricType, goalValue, isAchieved);
         return goalAchievementRepository.save(goalAchievement);
-    }
-
-    private Pace calAvgPace(int distanceMeter, Duration runningTime) {
-        double paceOfSecondPerMeter = (double) runningTime.toSeconds() / distanceMeter;
-        double paceOfMinutePerKilometer = (paceOfSecondPerMeter * METERS_IN_A_KILOMETER) / SECONDS_PER_MINUTE;
-        int minute = (int) Math.floor(paceOfMinutePerKilometer);
-        int second = (int) Math.floor((paceOfMinutePerKilometer - minute) * SECONDS_PER_MINUTE);
-
-        return new Pace(minute, second);
     }
 }

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -9,6 +9,7 @@ import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementPercentage
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRecord;
 import com.dnd.runus.domain.challenge.achievement.ChallengeAchievementRepository;
 import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.goalAchievement.GoalAchievement;
 import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
 import com.dnd.runus.domain.level.Level;
@@ -37,6 +38,7 @@ import java.util.List;
 
 import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_HOUR;
+import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_MINUTE;
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
 
 @Service
@@ -179,7 +181,9 @@ public class RunningRecordService {
                 .distanceMeter(request.runningData().distanceMeter())
                 .duration(request.runningData().runningTime())
                 .calorie(request.runningData().calorie())
-                .averagePace(request.runningData().averagePace())
+                .averagePace(calAvgPace(
+                        request.runningData().distanceMeter(),
+                        request.runningData().runningTime()))
                 .route(route)
                 .build());
 
@@ -279,5 +283,14 @@ public class RunningRecordService {
 
         GoalAchievement goalAchievement = new GoalAchievement(runningRecord, goalMetricType, goalValue, isAchieved);
         return goalAchievementRepository.save(goalAchievement);
+    }
+
+    private Pace calAvgPace(int distanceMeter, Duration runningTime) {
+        double paceOfSecondPerMeter = (double) runningTime.toSeconds() / distanceMeter;
+        double paceOfMinutePerKilometer = (paceOfSecondPerMeter * METERS_IN_A_KILOMETER) / SECONDS_PER_MINUTE;
+        int minute = (int) Math.floor(paceOfMinutePerKilometer);
+        int second = (int) Math.floor((paceOfMinutePerKilometer - minute) * SECONDS_PER_MINUTE);
+
+        return new Pace(minute, second);
     }
 }

--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -3,6 +3,9 @@ package com.dnd.runus.domain.common;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.Duration;
+
+import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_MINUTE;
 
 /**
@@ -23,6 +26,15 @@ public record Pace(int minute, int second) {
     public static Pace ofSeconds(int seconds) {
         int minute = seconds / SECONDS_PER_MINUTE;
         int second = seconds % SECONDS_PER_MINUTE;
+        return new Pace(minute, second);
+    }
+
+    public static Pace from(int distanceMeter, Duration runningTime) {
+        double paceOfSecondPerMeter = (double) runningTime.toSeconds() / distanceMeter;
+        double paceOfMinutePerKilometer = (paceOfSecondPerMeter * METERS_IN_A_KILOMETER) / SECONDS_PER_MINUTE;
+        int minute = (int) Math.floor(paceOfMinutePerKilometer);
+        int second = (int) Math.floor((paceOfMinutePerKilometer - minute) * SECONDS_PER_MINUTE);
+
         return new Pace(minute, second);
     }
 

--- a/src/main/java/com/dnd/runus/domain/common/Pace.java
+++ b/src/main/java/com/dnd/runus/domain/common/Pace.java
@@ -30,6 +30,10 @@ public record Pace(int minute, int second) {
     }
 
     public static Pace from(int distanceMeter, Duration runningTime) {
+        if (distanceMeter == 0 || runningTime.equals(Duration.ZERO)) {
+            return new Pace(0, 0);
+        }
+
         double paceOfSecondPerMeter = (double) runningTime.toSeconds() / distanceMeter;
         double paceOfMinutePerKilometer = (paceOfSecondPerMeter * METERS_IN_A_KILOMETER) / SECONDS_PER_MINUTE;
         int minute = (int) Math.floor(paceOfMinutePerKilometer);

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/RunningRecordMetricsDtoForAdd.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/RunningRecordMetricsDtoForAdd.java
@@ -1,0 +1,15 @@
+package com.dnd.runus.presentation.v1.running.dto;
+
+import com.dnd.runus.domain.common.Pace;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
+
+public record RunningRecordMetricsDtoForAdd(
+        @Schema(description = "멈춘 시간을 제외한 실제로 달린 시간", example = "123:45:56", format = "HH:mm:ss")
+        Duration runningTime,
+        @Schema(description = "달린 거리(m)", example = "1000")
+        int distanceMeter,
+        @Schema(description = "소모 칼로리(kcal)", example = "100")
+        double calorie
+) {
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/RunningRecordMetricsForAddDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/RunningRecordMetricsForAddDto.java
@@ -1,10 +1,9 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
-import com.dnd.runus.domain.common.Pace;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Duration;
 
-public record RunningRecordMetricsDtoForAdd(
+public record RunningRecordMetricsForAddDto(
         @Schema(description = "멈춘 시간을 제외한 실제로 달린 시간", example = "123:45:56", format = "HH:mm:ss")
         Duration runningTime,
         @Schema(description = "달린 거리(m)", example = "1000")

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordRequest.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordRequest.java
@@ -3,7 +3,7 @@ package com.dnd.runus.presentation.v1.running.dto.request;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.type.ErrorType;
-import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDtoForAdd;
+import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsForAddDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -34,7 +34,7 @@ public record RunningRecordRequest(
         @Schema(description = "목표 달성 모드, normal: 목표 설정X, challenge: 챌린지, goal: 개인 목표")
         RunningAchievementMode achievementMode,
         @NotNull
-        RunningRecordMetricsDtoForAdd runningData
+        RunningRecordMetricsForAddDto runningData
 ) {
     public RunningRecordRequest {
         if (startAt.isAfter(endAt)) {

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordRequest.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/request/RunningRecordRequest.java
@@ -3,7 +3,7 @@ package com.dnd.runus.presentation.v1.running.dto.request;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.type.ErrorType;
-import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDto;
+import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDtoForAdd;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -34,7 +34,7 @@ public record RunningRecordRequest(
         @Schema(description = "목표 달성 모드, normal: 목표 설정X, challenge: 챌린지, goal: 개인 목표")
         RunningAchievementMode achievementMode,
         @NotNull
-        RunningRecordMetricsDto runningData
+        RunningRecordMetricsDtoForAdd runningData
 ) {
     public RunningRecordRequest {
         if (startAt.isAfter(endAt)) {

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -393,6 +393,35 @@ class RunningRecordServiceTest {
     }
 
     @Test
+    @DisplayName("러닝의 페이스가 올바르게 계산되었는지 확인한다.")
+    void addRunningRecord_check_cal_pace() {
+        // given
+        RunningRecordRequest request = new RunningRecordRequest(
+                LocalDateTime.of(2021, 1, 1, 12, 10, 30),
+                LocalDateTime.of(2021, 1, 1, 13, 12, 10),
+                "start location",
+                "end location",
+                RunningEmoji.VERY_GOOD,
+                null,
+                null,
+                null,
+                RunningAchievementMode.NORMAL,
+                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(1_668), 3_280, 500.0));
+
+        Member member = new Member(MemberRole.USER, "nickname1");
+        RunningRecord expected = createRunningRecord(request, member);
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(runningRecordRepository.save(expected)).willReturn(expected);
+
+        // when
+        RunningRecordAddResultResponse response = runningRecordService.addRunningRecord(1L, request);
+
+        // then
+        assertEquals(new Pace(8, 28), response.runningData().averagePace());
+    }
+
+    @Test
     @DisplayName("이번 달, 달린 키로 수, 러닝 레벨을 조회한다.")
     void getMonthlyRunningSummery() {
         // given

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -41,8 +41,6 @@ import java.time.*;
 import java.util.List;
 import java.util.Optional;
 
-import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
-import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_MINUTE;
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
 import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -526,15 +524,6 @@ class RunningRecordServiceTest {
 
     private RunningRecord createRunningRecord(RunningRecordRequest request, Member member) {
 
-        RunningRecordMetricsForAddDto runningData = request.runningData();
-
-        double calPace = (double) runningData.runningTime().toSeconds()
-                / runningData.distanceMeter()
-                * METERS_IN_A_KILOMETER
-                / SECONDS_PER_MINUTE;
-        int minute = (int) Math.floor(calPace);
-        int second = (int) Math.floor((calPace - minute) * SECONDS_PER_MINUTE);
-
         return RunningRecord.builder()
                 .member(member)
                 .startAt(request.startAt().atZone(defaultZoneOffset))
@@ -545,7 +534,9 @@ class RunningRecordServiceTest {
                 .distanceMeter(request.runningData().distanceMeter())
                 .duration(request.runningData().runningTime())
                 .calorie(request.runningData().calorie())
-                .averagePace(new Pace(minute, second))
+                .averagePace(Pace.from(
+                        request.runningData().distanceMeter(),
+                        request.runningData().runningTime()))
                 .route(List.of(new Coordinate(0, 0, 0), new Coordinate(0, 0, 0)))
                 .build();
     }

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -21,7 +21,7 @@ import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.NotFoundException;
-import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsDtoForAdd;
+import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsForAddDto;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
@@ -211,7 +211,7 @@ class RunningRecordServiceTest {
                 null,
                 null,
                 RunningAchievementMode.CHALLENGE,
-                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(10_100), 10_000, 500.0));
+                new RunningRecordMetricsForAddDto(Duration.ofSeconds(10_100), 10_000, 500.0));
 
         Member member = new Member(MemberRole.USER, "nickname1");
         RunningRecord expected = createRunningRecord(request, member);
@@ -251,7 +251,7 @@ class RunningRecordServiceTest {
                 null,
                 1200,
                 RunningAchievementMode.GOAL,
-                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(10_100), 10_000, 500.0));
+                new RunningRecordMetricsForAddDto(Duration.ofSeconds(10_100), 10_000, 500.0));
 
         Member member = new Member(MemberRole.USER, "nickname1");
         RunningRecord expected = createRunningRecord(request, member);
@@ -290,7 +290,7 @@ class RunningRecordServiceTest {
                 null,
                 20_000,
                 RunningAchievementMode.GOAL,
-                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(10_100), 10_000, 500.0));
+                new RunningRecordMetricsForAddDto(Duration.ofSeconds(10_100), 10_000, 500.0));
 
         Member member = new Member(MemberRole.USER, "nickname1");
         RunningRecord expected = createRunningRecord(request, member);
@@ -329,7 +329,7 @@ class RunningRecordServiceTest {
                 5_000,
                 null,
                 RunningAchievementMode.GOAL,
-                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(10_100), 10_000, 500.0));
+                new RunningRecordMetricsForAddDto(Duration.ofSeconds(10_100), 10_000, 500.0));
 
         Member member = new Member(MemberRole.USER, "nickname1");
         RunningRecord expected = createRunningRecord(request, member);
@@ -368,7 +368,7 @@ class RunningRecordServiceTest {
                 10_000,
                 null,
                 RunningAchievementMode.GOAL,
-                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(10_100), 10_000, 500.0));
+                new RunningRecordMetricsForAddDto(Duration.ofSeconds(10_100), 10_000, 500.0));
 
         Member member = new Member(MemberRole.USER, "nickname1");
         RunningRecord expected = createRunningRecord(request, member);
@@ -406,7 +406,7 @@ class RunningRecordServiceTest {
                 null,
                 null,
                 RunningAchievementMode.NORMAL,
-                new RunningRecordMetricsDtoForAdd(Duration.ofSeconds(1_668), 3_280, 500.0));
+                new RunningRecordMetricsForAddDto(Duration.ofSeconds(1_668), 3_280, 500.0));
 
         Member member = new Member(MemberRole.USER, "nickname1");
         RunningRecord expected = createRunningRecord(request, member);
@@ -526,7 +526,7 @@ class RunningRecordServiceTest {
 
     private RunningRecord createRunningRecord(RunningRecordRequest request, Member member) {
 
-        RunningRecordMetricsDtoForAdd runningData = request.runningData();
+        RunningRecordMetricsForAddDto runningData = request.runningData();
 
         double calPace = (double) runningData.runningTime().toSeconds()
                 / runningData.distanceMeter()


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #257 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 평균페이스가 없는 `RunningRecordMetricsDtoForAdd.java` dto를 새로 추가 합니다. 
- 달린 거리와 시간으로 평균페이스를 계산하는 `calAvgPace` 함수를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
