### PR TITLE
Fix: 날짜가 바뀌면 새로운 날짜 파일에 log를 기록하도록 수정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,9 +3,6 @@
 
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
-    <timestamp key="ToMonth" datePattern="yyyy-MM"/>
-    <timestamp key="ToDay" datePattern="yyyy-MM-dd"/>
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%clr(%d{${LOG_DATEFORMAT_PATTERN}}){magenta} %clr([%thread]){blue} %clr(%-5level){} %clr([%logger{0}:%line]){cyan} : %msg %n
@@ -27,13 +24,10 @@
             </layout>
         </encoder>
 
-        <file>${LOG_PATH}/${ToMonth}/${ToDay}_${LOG_FILE_NAME}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>
-                ${LOG_PATH}/%d{yyyy-MM}/%d{yyyy-MM-dd}_${LOG_FILE_NAME}_%i.log
+                ${LOG_PATH}/%d{yyyy-MM}/%d{yyyy-MM-dd}_${LOG_FILE_NAME}.log
             </fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>30</maxHistory>
         </rollingPolicy>
     </appender>
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- x

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

새로운 날짜 로그 파일에 기록하지 않는 버그를 수정합니다.

[AS-IS]
- `SizeAndTimeBasedRollingPolicy`를 사용합니다.
- 이로 인해 날짜가 바뀌더라도 최대 용량에 미치지 않았으므로, 기존의 로그 파일에 계속 기록합니다.

[TO-BE]
-  `TimeBasedRollingPolicy` 로그 정책으로 변경합니다.
- 날짜가 바뀌면 새로운 날짜에 해당하는 로그 파일을 생성합니다. 그리고 새로운 로그 파일에 기록합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
