### PR TITLE
Feat: 로그 파일 저장 설정용  logback-spring.yml 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 ### etc ###
 .DS_Store
 
+### Project ###
 **/main/generated/
 
 **/resources/.env
@@ -46,3 +47,6 @@ out/
 !**/resources/.env.example
 
 **/resources/app/apple/*.p8
+
+### Logs ###
+logs/**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
 
     implementation(libs.resilience4j.spring.boot)
 
+    implementation(libs.bundles.logback)
+
     runtimeOnly(libs.micrometer.registry.prometheus)
 
     testImplementation(libs.bundles.spring.boot.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,9 @@ caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version
 micrometer-registry-prometheus = { group = "io.micrometer", name = "micrometer-registry-prometheus", version = "1.13.4" }
 resilience4j-spring-boot = { group = "io.github.resilience4j", name = "resilience4j-spring-boot3", version = "2.2.0" }
 
+logback-json-classic = { group = "ch.qos.logback.contrib", name = "logback-json-classic", version = "0.1.5" }
+logback-jackson = { group = "ch.qos.logback.contrib", name = "logback-jackson", version = "0.1.5" }
+
 [bundles]
 spring-boot = [
     "spring-boot-starter",
@@ -77,6 +80,11 @@ testcontainers = [
 jooq = [
     "jooq",
     "jooq-meta",
+]
+
+logback = [
+    "logback-json-classic",
+    "logback-jackson",
 ]
 
 [plugins]

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,45 @@
+<configuration>
+    <property resource="logback-variables.properties"/>
+
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <timestamp key="ToMonth" datePattern="yyyy-MM"/>
+    <timestamp key="ToDay" datePattern="yyyy-MM-dd"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%clr(%d{${LOG_DATEFORMAT_PATTERN}}){magenta} %clr([%thread]){blue} %clr(%-5level){} %clr([%logger{0}:%line]){cyan} : %msg %n
+            </pattern>
+        </layout>
+    </appender>
+
+    <appender name="FILE1" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <timestampFormat>${LOG_DATEFORMAT_PATTERN}</timestampFormat>
+
+                <timestampFormatTimezoneId>Asia/Seoul</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+
+        <file>${LOG_PATH}/${ToMonth}/${ToDay}_${LOG_FILE_NAME}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>
+                ${LOG_PATH}/%d{yyyy-MM}/%d{yyyy-MM-dd}_${LOG_FILE_NAME}_%i.log
+            </fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE1"/>
+    </root>
+
+</configuration>

--- a/src/main/resources/logback-variables.properties
+++ b/src/main/resources/logback-variables.properties
@@ -1,0 +1,3 @@
+LOG_PATH = ./logs
+LOG_FILE_NAME = runus
+LOG_DATEFORMAT_PATTERN = yyyy-MM-dd HH:mm:ss.SSSX


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #272 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 로그 파일 저장하기 위해 logback-spring.yml 파일을 추가합니다.
  - 기존에는 로그를 출력하고 따로 저장하지 않습니다.
  - 이 PR 작업으로 로그를 `logs` 경로 아래에 월별, 일별로 분리하여 로그를 저장합니다.
- 로그 파일 저장 경로인 `logs`는 gitignore 처리합니다.
- json 형태로 로그를 저장하기 위해 `logback-json-classic`, `logback-jackson` 의존성을 추가합니다.
## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 이 작업 이후로 운영서버에 Loki, Promtail 설정해둘께요!
