### PR TITLE
Feat: RunningRecordAddedEvent 이벤트를 수신하여 러닝 뱃지 부여 로직 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/badge/BadgeEventHandler.java
+++ b/src/main/java/com/dnd/runus/application/badge/BadgeEventHandler.java
@@ -1,10 +1,17 @@
 package com.dnd.runus.application.badge;
 
 import com.dnd.runus.application.member.event.SignupEvent;
+import com.dnd.runus.application.running.event.RunningRecordAddedEvent;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.global.constant.BadgeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
 @Component
 @RequiredArgsConstructor
@@ -14,5 +21,17 @@ public class BadgeEventHandler {
     @EventListener
     public void handleSignupEvent(SignupEvent signupEvent) {
         badgeService.achieveBadge(signupEvent.member(), BadgeType.PERSONAL_RECORD, 0);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleRunningRecordAddedEvent(RunningRecordAddedEvent event) {
+        Member member = event.member();
+        RunningRecord runningRecord = event.runningRecord();
+
+        badgeService.achieveBadge(member, BadgeType.PERSONAL_RECORD, runningRecord.distanceMeter());
+
+        badgeService.achieveBadge(member, BadgeType.DISTANCE_METER, event.totalDistanceMeter());
+        badgeService.achieveBadge(member, BadgeType.DURATION_SECONDS, event.totalRunningSeconds());
     }
 }

--- a/src/main/java/com/dnd/runus/application/member/MemberEventHandler.java
+++ b/src/main/java/com/dnd/runus/application/member/MemberEventHandler.java
@@ -2,9 +2,15 @@ package com.dnd.runus.application.member;
 
 import com.dnd.runus.application.member.event.SignupEvent;
 import com.dnd.runus.application.member.event.WithdrawEvent;
+import com.dnd.runus.application.running.event.RunningRecordAddedEvent;
+import com.dnd.runus.domain.running.RunningRecord;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
 @Component
 @RequiredArgsConstructor
@@ -18,8 +24,17 @@ public class MemberEventHandler {
         memberService.initMember(signupEvent.member());
     }
 
+    @Async
     @EventListener
     public void handleWithdrawEvent(WithdrawEvent withdrawEvent) {
         memberWithdrawService.deleteAllDataAboutMember(withdrawEvent.memberId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleRunningAddEvent(RunningRecordAddedEvent runningRecordAddedEvent) {
+        RunningRecord runningRecord = runningRecordAddedEvent.runningRecord();
+
+        memberService.addExp(runningRecordAddedEvent.member().memberId(), runningRecord.distanceMeter());
     }
 }

--- a/src/main/java/com/dnd/runus/application/member/MemberService.java
+++ b/src/main/java/com/dnd/runus/application/member/MemberService.java
@@ -33,4 +33,9 @@ public class MemberService {
                 Level.formatLevelName(nextLevel),
                 Level.formatExp(memberCurrentLevel.level().expRangeEnd() - memberCurrentLevel.currentExp()));
     }
+
+    @Transactional
+    public void addExp(long memberId, int plusExp) {
+        memberLevelRepository.updateMemberLevel(memberId, plusExp);
+    }
 }

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -197,6 +197,10 @@ public class RunningRecordService {
                 .route(route)
                 .build());
 
