### PR TITLE
Fix: 활동요약 응답 형식 변경

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -156,8 +156,7 @@ public class RunningRecordService {
 
         List<WeeklyRunningRatingDto> weeklyValues = Arrays.stream(DayOfWeek.values())
                 .map(day -> new WeeklyRunningRatingDto(
-                        day.getDisplayName(TextStyle.SHORT, Locale.KOREAN), 0.0 // 초기값으로 0.0 설정
-                        ))
+                        day.getDisplayName(TextStyle.SHORT, Locale.KOREAN), 0.0)) // 초기값으로 0.0 설정
                 .collect(Collectors.toList());
 
         // weeklyValues에 값 set

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -25,6 +25,7 @@ import com.dnd.runus.domain.scale.ScaleAchievement;
 import com.dnd.runus.domain.scale.ScaleAchievementRepository;
 import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.exception.NotFoundException;
+import com.dnd.runus.presentation.v1.running.dto.WeeklyRunningRatingDto;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
 import com.dnd.runus.presentation.v1.running.dto.response.*;
@@ -32,9 +33,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
 import java.time.*;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_HOUR;
@@ -149,10 +154,20 @@ public class RunningRecordService {
             conversionFactor = SECONDS_PER_HOUR;
         }
 
-        double[] weeklyValues = new double[7];
+        List<WeeklyRunningRatingDto> weeklyValues = Arrays.stream(DayOfWeek.values())
+                .map(day -> new WeeklyRunningRatingDto(
+                        day.getDisplayName(TextStyle.SHORT, Locale.KOREAN), 0.0 // 초기값으로 0.0 설정
+                        ))
+                .collect(Collectors.toList());
+
+        // weeklyValues에 값 set
         for (DailyRunningRecordSummary summary : weekSummaries) {
-            int dayOfWeek = summary.date().getDayOfWeek().getValue() - 1;
-            weeklyValues[dayOfWeek] = summary.sumValue() / conversionFactor;
+            DayOfWeek dayOfWeek = summary.date().getDayOfWeek();
+            weeklyValues.set(
+                    dayOfWeek.getValue() - 1,
+                    new WeeklyRunningRatingDto(
+                            dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN),
+                            summary.sumValue() / conversionFactor));
         }
 
         return new RunningRecordWeeklySummaryResponse(

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -88,9 +88,6 @@ public class RunningRecordController {
     - request 값이 DISTANCE 이면 이번주 요일별 달린 거리와, 지난주 달린 거리의 평균 값을 리턴합니다.<br>
     - request 값이 TIME 이면 이번주 요일별 달린 시간과, 지난주 달린 시간의 평균 값을 리턴합니다.<br>
     - request값과 상관 없이 공통의로 이번주 날짜(월요일 날짜 ~ 일요일 날짜)를 리턴합니다.<br>
-
-    이번 주 기록은 리스트형식으로(weeklyValues)로 리턴 되며 인덱스 값에 따른 데이터는 다음과 같습니다.<br>
-    - weeklyValues = [월요일 기록, 화요일 기록, .... , 일요일 기록]
     """)
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("weekly-summary")

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/WeeklyRunningRatingDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/WeeklyRunningRatingDto.java
@@ -1,7 +1,11 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record WeeklyRunningRatingDto(
+    @Schema(description = "요일", example = "월")
     String day,
+    @Schema(description = "거리는 km, 시간은 시간(Hour) 단위, 기록없으면 0")
     double rating
 ) {
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/WeeklyRunningRatingDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/WeeklyRunningRatingDto.java
@@ -1,0 +1,7 @@
+package com.dnd.runus.presentation.v1.running.dto;
+
+public record WeeklyRunningRatingDto(
+    String day,
+    double rating
+) {
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
@@ -6,7 +6,7 @@ import java.time.format.DateTimeFormatter;
 
 public record RunningRecordWeeklySummaryResponse(
     @Schema(description = "이번주 날짜", example = "2024.09.09 ~ 09.15")
-    String date,
+    String weeklyDate,
     @Schema(description = "요일 별 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
         + "월요일(index:0) ~ 일요일(index:6)의 값, 기록없는 날은 0을 리턴")
     double[] weeklyValues,
@@ -21,12 +21,7 @@ public record RunningRecordWeeklySummaryResponse(
     private static String dateFormat(LocalDate startDate, LocalDate endDate) {
         DateTimeFormatter yyyyMMddFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         String formattedStartDate = startDate.format(yyyyMMddFormatter);
-        String formattedEndDate = endDate.format(DateTimeFormatter.ofPattern("MM.dd"));
-        if (startDate.getYear() != endDate.getYear()) {
-            //연도가 다를 경우 yyyy.MM.dd ~ yyyy.MM.dd
-            formattedEndDate = endDate.format(yyyyMMddFormatter);
-        }
-        //yyyy.MM.dd ~ MM.dd 로 리턴
+        String formattedEndDate = endDate.format(yyyyMMddFormatter);
         return formattedStartDate + " ~ " + formattedEndDate;
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
@@ -1,20 +1,22 @@
 package com.dnd.runus.presentation.v1.running.dto.response;
 
+import com.dnd.runus.presentation.v1.running.dto.WeeklyRunningRatingDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 public record RunningRecordWeeklySummaryResponse(
     @Schema(description = "이번주 날짜", example = "2024.09.09 ~ 09.15")
     String weeklyDate,
     @Schema(description = "요일 별 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
         + "월요일(index:0) ~ 일요일(index:6)의 값, 기록없는 날은 0을 리턴")
-    double[] weeklyValues,
+    List<WeeklyRunningRatingDto> weeklyValues,
     @Schema(description = "지난주 평균 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
         + "지난주에 기록이 없으면 0을 리턴")
     double lastWeekAvgValue
 ) {
-    public RunningRecordWeeklySummaryResponse(LocalDate startDate, LocalDate endDate, double[] weeklyValues, double lastWeekAvgValue) {
+    public RunningRecordWeeklySummaryResponse(LocalDate startDate, LocalDate endDate, List<WeeklyRunningRatingDto> weeklyValues, double lastWeekAvgValue) {
         this(dateFormat(startDate, endDate), weeklyValues, lastWeekAvgValue);
     }
 

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordWeeklySummaryResponse.java
@@ -7,10 +7,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public record RunningRecordWeeklySummaryResponse(
-    @Schema(description = "이번주 날짜", example = "2024.09.09 ~ 09.15")
+    @Schema(description = "이번주 날짜", example = "2024.09.09 ~ 2024.09.15")
     String weeklyDate,
-    @Schema(description = "요일 별 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
-        + "월요일(index:0) ~ 일요일(index:6)의 값, 기록없는 날은 0을 리턴")
+    @Schema(description = "요일 별 활동 값<br>"
+        + "월 ~ 일 순서로 리턴")
     List<WeeklyRunningRatingDto> weeklyValues,
     @Schema(description = "지난주 평균 활동 값, 거리는 km, 시간은 시간(Hour) 단위<br>"
         + "지난주에 기록이 없으면 0을 리턴")

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -476,8 +476,6 @@ class RunningRecordServiceTest {
         RunningRecordWeeklySummaryResponse response = runningRecordService.getWeeklySummary(memberId, summaryType);
 
         // then
-        assertTrue(response.date().contains("~"));
-
         double[] weeklyValues = response.weeklyValues();
         int runningDateIdx = runningDate.get(DAY_OF_WEEK) - 1;
         assertThat(weeklyValues.length).isEqualTo(7);
@@ -513,8 +511,6 @@ class RunningRecordServiceTest {
         RunningRecordWeeklySummaryResponse response = runningRecordService.getWeeklySummary(memberId, summaryType);
 
         // then
-        assertTrue(response.date().contains("~"));
-
         double[] weeklyValues = response.weeklyValues();
         int runningDateIdx = runningDate.get(DAY_OF_WEEK) - 1;
         assertThat(weeklyValues.length).isEqualTo(7);

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -22,6 +22,7 @@ import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.NotFoundException;
 import com.dnd.runus.presentation.v1.running.dto.RunningRecordMetricsForAddDto;
+import com.dnd.runus.presentation.v1.running.dto.WeeklyRunningRatingDto;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
@@ -476,10 +477,10 @@ class RunningRecordServiceTest {
         RunningRecordWeeklySummaryResponse response = runningRecordService.getWeeklySummary(memberId, summaryType);
 
         // then
-        double[] weeklyValues = response.weeklyValues();
-        int runningDateIdx = runningDate.get(DAY_OF_WEEK) - 1;
-        assertThat(weeklyValues.length).isEqualTo(7);
-        assertThat(weeklyValues[runningDateIdx]).isEqualTo(3.567);
+        List<WeeklyRunningRatingDto> weeklyValues = response.weeklyValues();
+        WeeklyRunningRatingDto weeklyValue = weeklyValues.get(runningDate.get(DAY_OF_WEEK) - 1);
+        assertThat(weeklyValues.size()).isEqualTo(7);
+        assertThat(weeklyValue.rating()).isEqualTo(3.567);
         assertThat(response.lastWeekAvgValue()).isEqualTo(0.8);
     }
 
@@ -511,10 +512,10 @@ class RunningRecordServiceTest {
         RunningRecordWeeklySummaryResponse response = runningRecordService.getWeeklySummary(memberId, summaryType);
 
         // then
-        double[] weeklyValues = response.weeklyValues();
-        int runningDateIdx = runningDate.get(DAY_OF_WEEK) - 1;
-        assertThat(weeklyValues.length).isEqualTo(7);
-        assertThat(weeklyValues[runningDateIdx]).isEqualTo(expectedRunningDurationHour);
+        List<WeeklyRunningRatingDto> weeklyValues = response.weeklyValues();
+        WeeklyRunningRatingDto weeklyValue = weeklyValues.get(runningDate.get(DAY_OF_WEEK) - 1);
+        assertThat(weeklyValues.size()).isEqualTo(7);
+        assertThat(weeklyValue.rating()).isEqualTo(expectedRunningDurationHour);
         assertThat(response.lastWeekAvgValue()).isEqualTo(expectedRunningDurationHour);
     }
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #258 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 이번 주 날짜 응답의 형식을 `yyyy.MM.dd ~ MM.dd` 에서 `yyyy.MM.dd ~ yyyy.MM.dd`로 변경합니다.
- 요일 별 활동 값 응답을 double[] 에서 List<WeeklyRunningRatingDto>로 변경합니다.
    - 요일 별 활동 값을 나타내는 `WeeklyRunningRatingDto`를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
