### PR TITLE
Fix: JpaRunningRecordRepository.findByMemberIdAndStartAtBetween 메서드에서 member 테이블을 fetch join하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/JpaRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/running/JpaRunningRecordRepository.java
@@ -1,6 +1,7 @@
 package com.dnd.runus.infrastructure.persistence.jpa.running;
 
 import com.dnd.runus.infrastructure.persistence.jpa.running.entity.RunningRecordEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.OffsetDateTime;
@@ -10,10 +11,12 @@ public interface JpaRunningRecordRepository extends JpaRepository<RunningRecordE
 
     void deleteByMemberId(long memberId);
 
+    @EntityGraph(attributePaths = {"member"})
     List<RunningRecordEntity> findByMemberIdAndStartAtBetween(
             long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
     boolean existsByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
+    @EntityGraph(attributePaths = {"member"})
     List<RunningRecordEntity> findByMemberId(long memberId);
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #265 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존에는 러닝 기록 조회 시 마다 member 테이블을 다시 조회합니다. (N + 1 문제) 
- 이 PR에서는 `JpaRunningRecordRepository.findByMemberIdAndStartAtBetween()` 메서드에서 `member` 테이블을 fetch join하도록 수정합니다.


## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
