### PR TITLE
Feat: 회원가입 뱃지 부여 기능 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/badge/BadgeEventHandler.java
+++ b/src/main/java/com/dnd/runus/application/badge/BadgeEventHandler.java
@@ -1,0 +1,18 @@
+package com.dnd.runus.application.badge;
+
+import com.dnd.runus.application.member.event.SignupEvent;
+import com.dnd.runus.global.constant.BadgeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BadgeEventHandler {
+    private final BadgeService badgeService;
+
+    @EventListener
+    public void handleSignupEvent(SignupEvent signupEvent) {
+        badgeService.achieveBadge(signupEvent.member(), BadgeType.PERSONAL_RECORD, 0);
+    }
+}

--- a/src/main/java/com/dnd/runus/application/badge/BadgeService.java
+++ b/src/main/java/com/dnd/runus/application/badge/BadgeService.java
@@ -1,8 +1,7 @@
 package com.dnd.runus.application.badge;
 
-import com.dnd.runus.domain.badge.BadgeAchievementRepository;
-import com.dnd.runus.domain.badge.BadgeRepository;
-import com.dnd.runus.domain.badge.BadgeWithAchieveStatusAndAchievedAt;
+import com.dnd.runus.domain.badge.*;
+import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.global.constant.BadgeType;
 import com.dnd.runus.presentation.v1.badge.dto.response.AchievedBadgesResponse;
 import com.dnd.runus.presentation.v1.badge.dto.response.AllBadgesListResponse;
@@ -25,6 +24,19 @@ import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 public class BadgeService {
     private final BadgeAchievementRepository badgeAchievementRepository;
     private final BadgeRepository badgeRepository;
+
+    public void achieveBadge(Member member, BadgeType badgeType, int value) {
+        List<Badge> badges = badgeRepository.findByTypeAndRequiredValueLessThanEqual(badgeType, value);
+        if (badges.isEmpty()) {
+            return;
+        }
+
+        List<BadgeAchievement> badgeAchievements = badges.stream()
+                .map(badge -> new BadgeAchievement(badge, member))
+                .toList();
+
+        badgeAchievementRepository.saveAllIgnoreDuplicated(badgeAchievements);
+    }
 
     public AchievedBadgesResponse getAchievedBadges(long memberId) {
         return new AchievedBadgesResponse(badgeAchievementRepository.findByMemberIdWithBadge(memberId).stream()

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeRepository.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeRepository.java
@@ -1,7 +1,11 @@
 package com.dnd.runus.domain.badge;
 
+import com.dnd.runus.global.constant.BadgeType;
+
 import java.util.List;
 
 public interface BadgeRepository {
+    List<Badge> findByTypeAndRequiredValueLessThanEqual(BadgeType badgeType, int requiredValue);
+
     List<BadgeWithAchieveStatusAndAchievedAt> findAllBadgesWithAchieveStatusByMemberId(long memberId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeRepositoryImpl.java
@@ -1,8 +1,12 @@
 package com.dnd.runus.infrastructure.persistence.domain.badge;
 
+import com.dnd.runus.domain.badge.Badge;
 import com.dnd.runus.domain.badge.BadgeRepository;
 import com.dnd.runus.domain.badge.BadgeWithAchieveStatusAndAchievedAt;
+import com.dnd.runus.global.constant.BadgeType;
 import com.dnd.runus.infrastructure.persistence.jooq.badge.JooqBadgeRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.badge.JpaBadgeRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.badge.entity.BadgeEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +15,15 @@ import java.util.List;
 @Repository
 @RequiredArgsConstructor
 public class BadgeRepositoryImpl implements BadgeRepository {
+    private final JpaBadgeRepository jpaBadgeRepository;
     private final JooqBadgeRepository jooqBadgeRepository;
+
+    @Override
+    public List<Badge> findByTypeAndRequiredValueLessThanEqual(BadgeType badgeType, int requiredValue) {
+        return jpaBadgeRepository.findByTypeAndRequiredValueLessThanEqual(badgeType, requiredValue).stream()
+                .map(BadgeEntity::toDomain)
+                .toList();
+    }
 
     @Override
     public List<BadgeWithAchieveStatusAndAchievedAt> findAllBadgesWithAchieveStatusByMemberId(long memberId) {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
@@ -30,6 +30,7 @@ public class JooqBadgeAchievementRepository {
     }
 
     public void saveAllIgnoreDuplicated(List<BadgeAchievement> badgeAchievements) {
+        OffsetDateTime now = OffsetDateTime.now();
         dsl.batch(badgeAchievements.stream()
                         .map(badgeAchievement -> dsl.insertInto(BADGE_ACHIEVEMENT)
                                 .set(
@@ -38,8 +39,12 @@ public class JooqBadgeAchievementRepository {
                                 .set(
                                         BADGE_ACHIEVEMENT.MEMBER_ID,
                                         badgeAchievement.member().memberId())
-                                .set(BADGE_ACHIEVEMENT.CREATED_AT, badgeAchievement.createdAt())
-                                .set(BADGE_ACHIEVEMENT.UPDATED_AT, badgeAchievement.updatedAt())
+                                .set(
+                                        BADGE_ACHIEVEMENT.CREATED_AT,
+                                        badgeAchievement.createdAt() == null ? now : badgeAchievement.createdAt())
+                                .set(
+                                        BADGE_ACHIEVEMENT.UPDATED_AT,
+                                        badgeAchievement.updatedAt() == null ? now : badgeAchievement.updatedAt())
                                 .onConflictDoNothing())
                         .toList())
                 .execute();

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/JpaBadgeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/badge/JpaBadgeRepository.java
@@ -1,0 +1,11 @@
+package com.dnd.runus.infrastructure.persistence.jpa.badge;
+
+import com.dnd.runus.global.constant.BadgeType;
+import com.dnd.runus.infrastructure.persistence.jpa.badge.entity.BadgeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaBadgeRepository extends JpaRepository<BadgeEntity, Long> {
+    List<BadgeEntity> findByTypeAndRequiredValueLessThanEqual(BadgeType badgeType, int requiredValue);
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #45 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 회원가입 시, `BadgeType.PERSONAL_RECORD`이고 요구량이 0 이하인 `시작이 반이다` 뱃지를 부여합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 운영 디비에 현재 멤버들에 대해서 가입 시간에 맞게 해당 뱃지를 추가했어요!

```sql
INSERT INTO badge_achievement (badge_id, member_id, created_at, updated_at)
SELECT 
    3, -- 회원가입 뱃지 id
    m.id, 
    m.created_at, 
    NOW()
FROM 
    member m;
```