+        OffsetDateTime now = OffsetDateTime.now();
+        int totalDistance = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId, BASE_TIME, now);
+        Duration totalDuration = runningRecordRepository.findTotalDurationByMemberId(memberId, BASE_TIME, now);
+
         eventPublisher.publishEvent(new RunningRecordAddedEvent(member, record, totalDistance, totalDuration));
 
         switch (request.achievementMode()) {

--- a/src/main/java/com/dnd/runus/application/running/event/RunningRecordAddedEvent.java
+++ b/src/main/java/com/dnd/runus/application/running/event/RunningRecordAddedEvent.java
@@ -1,0 +1,13 @@
+package com.dnd.runus.application.running.event;
+
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.running.RunningRecord;
+
+import java.time.Duration;
+
+public record RunningRecordAddedEvent(
+        Member member, RunningRecord runningRecord, int totalDistanceMeter, Duration totalDuration) {
+    public int totalRunningSeconds() {
+        return (int) totalDuration.getSeconds();
+    }
+}

--- a/src/main/java/com/dnd/runus/application/scale/ScaleEventHandler.java
+++ b/src/main/java/com/dnd/runus/application/scale/ScaleEventHandler.java
@@ -1,0 +1,24 @@
+package com.dnd.runus.application.scale;
+
+import com.dnd.runus.application.running.event.RunningRecordAddedEvent;
+import com.dnd.runus.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Component
+@RequiredArgsConstructor
+public class ScaleEventHandler {
+
+    private final ScaleService scaleService;
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleScaleEvent(RunningRecordAddedEvent runningRecordAddedEvent) {
+        Member member = runningRecordAddedEvent.member();
+        scaleService.saveScaleAchievements(member);
+    }
+}

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -2,6 +2,7 @@ package com.dnd.runus.domain.running;
 
 import com.dnd.runus.domain.member.Member;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,8 @@ public interface RunningRecordRepository {
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
     int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
+
+    Duration findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 
     List<RunningRecord> findByMember(Member member);
 

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.dnd.runus.infrastructure.persistence.jpa.running.entity.RunningRecord
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -55,6 +56,12 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     @Override
     public int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endtDate) {
         return jooqRunningRecordRepository.findTotalDistanceMeterByMemberId(memberId, startDate, endtDate);
+    }
+
+    @Override
+    public Duration findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
+        return Duration.ofSeconds(
+                jooqRunningRecordRepository.findTotalDurationByMemberId(memberId, startDate, endDate));
     }
 
     @Override

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -109,6 +109,19 @@ public class JooqRunningRecordRepository {
                 .fetch(new DailyRunningSummary());
     }
 
+    public long findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
+        Record1<Long> result = dsl.select(sum(RUNNING_RECORD.DURATION_SECONDS).cast(Long.class))
+                .from(RUNNING_RECORD)
+                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .and(RUNNING_RECORD.START_AT.ge(startDate))
+                .and(RUNNING_RECORD.START_AT.lt(nextDateOfEndDate))
+                .fetchOne();
+        if (result != null && result.value1() != null) {
+            return result.value1();
+        }
+        return 0;
+    }
+
     private static class DailyRunningSummary implements RecordMapper<Record, DailyRunningRecordSummary> {
         @Override
         public DailyRunningRecordSummary map(Record record) {

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -16,8 +16,6 @@ import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.DailyRunningRecordSummary;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
-import com.dnd.runus.domain.scale.ScaleAchievementRepository;
-import com.dnd.runus.domain.scale.ScaleRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.NotFoundException;
@@ -37,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.*;
 import java.util.List;
@@ -77,10 +76,7 @@ class RunningRecordServiceTest {
     private GoalAchievementRepository goalAchievementRepository;
 
     @Mock
-    private ScaleRepository scaleRepository;
-
-    @Mock
-    private ScaleAchievementRepository scaleAchievementRepository;
+    private ApplicationEventPublisher eventPublisher;
 
     private final ZoneOffset defaultZoneOffset = ZoneOffset.of("+9");
 
@@ -94,8 +90,7 @@ class RunningRecordServiceTest {
                 challengeAchievementRepository,
                 percentageValuesRepository,
                 goalAchievementRepository,
-                scaleRepository,
-                scaleAchievementRepository,
+                eventPublisher,
                 defaultZoneOffset);
     }
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #289 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 러닝 기록 추가 시, `RunningRecordAddedEvent` 이벤트를 발생하도록 변경합니다.
- `RunningRecordAddedEvent` 이벤트를 수신받는 Listener들을 추가합니다.
  - `BadgeEventHandler`: 개인기록(첫 러닝), 거리, 시간에 따른 뱃지 부여
  - `MemberEventHandler`: 러닝한 거리에 따라 레벨 경험치 추가
  - `ScaleEventHandler`: 달성한 거리 목표들 추가

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
