### PR TITLE
Feat: badge_achievement 중복 무시하고 저장하는 함수 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/badge/BadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeAchievementRepository.java
@@ -11,5 +11,7 @@ public interface BadgeAchievementRepository {
 
     BadgeAchievement save(BadgeAchievement badgeAchievement);
 
+    void saveAllIgnoreDuplicated(List<BadgeAchievement> badgeAchievements);
+
     void deleteByMemberId(long memberId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImpl.java
@@ -36,6 +36,11 @@ public class BadgeAchievementRepositoryImpl implements BadgeAchievementRepositor
     }
 
     @Override
+    public void saveAllIgnoreDuplicated(List<BadgeAchievement> badgeAchievements) {
+        jooqBadgeAchievementRepository.saveAllIgnoreDuplicated(badgeAchievements);
+    }
+
+    @Override
     public void deleteByMemberId(long memberId) {
         jpaBadgeAchievementRepository.deleteByMemberId(memberId);
     }

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImplTest.java
@@ -8,12 +8,15 @@ import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.global.constant.BadgeType;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.infrastructure.persistence.annotation.RepositoryTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import com.dnd.runus.infrastructure.persistence.jpa.badge.entity.BadgeAchievementEntity;
+import com.dnd.runus.infrastructure.persistence.jpa.badge.entity.BadgeEntity;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @RepositoryTest
 class BadgeAchievementRepositoryImplTest {
@@ -46,5 +49,94 @@ class BadgeAchievementRepositoryImplTest {
         assertFalse(badgeAchievementRepository
                 .findById(badgeAchievement.badgeAchievementId())
                 .isPresent());
+    }
+
+    @Nested
+    @DisplayName("BadgeAchievement 저장 테스트")
+    class BadgeAchievementSaveTest {
+        @Autowired
+        private EntityManager entityManager;
+
+        private Badge badge1;
+        private Badge badge2;
+
+        private BadgeAchievement badgeAchievement1;
+        private BadgeAchievement badgeAchievement2;
+
+        @BeforeEach
+        void beforeEach() {
+            BadgeEntity badgeEntity1 =
+                    BadgeEntity.from(new Badge(0L, "testBadge1", "testBadge1", "tesUrl1", BadgeType.DISTANCE_METER, 0));
+            BadgeEntity badgeEntity2 =
+                    BadgeEntity.from(new Badge(0L, "testBadge2", "testBadge2", "tesUrl2", BadgeType.DISTANCE_METER, 2));
+
+            entityManager.persist(badgeEntity1);
+            entityManager.persist(badgeEntity2);
+
+            badge1 = badgeEntity1.toDomain();
+            badge2 = badgeEntity2.toDomain();
+
+            badgeAchievement1 = new BadgeAchievement(badge1, savedMember);
+            badgeAchievement2 = new BadgeAchievement(badge2, savedMember);
+
+            badgeAchievementRepository.save(badgeAchievement1);
+            badgeAchievementRepository.save(badgeAchievement2);
+        }
+
+        @AfterEach
+        void afterEach() {
+            entityManager.createQuery("delete from badge_achievement").executeUpdate();
+            entityManager.createQuery("delete from badge").executeUpdate();
+        }
+
+        @Test
+        @DisplayName("saveAllIgnoreDuplicated: 중복된 데이터가 없을 때 모든 데이터를 저장한다.")
+        void saveAllIgnoreDuplicated() {
+            // given
+            List<BadgeAchievement> badgeAchievements = List.of(badgeAchievement1, badgeAchievement2);
+
+            // when
+            badgeAchievementRepository.saveAllIgnoreDuplicated(badgeAchievements);
+
+            // then
+            List<BadgeAchievement> achievements = entityManager
+                    .createQuery("select ba from badge_achievement ba", BadgeAchievementEntity.class)
+                    .getResultList()
+                    .stream()
+                    .map(BadgeAchievementEntity::toDomain)
+                    .toList();
+
+            assertFalse(achievements.isEmpty());
+
+            assertEquals(2, achievements.size());
+            assertTrue(achievements.stream().anyMatch(ba -> ba.badge().badgeId() == badge1.badgeId()));
+            assertTrue(achievements.stream().anyMatch(ba -> ba.badge().badgeId() == badge2.badgeId()));
+        }
+
+        @Test
+        @DisplayName("saveAllIgnoreDuplicated: 중복된 데이터가 있을 때 중복된 데이터는 무시하고 저장한다.")
+        void saveAllIgnoreDuplicated_case_duplicated() {
+            // given
+            List<BadgeAchievement> badgeAchievements = List.of(badgeAchievement1, badgeAchievement2);
+
+            // when
+            // 저장 여러번 시도
+            badgeAchievementRepository.saveAllIgnoreDuplicated(badgeAchievements);
+            badgeAchievementRepository.saveAllIgnoreDuplicated(badgeAchievements);
+
+            // then
+            List<BadgeAchievement> achievements = entityManager
+                    .createQuery("select ba from badge_achievement ba", BadgeAchievementEntity.class)
+                    .getResultList()
+                    .stream()
+                    .map(BadgeAchievementEntity::toDomain)
+                    .toList();
+
+            assertFalse(achievements.isEmpty());
+
+            assertEquals(2, achievements.size());
+            assertTrue(achievements.stream().anyMatch(ba -> ba.badge().badgeId() == badge1.badgeId()));
+            assertTrue(achievements.stream().anyMatch(ba -> ba.badge().badgeId() == badge2.badgeId()));
+        }
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #281 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 중복되는 배지 달성 row를 제외하고 새로운 row만 추가하는 레포지터리 함수를 jOOQ로 추가합니다.
    - `onConflictDoNothing` 사용

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
