### PR TITLE
Feat: 챌린지 랜덤 기능 구현

### DIFF
--- a/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
+++ b/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
@@ -8,7 +8,10 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 
@@ -26,15 +29,22 @@ public class ChallengeService {
                 .toOffsetDateTime();
         OffsetDateTime yesterday = todayMidnight.minusDays(1);
 
+        List<ChallengesResponse> challengesResponses;
         // 어제 기록이 없으면
         if (!runningRecordRepository.hasByMemberIdAndStartAtBetween(memberId, yesterday, todayMidnight)) {
-            return challengeRepository.findAllIsNotDefeatYesterday().stream()
+            challengesResponses = challengeRepository.findAllIsNotDefeatYesterday().stream()
                     .map(ChallengesResponse::from)
-                    .toList();
+                    .collect(Collectors.toList());
+        } else {
+            challengesResponses = challengeRepository.findAllChallenges().stream()
+                    .map(ChallengesResponse::from)
+                    .collect(Collectors.toList());
         }
 
-        return challengeRepository.findAllChallenges().stream()
-                .map(ChallengesResponse::from)
-                .toList();
+        // 랜덤으로 2개 리턴
+        Random randomWithSeed = new Random(todayMidnight.toEpochSecond());
+        Collections.shuffle(challengesResponses, randomWithSeed);
+
+        return challengesResponses.subList(0, 2);
     }
 }

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-class ChallengeDataServiceTest {
+class ChallengeServiceTest {
 
     @Mock
     private RunningRecordRepository runningRecordRepository;

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -18,7 +18,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,7 +44,7 @@ class ChallengeServiceTest {
         member = new Member(MemberRole.USER, "nickname");
     }
 
-    @DisplayName("어제 기록이 있는경우 챌린지 리스트 조회 : 챌린지 name에 '어제'값이 포함한 값이 있어야함")
+    @DisplayName("어제 기록이 있는경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
     @Test
     void getChallengesWithYesterdayRecords() {
         // given
@@ -65,10 +65,10 @@ class ChallengeServiceTest {
         List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
 
         // then
-        assertTrue(challenges.stream().anyMatch(c -> c.title().contains("어제")));
+        assertThat(challenges.size()).isEqualTo(2);
     }
 
-    @DisplayName("어제 기록이 없는 경우 챌린지 리스트 조회 : 챌린지 name에 '어제'값이 포함한 값이 없어야함")
+    @DisplayName("어제 기록이 없는 경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
     @Test
     void getChallengesWithoutYesterdayRecords() {
         // given
@@ -85,6 +85,6 @@ class ChallengeServiceTest {
         List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
 
         // then
-        assertTrue(challenges.stream().noneMatch(c -> c.title().contains("어제")));
+        assertThat(challenges.size()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #290 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 사용자의 어제의 러닝 기록 유무에 따라 챌린지 리스트를 다르게 조회합니다.
- 조회한 리스트를 오늘의 날짜(자정)의 값을 seed로 설정하고 리스트를 shuffle합니다.
- shuffle한 리스트의 인덱스가 0,1인 값을 리턴합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- key 값으로 (날짜 + 어제 러닝 기록 유무)로해서 캐시사용하는 것 어떻게 생각하시나요? 자정에 캐시를 갱신하도록 하고, 사용자가 챌린지 값을 요청할 때 사용자가 어제 러닝 기록 유무만 확인하고 캐싱하는 것 어떻게 생각하시나요?? 굳이 캐싱이 필요할까 싶기도 하는데 재원님은 어떻게 생각하시나요?
- 만약 캐시를 적용하게 된다면 우선 해당 pr 머지하고, 적용하는 것으로 진행하면 좋을 것 같습니다.
- 그리고 지금은 챌린지 데이터가 적어서 Collections.shuffle을 사용했는데 추후 데이터가 늘어날 가능성이 적긴하지만, 데이터가 많아 진다면 성능 이슈가 발생할 것 같아서 추후 이 부분도 좀 고민해봐야 될 것 같아요!
