### PR TITLE
Fix: badge_achievement 테이블에 unique key 추가

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeAchievementEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/entity/BadgeAchievementEntity.java
@@ -12,6 +12,10 @@ import lombok.NoArgsConstructor;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Table(
+        uniqueConstraints = {
+            @UniqueConstraint(columnNames = {"badge_id", "member_id"}),
+        })
 @Getter
 @Entity(name = "badge_achievement")
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/resources/db/migration/V5.0.13__badge_achievement_unique.sql
+++ b/src/main/resources/db/migration/V5.0.13__badge_achievement_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE badge_achievement
+    ADD CONSTRAINT unique_badge_member UNIQUE (badge_id, member_id);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #279 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 배지 달성 테이블에 유니크 키(`badge_id`, `member_id`)를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
