### PR TITLE
Fix: 나의 기록 뱃지 조회를 최신 기준으로 최대 3개 리턴하도록 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/badge/BadgeService.java
+++ b/src/main/java/com/dnd/runus/application/badge/BadgeService.java
@@ -39,13 +39,14 @@ public class BadgeService {
     }
 
     public AchievedBadgesResponse getAchievedBadges(long memberId) {
-        return new AchievedBadgesResponse(badgeAchievementRepository.findByMemberIdWithBadge(memberId).stream()
-                .map(badgeAchievement -> new AchievedBadgesResponse.AchievedBadge(
-                        badgeAchievement.badge().badgeId(),
-                        badgeAchievement.badge().name(),
-                        badgeAchievement.badge().imageUrl(),
-                        badgeAchievement.createdAt().toLocalDateTime()))
-                .toList());
+        return new AchievedBadgesResponse(
+                badgeAchievementRepository.findByMemberIdWithBadgeOrderByAchievedAtLimit(memberId, 3).stream()
+                        .map(badgeAchievement -> new AchievedBadgesResponse.AchievedBadge(
+                                badgeAchievement.badge().badgeId(),
+                                badgeAchievement.badge().name(),
+                                badgeAchievement.badge().imageUrl(),
+                                badgeAchievement.createdAt().toLocalDateTime()))
+                        .toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd/runus/domain/badge/BadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/domain/badge/BadgeAchievementRepository.java
@@ -7,7 +7,7 @@ public interface BadgeAchievementRepository {
 
     Optional<BadgeAchievement> findById(long id);
 
-    List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadge(long memberId);
+    List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadgeOrderByAchievedAtLimit(long memberId, int limit);
 
     BadgeAchievement save(BadgeAchievement badgeAchievement);
 

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/badge/BadgeAchievementRepositoryImpl.java
@@ -24,8 +24,8 @@ public class BadgeAchievementRepositoryImpl implements BadgeAchievementRepositor
     }
 
     @Override
-    public List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadge(long memberId) {
-        return jooqBadgeAchievementRepository.findByMemberIdWithBadge(memberId);
+    public List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadgeOrderByAchievedAtLimit(long memberId, int limit) {
+        return jooqBadgeAchievementRepository.findByMemberIdWithBadgeOrderByAchievedAtLimit(memberId, limit);
     }
 
     @Override

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
@@ -22,6 +22,8 @@ public class JooqBadgeAchievementRepository {
                 .join(BADGE)
                 .on(BADGE_ACHIEVEMENT.BADGE_ID.eq(BADGE.ID))
                 .where(BADGE_ACHIEVEMENT.MEMBER_ID.eq(memberId))
+                .orderBy(BADGE_ACHIEVEMENT.CREATED_AT.desc())
+                .limit(3)
                 .fetch(badge -> new BadgeAchievement.OnlyBadge(
                         badge.get(BADGE_ACHIEVEMENT.ID),
                         new JooqBadgeMapper().map(badge),

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/badge/JooqBadgeAchievementRepository.java
@@ -16,14 +16,14 @@ import static com.dnd.runus.jooq.Tables.BADGE_ACHIEVEMENT;
 public class JooqBadgeAchievementRepository {
     private final DSLContext dsl;
 
-    public List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadge(long memberId) {
+    public List<BadgeAchievement.OnlyBadge> findByMemberIdWithBadgeOrderByAchievedAtLimit(long memberId, int limit) {
         return dsl.select()
                 .from(BADGE_ACHIEVEMENT)
                 .join(BADGE)
                 .on(BADGE_ACHIEVEMENT.BADGE_ID.eq(BADGE.ID))
                 .where(BADGE_ACHIEVEMENT.MEMBER_ID.eq(memberId))
                 .orderBy(BADGE_ACHIEVEMENT.CREATED_AT.desc())
-                .limit(3)
+                .limit(limit)
                 .fetch(badge -> new BadgeAchievement.OnlyBadge(
                         badge.get(BADGE_ACHIEVEMENT.ID),
                         new JooqBadgeMapper().map(badge),

--- a/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/badge/BadgeServiceTest.java
@@ -46,7 +46,7 @@ class BadgeServiceTest {
         Badge badge1 = new Badge(1L, "badge1", "description", "imageUrl1", BadgeType.STREAK, 100);
         Badge badge2 = new Badge(2L, "badge2", "description", "imageUrl2", BadgeType.DISTANCE_METER, 1000);
 
-        given(badgeAchievementRepository.findByMemberIdWithBadge(1L))
+        given(badgeAchievementRepository.findByMemberIdWithBadgeOrderByAchievedAtLimit(1L, 3))
                 .willReturn(List.of(
                         new BadgeAchievement.OnlyBadge(1, badge1, OffsetDateTime.now(), OffsetDateTime.now()),
                         new BadgeAchievement.OnlyBadge(2, badge2, OffsetDateTime.now(), OffsetDateTime.now())));
@@ -68,7 +68,8 @@ class BadgeServiceTest {
     @DisplayName("자신이 획득한 뱃지가 없다면, 뱃지가 없는 응답을 반환한다.")
     void getAchievedBadges_Empty() {
         // given
-        given(badgeAchievementRepository.findByMemberIdWithBadge(1L)).willReturn(List.of());
+        given(badgeAchievementRepository.findByMemberIdWithBadgeOrderByAchievedAtLimit(1L, 3))
+                .willReturn(List.of());
 
         // when
         AchievedBadgesResponse achievedBadgesResponse = badgeService.getAchievedBadges(1L);


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #285 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `/api/v1/badges/me`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 나의 기록의 뱃지 리스트 조회 시, 획득한 날짜 최신 기준으로 최대 3개를 리턴하도록 변경합니다.
   - 조회 쿼리를 최신 기준으로 order by후 3개만 조회하도록 변경합니다.
   - BadgeAchievementRepository의 `findByMemberIdWithBadge`함수명을 좀 더 명확한 `findByMemberIdWithBadgeOrderByAchievedAtLimit`로 변경합니다. 

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
