### PR TITLE
Fix: 뱃지 리스트 조회 API 응답형식 변경

### DIFF
--- a/src/main/java/com/dnd/runus/application/badge/BadgeService.java
+++ b/src/main/java/com/dnd/runus/application/badge/BadgeService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -42,10 +42,11 @@ public class BadgeService {
         List<BadgeWithAchieveStatusAndAchievedAt> allBadges =
                 badgeRepository.findAllBadgesWithAchieveStatusByMemberId(memberId);
 
-        OffsetDateTime oneWeekAgo = LocalDate.now(SERVER_TIMEZONE_ID)
+        LocalDateTime oneWeekAgo = LocalDate.now(SERVER_TIMEZONE_ID)
                 .atStartOfDay(SERVER_TIMEZONE_ID)
                 .toOffsetDateTime()
-                .minusDays(7);
+                .minusDays(7)
+                .toLocalDateTime();
 
         EnumMap<BadgeType, List<BadgeWithAchievedStatus>> badgeMap = allBadges.stream()
                 .collect(Collectors.groupingBy(
@@ -67,7 +68,7 @@ public class BadgeService {
                 badgeMap.getOrDefault(BadgeType.LEVEL, Collections.emptyList()));
     }
 
-    private boolean isRecent(BadgeWithAchieveStatusAndAchievedAt badge, OffsetDateTime criterionDate) {
+    private boolean isRecent(BadgeWithAchieveStatusAndAchievedAt badge, LocalDateTime criterionDate) {
         return badge.isAchieved() && criterionDate.isBefore(badge.achievedAt());
     }
 }

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeWithAchieveStatusAndAchievedAt.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeWithAchieveStatusAndAchievedAt.java
@@ -2,10 +2,11 @@ package com.dnd.runus.domain.badge;
 
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
-public record BadgeWithAchieveStatusAndAchievedAt(@NotNull Badge badge, boolean isAchieved, OffsetDateTime achievedAt) {
+public record BadgeWithAchieveStatusAndAchievedAt(@NotNull Badge badge, boolean isAchieved, LocalDateTime achievedAt) {
     public BadgeWithAchieveStatusAndAchievedAt(Badge badge, OffsetDateTime achievedAt) {
-        this(badge, achievedAt != null, achievedAt);
+        this(badge, achievedAt != null, achievedAt != null ? achievedAt.toLocalDateTime() : null);
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/badge/dto/response/AllBadgesListResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/badge/dto/response/AllBadgesListResponse.java
@@ -3,6 +3,7 @@ package com.dnd.runus.presentation.v1.badge.dto.response;
 import com.dnd.runus.domain.badge.Badge;
 import com.dnd.runus.domain.badge.BadgeWithAchieveStatusAndAchievedAt;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AllBadgesListResponse(
@@ -21,18 +22,20 @@ public record AllBadgesListResponse(
 ) {
     public record BadgeWithAchievedStatus(
         @Schema(description = "뱃지 id")
-        long id,
+        long badgeId,
         @Schema(description = "뱃지 이름")
         String name,
         @Schema(description = "뱃지 이미지 url")
         String imageUrl,
         @Schema(description = "뱃지 달성 여부")
-        boolean isAchieved
+        boolean isAchieved,
+        @Schema(description = "배지 달성 날짜")
+        LocalDateTime achievedAt
     ) {
         public static BadgeWithAchievedStatus from(
             BadgeWithAchieveStatusAndAchievedAt badgeWithAchievedStatus) {
             Badge badge = badgeWithAchievedStatus.badge();
-            return new BadgeWithAchievedStatus(badge.badgeId(), badge.name(), badge.imageUrl(), badgeWithAchievedStatus.isAchieved());
+            return new BadgeWithAchievedStatus(badge.badgeId(), badge.name(), badge.imageUrl(), badgeWithAchievedStatus.isAchieved(), badgeWithAchievedStatus.achievedAt());
         }
     }
 }

--- a/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -82,9 +83,7 @@ class BadgeServiceTest {
     void findAllBadges() {
         // given
         long memberId = 1L;
-        OffsetDateTime todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
-                .atStartOfDay(SERVER_TIMEZONE_ID)
-                .toOffsetDateTime();
+        LocalDateTime todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID).atTime(0, 0, 0);
         given(badgeRepository.findAllBadgesWithAchieveStatusByMemberId(memberId))
                 .willReturn(List.of(
                         new BadgeWithAchieveStatusAndAchievedAt(


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #274 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 뱃지 리스트 응답에 achievedAt(성취 날짜값을 추가합니다.)
- 사용자가 뱃지를 성취했으면 achievedAt에 성취한 날짜가, 아니면 null값을 리턴합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- `BadgeWithAchievedStatus`하고 `BadgeWithAchieveStatusAndAchievedAt`부분을 합칠 수 있을 것 같은데 해당 부분은 시간되면 추후 리팩터링 하겠습니다.
