### PR TITLE
Fix: 활동요약에서 저번주 평균값이 이번주 평균값으로 나오는 버그 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -144,13 +144,13 @@ public class RunningRecordService {
             weekSummaries = runningRecordRepository.findDailyDistancesMeterByDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
             avgValue = runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
-                    memberId, startWeekDate, nextOfEndWeekDate);
+                    memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7));
             conversionFactor = METERS_IN_A_KILOMETER;
         } else {
             weekSummaries = runningRecordRepository.findDailyDurationsSecByDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
             avgValue = runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
-                    memberId, startWeekDate, nextOfEndWeekDate);
+                    memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7));
             conversionFactor = SECONDS_PER_HOUR;
         }
 

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -470,7 +470,7 @@ class RunningRecordServiceTest {
                 .willReturn(List.of(new DailyRunningRecordSummary(runningDate.toLocalDate(), 3567)));
 
         given(runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
-                        memberId, startWeekDate, nextOfEndWeekDate))
+                        memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7)))
                 .willReturn(800);
 
         // when
@@ -505,7 +505,7 @@ class RunningRecordServiceTest {
                 .willReturn(List.of(new DailyRunningRecordSummary(runningDate.toLocalDate(), runningDurationSec)));
 
         given(runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
-                        memberId, startWeekDate, nextOfEndWeekDate))
+                        memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7)))
                 .willReturn(runningDurationSec);
 
         // when


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #284 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 활동요약에서 저번주 평균값이 이번주 평균값으로 나오는 버그를 수정합니다.
   - 평균 값 조회시 날짜 범위를 이번주에서 저번주로 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- X
