### PR TITLE
Refactor: 러닝 레코드 Repository 리팩터링

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -140,7 +140,7 @@ public class RunningRecordService {
         if (summaryType.equals(RunningRecordWeeklySummaryType.DISTANCE)) {
             weekSummaries = runningRecordRepository.findDailyDistancesMeterByDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
-            avgValue = runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
+            avgValue = runningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
                     memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7));
             conversionFactor = METERS_IN_A_KILOMETER;
         } else {

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -198,7 +198,8 @@ public class RunningRecordService {
                 .build());
 
         OffsetDateTime now = OffsetDateTime.now();
-        int totalDistance = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId, BASE_TIME, now);
+        int totalDistance =
+                runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, BASE_TIME, now);
         Duration totalDuration = runningRecordRepository.findTotalDurationByMemberId(memberId, BASE_TIME, now);
 
         eventPublisher.publishEvent(new RunningRecordAddedEvent(member, record, totalDistance, totalDuration));
@@ -226,7 +227,7 @@ public class RunningRecordService {
 
         int monthValue = startDateOfMonth.getMonthValue();
 
-        int monthlyTotalDistance = runningRecordRepository.findTotalDistanceMeterByMemberId(
+        int monthlyTotalDistance = runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(
                 memberId, startDateOfMonth, startDateOfNextMonth);
 
         MemberLevel.Current currentMemberLevel = memberLevelRepository.findByMemberIdWithLevel(memberId);

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -198,8 +198,7 @@ public class RunningRecordService {
                 .build());
 
         OffsetDateTime now = OffsetDateTime.now();
-        int totalDistance =
-                runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, BASE_TIME, now);
+        int totalDistance = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId);
         Duration totalDuration = runningRecordRepository.findTotalDurationByMemberId(memberId, BASE_TIME, now);
 
         eventPublisher.publishEvent(new RunningRecordAddedEvent(member, record, totalDistance, totalDuration));

--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -138,15 +138,15 @@ public class RunningRecordService {
         double conversionFactor;
 
         if (summaryType.equals(RunningRecordWeeklySummaryType.DISTANCE)) {
-            weekSummaries = runningRecordRepository.findDailyDistancesMeterByDateRange(
+            weekSummaries = runningRecordRepository.findDailyDistancesMeterWithDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
             avgValue = runningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
                     memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7));
             conversionFactor = METERS_IN_A_KILOMETER;
         } else {
-            weekSummaries = runningRecordRepository.findDailyDurationsSecByDateRange(
+            weekSummaries = runningRecordRepository.findDailyDurationsSecWithDateRange(
                     memberId, startWeekDate, nextOfEndWeekDate);
-            avgValue = runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
+            avgValue = runningRecordRepository.findAvgDurationSecByMemberIdWithDateRange(
                     memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7));
             conversionFactor = SECONDS_PER_HOUR;
         }

--- a/src/main/java/com/dnd/runus/application/scale/ScaleService.java
+++ b/src/main/java/com/dnd/runus/application/scale/ScaleService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -71,10 +70,7 @@ public class ScaleService {
     private ScaleCoursesResponse.CurrentCourse calculateCurrentScaleLeftMeter(
             List<ScaleAchievementLog> scaleAchievementLogs, long memberId) {
 
-        OffsetDateTime now = OffsetDateTime.now();
-        OffsetDateTime start = OffsetDateTime.of(LocalDate.of(1, 1, 1).atStartOfDay(), now.getOffset());
-        int memberRunMeterSum =
-                runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, start, now);
+        int memberRunMeterSum = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId);
 
         ScaleAchievementLog currentScale = scaleAchievementLogs.stream()
                 .filter(log -> log.achievedDate() == null)

--- a/src/main/java/com/dnd/runus/application/scale/ScaleService.java
+++ b/src/main/java/com/dnd/runus/application/scale/ScaleService.java
@@ -73,7 +73,8 @@ public class ScaleService {
 
         OffsetDateTime now = OffsetDateTime.now();
         OffsetDateTime start = OffsetDateTime.of(LocalDate.of(1, 1, 1).atStartOfDay(), now.getOffset());
-        int memberRunMeterSum = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId, start, now);
+        int memberRunMeterSum =
+                runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, start, now);
 
         ScaleAchievementLog currentScale = scaleAchievementLogs.stream()
                 .filter(log -> log.achievedDate() == null)

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -10,14 +10,8 @@ import java.util.Optional;
 public interface RunningRecordRepository {
     Optional<RunningRecord> findById(long runningRecordId);
 
-    RunningRecord save(RunningRecord runningRecord);
-
-    void deleteByMemberId(long memberId);
-
     List<RunningRecord> findByMemberIdAndStartAtBetween(
             long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
-
-    boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
     int findTotalDistanceMeterByMemberIdWithRangeDate(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 
@@ -31,9 +25,15 @@ public interface RunningRecordRepository {
     List<DailyRunningRecordSummary> findDailyDurationsSecByDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 
-    int findAvgDistanceMeterByMemberIdAndDateRange(
+    int findAvgDistanceMeterByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 
     int findAvgDurationSecByMemberIdAndDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
+
+    boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
+
+    RunningRecord save(RunningRecord runningRecord);
+
+    void deleteByMemberId(long memberId);
 }

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -19,7 +19,7 @@ public interface RunningRecordRepository {
 
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
-    int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
+    int findTotalDistanceMeterByMemberIdWithRangeDate(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 
     Duration findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -13,11 +13,11 @@ public interface RunningRecordRepository {
     List<RunningRecord> findByMemberIdAndStartAtBetween(
             long memberId, OffsetDateTime startTime, OffsetDateTime endTime);
 
+    List<RunningRecord> findByMember(Member member);
+
     int findTotalDistanceMeterByMemberIdWithRangeDate(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 
     Duration findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
-
-    List<RunningRecord> findByMember(Member member);
 
     List<DailyRunningRecordSummary> findDailyDistancesMeterWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -19,16 +19,16 @@ public interface RunningRecordRepository {
 
     List<RunningRecord> findByMember(Member member);
 
-    List<DailyRunningRecordSummary> findDailyDistancesMeterByDateRange(
+    List<DailyRunningRecordSummary> findDailyDistancesMeterWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 
-    List<DailyRunningRecordSummary> findDailyDurationsSecByDateRange(
+    List<DailyRunningRecordSummary> findDailyDurationsSecWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 
     int findAvgDistanceMeterByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 
-    int findAvgDurationSecByMemberIdAndDateRange(
+    int findAvgDurationSecByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate);
 
     boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime);

--- a/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/domain/running/RunningRecordRepository.java
@@ -15,6 +15,8 @@ public interface RunningRecordRepository {
 
     List<RunningRecord> findByMember(Member member);
 
+    int findTotalDistanceMeterByMemberId(long memberId);
+
     int findTotalDistanceMeterByMemberIdWithRangeDate(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);
 
     Duration findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate);

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -54,8 +54,9 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endtDate) {
-        return jooqRunningRecordRepository.findTotalDistanceMeterByMemberId(memberId, startDate, endtDate);
+    public int findTotalDistanceMeterByMemberIdWithRangeDate(
+            long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
+        return jooqRunningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, startDate, endDate);
     }
 
     @Override

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -37,6 +37,13 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
+    public List<RunningRecord> findByMember(Member member) {
+        return jpaRunningRecordRepository.findByMemberId(member.memberId()).stream()
+                .map(RunningRecordEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public int findTotalDistanceMeterByMemberIdWithRangeDate(
             long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         return jooqRunningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, startDate, endDate);
@@ -46,13 +53,6 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     public Duration findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         return Duration.ofSeconds(
                 jooqRunningRecordRepository.findTotalDurationByMemberId(memberId, startDate, endDate));
-    }
-
-    @Override
-    public List<RunningRecord> findByMember(Member member) {
-        return jpaRunningRecordRepository.findByMemberId(member.memberId()).stream()
-                .map(RunningRecordEntity::toDomain)
-                .toList();
     }
 
     @Override

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -56,15 +56,15 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public List<DailyRunningRecordSummary> findDailyDistancesMeterByDateRange(
+    public List<DailyRunningRecordSummary> findDailyDistancesMeterWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
-        return jooqRunningRecordRepository.findDailyDistancesMeterByDateRange(memberId, startDate, nextDateOfEndDate);
+        return jooqRunningRecordRepository.findDailyDistancesMeterWithDateRange(memberId, startDate, nextDateOfEndDate);
     }
 
     @Override
-    public List<DailyRunningRecordSummary> findDailyDurationsSecByDateRange(
+    public List<DailyRunningRecordSummary> findDailyDurationsSecWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
-        return jooqRunningRecordRepository.findDailyDurationsSecMeterByDateRange(
+        return jooqRunningRecordRepository.findDailyDurationsSecMeterWithDateRange(
                 memberId, startDate, nextDateOfEndDate);
     }
 
@@ -76,9 +76,9 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public int findAvgDurationSecByMemberIdAndDateRange(
+    public int findAvgDurationSecByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
-        return jooqRunningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
+        return jooqRunningRecordRepository.findAvgDurationSecByMemberIdWithDateRange(
                 memberId, startDate, nextDateOfEndDate);
     }
 

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -29,28 +29,11 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public RunningRecord save(RunningRecord runningRecord) {
-        return jpaRunningRecordRepository
-                .save(RunningRecordEntity.from(runningRecord))
-                .toDomain();
-    }
-
-    @Override
-    public void deleteByMemberId(long memberId) {
-        jpaRunningRecordRepository.deleteByMemberId(memberId);
-    }
-
-    @Override
     public List<RunningRecord> findByMemberIdAndStartAtBetween(
             long memberId, OffsetDateTime startTime, OffsetDateTime endTime) {
         return jpaRunningRecordRepository.findByMemberIdAndStartAtBetween(memberId, startTime, endTime).stream()
                 .map(RunningRecordEntity::toDomain)
                 .collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime) {
-        return jpaRunningRecordRepository.existsByMemberIdAndStartAtBetween(memberId, startTime, endTime);
     }
 
     @Override
@@ -86,9 +69,9 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
-    public int findAvgDistanceMeterByMemberIdAndDateRange(
+    public int findAvgDistanceMeterByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
-        return jooqRunningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
+        return jooqRunningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
                 memberId, startDate, nextDateOfEndDate);
     }
 
@@ -97,5 +80,22 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
         return jooqRunningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
                 memberId, startDate, nextDateOfEndDate);
+    }
+
+    @Override
+    public boolean hasByMemberIdAndStartAtBetween(long memberId, OffsetDateTime startTime, OffsetDateTime endTime) {
+        return jpaRunningRecordRepository.existsByMemberIdAndStartAtBetween(memberId, startTime, endTime);
+    }
+
+    @Override
+    public RunningRecord save(RunningRecord runningRecord) {
+        return jpaRunningRecordRepository
+                .save(RunningRecordEntity.from(runningRecord))
+                .toDomain();
+    }
+
+    @Override
+    public void deleteByMemberId(long memberId) {
+        jpaRunningRecordRepository.deleteByMemberId(memberId);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImpl.java
@@ -44,6 +44,11 @@ public class RunningRecordRepositoryImpl implements RunningRecordRepository {
     }
 
     @Override
+    public int findTotalDistanceMeterByMemberId(long memberId) {
+        return jooqRunningRecordRepository.findTotalDistanceMeterByMemberId(memberId);
+    }
+
+    @Override
     public int findTotalDistanceMeterByMemberIdWithRangeDate(
             long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         return jooqRunningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(memberId, startDate, endDate);

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -21,6 +21,17 @@ import static org.jooq.impl.DSL.*;
 public class JooqRunningRecordRepository {
     private final DSLContext dsl;
 
+    public int findTotalDistanceMeterByMemberId(long memberId) {
+        Record1<Integer> result = dsl.select(sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
+                .from(RUNNING_RECORD)
+                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .fetchOne();
+        if (result != null && result.value1() != null) {
+            return result.value1();
+        }
+        return 0;
+    }
+
     public int findTotalDistanceMeterByMemberIdWithRangeDate(
             long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         Record1<Integer> result = dsl.select(sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -35,6 +35,19 @@ public class JooqRunningRecordRepository {
         return 0;
     }
 
+    public long findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
+        Record1<Long> result = dsl.select(sum(RUNNING_RECORD.DURATION_SECONDS).cast(Long.class))
+                .from(RUNNING_RECORD)
+                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
+                .and(RUNNING_RECORD.START_AT.ge(startDate))
+                .and(RUNNING_RECORD.START_AT.lt(nextDateOfEndDate))
+                .fetchOne();
+        if (result != null && result.value1() != null) {
+            return result.value1();
+        }
+        return 0;
+    }
+
     public int findAvgDistanceMeterByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
         Record1<Integer> result = dsl.select(avg(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
@@ -108,19 +121,6 @@ public class JooqRunningRecordRepository {
                 .groupBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
                 .orderBy(cast(RUNNING_RECORD.START_AT, SQLDataType.DATE))
                 .fetch(new DailyRunningSummary());
-    }
-
-    public long findTotalDurationByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
-        Record1<Long> result = dsl.select(sum(RUNNING_RECORD.DURATION_SECONDS).cast(Long.class))
-                .from(RUNNING_RECORD)
-                .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))
-                .and(RUNNING_RECORD.START_AT.ge(startDate))
-                .and(RUNNING_RECORD.START_AT.lt(nextDateOfEndDate))
-                .fetchOne();
-        if (result != null && result.value1() != null) {
-            return result.value1();
-        }
-        return 0;
     }
 
     private static class DailyRunningSummary implements RecordMapper<Record, DailyRunningRecordSummary> {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -49,7 +49,7 @@ public class JooqRunningRecordRepository {
         return 0;
     }
 
-    public int findAvgDurationSecByMemberIdAndDateRange(
+    public int findAvgDurationSecByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
         Record1<Integer> result = dsl.select(
                         avg(RUNNING_RECORD.DURATION_SECONDS).cast(Integer.class))
@@ -72,7 +72,7 @@ public class JooqRunningRecordRepository {
      * @return 기간 내 각 날짜별 달린 거리 합계를 포함한 리스트.
      * 각 요소는 날짜와 해당 날짜의 거리 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
      */
-    public List<DailyRunningRecordSummary> findDailyDistancesMeterByDateRange(
+    public List<DailyRunningRecordSummary> findDailyDistancesMeterWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
 
         return dsl.select(
@@ -95,7 +95,7 @@ public class JooqRunningRecordRepository {
      * @return 기간 내 각 날짜별 달린 시간 합계를 포함한 리스트.
      * 각 요소는 날짜와 해당 날짜의 달린 시간 합계를 나타내는 {@link DailyRunningRecordSummary} 객체입니다.
      */
-    public List<DailyRunningRecordSummary> findDailyDurationsSecMeterByDateRange(
+    public List<DailyRunningRecordSummary> findDailyDurationsSecMeterWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
 
         return dsl.select(

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -35,7 +35,7 @@ public class JooqRunningRecordRepository {
         return 0;
     }
 
-    public int findAvgDistanceMeterByMemberIdAndDateRange(
+    public int findAvgDistanceMeterByMemberIdWithDateRange(
             long memberId, OffsetDateTime startDate, OffsetDateTime nextDateOfEndDate) {
         Record1<Integer> result = dsl.select(avg(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
                 .from(RUNNING_RECORD)

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/running/JooqRunningRecordRepository.java
@@ -21,7 +21,8 @@ import static org.jooq.impl.DSL.*;
 public class JooqRunningRecordRepository {
     private final DSLContext dsl;
 
-    public int findTotalDistanceMeterByMemberId(long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
+    public int findTotalDistanceMeterByMemberIdWithRangeDate(
+            long memberId, OffsetDateTime startDate, OffsetDateTime endDate) {
         Record1<Integer> result = dsl.select(sum(RUNNING_RECORD.DISTANCE_METER).cast(Integer.class))
                 .from(RUNNING_RECORD)
                 .where(RUNNING_RECORD.MEMBER_ID.eq(memberId))

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -464,7 +464,7 @@ class RunningRecordServiceTest {
         given(runningRecordRepository.findDailyDistancesMeterByDateRange(memberId, startWeekDate, nextOfEndWeekDate))
                 .willReturn(List.of(new DailyRunningRecordSummary(runningDate.toLocalDate(), 3567)));
 
-        given(runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
+        given(runningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
                         memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7)))
                 .willReturn(800);
 

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -427,7 +427,7 @@ class RunningRecordServiceTest {
                     .when(() -> OffsetDateTime.now(ZoneId.of(SERVER_TIMEZONE)))
                     .thenReturn(fixedDate);
 
-            given(runningRecordRepository.findTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
+            given(runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(eq(memberId), any(), any()))
                     .willReturn(45_780);
 
             given(memberLevelRepository.findByMemberIdWithLevel(memberId))

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -461,7 +461,7 @@ class RunningRecordServiceTest {
 
         OffsetDateTime runningDate = startWeekDate.plusDays(2);
 
-        given(runningRecordRepository.findDailyDistancesMeterByDateRange(memberId, startWeekDate, nextOfEndWeekDate))
+        given(runningRecordRepository.findDailyDistancesMeterWithDateRange(memberId, startWeekDate, nextOfEndWeekDate))
                 .willReturn(List.of(new DailyRunningRecordSummary(runningDate.toLocalDate(), 3567)));
 
         given(runningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
@@ -496,10 +496,10 @@ class RunningRecordServiceTest {
 
         OffsetDateTime runningDate = startWeekDate.plusDays(2);
 
-        given(runningRecordRepository.findDailyDurationsSecByDateRange(memberId, startWeekDate, nextOfEndWeekDate))
+        given(runningRecordRepository.findDailyDurationsSecWithDateRange(memberId, startWeekDate, nextOfEndWeekDate))
                 .willReturn(List.of(new DailyRunningRecordSummary(runningDate.toLocalDate(), runningDurationSec)));
 
-        given(runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
+        given(runningRecordRepository.findAvgDurationSecByMemberIdWithDateRange(
                         memberId, startWeekDate.minusDays(7), nextOfEndWeekDate.minusDays(7)))
                 .willReturn(runningDurationSec);
 

--- a/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
@@ -56,7 +56,7 @@ class ScaleServiceTest {
                         new ScaleAchievementLog(scale2, null),
                         new ScaleAchievementLog(scale3, null)));
         int runningMeterSum = 50;
-        given(runningRecordRepository.findTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
+        given(runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(eq(memberId), any(), any()))
                 .willReturn(runningMeterSum);
 
         // when
@@ -78,7 +78,7 @@ class ScaleServiceTest {
                         new ScaleAchievementLog(scale1, OffsetDateTime.now()),
                         new ScaleAchievementLog(scale2, null),
                         new ScaleAchievementLog(scale3, null)));
-        given(runningRecordRepository.findTotalDistanceMeterByMemberId(eq(memberId), any(), any()))
+        given(runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(eq(memberId), any(), any()))
                 .willReturn(1000);
 
         // when

--- a/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
@@ -88,8 +88,8 @@ class ScaleServiceTest {
         assertNotNull(response);
         assertEquals(1, response.achievedCourses().size());
 
-        assertEquals(scale1.name(), response.achievedCourses().get(0).name());
-        assertEquals("0.2km", response.achievedCourses().get(0).totalDistance());
+        assertEquals(scale1.name(), response.achievedCourses().getFirst().name());
+        assertEquals("0.2km", response.achievedCourses().getFirst().totalDistance());
 
         assertEquals(scale2.name(), response.currentCourse().name());
         assertEquals("800m", response.currentCourse().achievedDistance());

--- a/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/scale/ScaleServiceTest.java
@@ -17,8 +17,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,7 +54,7 @@ class ScaleServiceTest {
                         new ScaleAchievementLog(scale2, null),
                         new ScaleAchievementLog(scale3, null)));
         int runningMeterSum = 50;
-        given(runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(eq(memberId), any(), any()))
+        given(runningRecordRepository.findTotalDistanceMeterByMemberId(memberId))
                 .willReturn(runningMeterSum);
 
         // when
@@ -78,7 +76,7 @@ class ScaleServiceTest {
                         new ScaleAchievementLog(scale1, OffsetDateTime.now()),
                         new ScaleAchievementLog(scale2, null),
                         new ScaleAchievementLog(scale3, null)));
-        given(runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(eq(memberId), any(), any()))
+        given(runningRecordRepository.findTotalDistanceMeterByMemberId(memberId))
                 .willReturn(1000);
 
         // when

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -340,7 +340,7 @@ class RunningRecordRepositoryImplTest {
         OffsetDateTime nextOfDndDate = startDate.plusDays(7);
 
         // when
-        int avgResult = runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
+        int avgResult = runningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
                 savedMember.memberId(), startDate, nextOfDndDate);
 
         // then
@@ -417,7 +417,7 @@ class RunningRecordRepositoryImplTest {
                 RunningEmoji.SOSO));
 
         // when
-        int avgResult = runningRecordRepository.findAvgDistanceMeterByMemberIdAndDateRange(
+        int avgResult = runningRecordRepository.findAvgDistanceMeterByMemberIdWithDateRange(
                 savedMember.memberId(), startDate.toOffsetDateTime(), nextOfDndDate.toOffsetDateTime());
 
         // then

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -228,7 +228,7 @@ class RunningRecordRepositoryImplTest {
         OffsetDateTime nextOfDndDate = startDate.plusDays(7);
 
         // when
-        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDistancesMeterByDateRange(
+        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDistancesMeterWithDateRange(
                 savedMember.memberId(), startDate, nextOfDndDate);
 
         // then
@@ -264,7 +264,7 @@ class RunningRecordRepositoryImplTest {
         }
 
         // when
-        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDistancesMeterByDateRange(
+        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDistancesMeterWithDateRange(
                 savedMember.memberId(), startDate, nextOfDndDate);
 
         // then
@@ -284,7 +284,7 @@ class RunningRecordRepositoryImplTest {
         OffsetDateTime nextOfDndDate = startDate.plusDays(7);
 
         // when
-        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDurationsSecByDateRange(
+        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDurationsSecWithDateRange(
                 savedMember.memberId(), startDate, nextOfDndDate);
 
         // then
@@ -320,7 +320,7 @@ class RunningRecordRepositoryImplTest {
         }
 
         // when
-        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDurationsSecByDateRange(
+        List<DailyRunningRecordSummary> result = runningRecordRepository.findDailyDurationsSecWithDateRange(
                 savedMember.memberId(), startDate, nextOfDndDate);
 
         // then
@@ -436,7 +436,7 @@ class RunningRecordRepositoryImplTest {
         OffsetDateTime nextOfDndDate = startDate.plusDays(7);
 
         // when
-        int avgResult = runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
+        int avgResult = runningRecordRepository.findAvgDurationSecByMemberIdWithDateRange(
                 savedMember.memberId(), startDate, nextOfDndDate);
 
         // then
@@ -513,7 +513,7 @@ class RunningRecordRepositoryImplTest {
                 RunningEmoji.SOSO));
 
         // when
-        int avgResult = runningRecordRepository.findAvgDurationSecByMemberIdAndDateRange(
+        int avgResult = runningRecordRepository.findAvgDurationSecByMemberIdWithDateRange(
                 savedMember.memberId(), startDate.toOffsetDateTime(), nextOfDndDate.toOffsetDateTime());
 
         // then

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -269,7 +269,7 @@ class RunningRecordRepositoryImplTest {
 
         // then
         assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).sumValue()).isEqualTo(10_000);
+        assertThat(result.getFirst().sumValue()).isEqualTo(10_000);
     }
 
     @DisplayName("러닝 주간 서머리 조회(시간) : 러닝 데이터가 없을 경우")
@@ -325,7 +325,7 @@ class RunningRecordRepositoryImplTest {
 
         // then
         assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).sumValue()).isEqualTo(Duration.ofHours(2).toSeconds());
+        assertThat(result.getFirst().sumValue()).isEqualTo(Duration.ofHours(2).toSeconds());
     }
 
     @DisplayName("러닝 기간별 평균 거리 조회: 기간내 러닝 데이터가 없으면 0을 리턴한다.")

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/running/RunningRecordRepositoryImplTest.java
@@ -146,7 +146,7 @@ class RunningRecordRepositoryImplTest {
         OffsetDateTime startDateOfNextMonth = startDateOfMonth.plusMonths(1);
 
         // when
-        int totalDistanceMeterByMemberId = runningRecordRepository.findTotalDistanceMeterByMemberId(
+        int totalDistanceMeterByMemberId = runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(
                 savedMember.memberId(), startDateOfMonth, startDateOfNextMonth);
 
         // than
@@ -181,7 +181,7 @@ class RunningRecordRepositoryImplTest {
         OffsetDateTime startDateOfNextMonth = startDateOfMonth.plusMonths(1);
 
         // when
-        int totalDistanceMeterByMemberId = runningRecordRepository.findTotalDistanceMeterByMemberId(
+        int totalDistanceMeterByMemberId = runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(
                 savedMember.memberId(), startDateOfMonth, startDateOfNextMonth);
 
         // than


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #294 

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기간 안의 데이터를 조회하는 함수명을 하나로 통일 했습니다.
    - 기존의 `ByDateRange`, `AndDateRange` 등 여러개로 나타나있던 접미사를 `WithDateRage`로 변경했습니다.
- 리파지토리의 함수 순서를 다음과 같이 변경했습니다.
    - find -> update -> save -> delete 순, jpa -> jooq 순
- 날짜 관련 없이 사용자에 따라 전체 러닝 거리 합을 조회하는 함수가 여러 곳에서 사용해서 사용자 id에 따라  전체 러닝 거리 합을 조회하는 리파지토리 함수 `findTotalDistanceMeterByMemberId`를 추가했습니다.
- 기존에 사용자의 전체 러닝 거리를 조회하는 로직에서 `findTotalDistanceMeterByMemberIdWithRangeDate`를 `findTotalDistanceMeterByMemberId`로 변경했습니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 사용자에 따라 전체 러닝 거리 합을 조회하는 함수가 여러 곳에서 필요할 것 같아서 따로 만들었는데 혹시 괜찮은가요?
- 리파지토리의 함수들이 늘어나면서 한번에 보기 힘들어 지는 것 같아요! 함수의 순서를 다음 백엔드 스크럼때 같이 정하면 좋을 것 같아요!
