### PR TITLE
Feat: 나의 기록 조회 V2 작업(퍼센테이지 값 추가)

### DIFF
--- a/src/main/java/com/dnd/runus/application/member/MemberService.java
+++ b/src/main/java/com/dnd/runus/application/member/MemberService.java
@@ -1,6 +1,5 @@
 package com.dnd.runus.application.member;
 
-import com.dnd.runus.domain.level.Level;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.member.MemberLevel;
 import com.dnd.runus.domain.member.MemberLevelRepository;
@@ -28,10 +27,11 @@ public class MemberService {
 
         return new MyProfileResponse(
                 memberCurrentLevel.level().imageUrl(),
-                Level.formatLevelName(currentLevel),
-                Level.formatExp(memberCurrentLevel.currentExp()),
-                Level.formatLevelName(nextLevel),
-                Level.formatExp(memberCurrentLevel.level().expRangeEnd() - memberCurrentLevel.currentExp()));
+                currentLevel,
+                memberCurrentLevel.currentExp(),
+                nextLevel,
+                memberCurrentLevel.level().expRangeStart(),
+                memberCurrentLevel.level().expRangeEnd());
     }
 
     @Transactional

--- a/src/main/java/com/dnd/runus/presentation/v1/member/MemberProfileController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/member/MemberProfileController.java
@@ -2,7 +2,7 @@ package com.dnd.runus.presentation.v1.member;
 
 import com.dnd.runus.application.member.MemberService;
 import com.dnd.runus.presentation.annotation.MemberId;
-import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponseV1;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +18,7 @@ public class MemberProfileController {
 
     @GetMapping("me")
     @ResponseStatus(HttpStatus.OK)
-    public MyProfileResponse getMyProfile(@MemberId long memberId) {
-        return memberService.getMyProfile(memberId);
+    public MyProfileResponseV1 getMyProfile(@MemberId long memberId) {
+        return MyProfileResponseV1.from(memberService.getMyProfile(memberId));
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponse.java
@@ -1,17 +1,12 @@
 package com.dnd.runus.presentation.v1.member.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MyProfileResponse(
-        @Schema(description = "현재 프로필 이미지")
         String profileImageUrl,
-        @Schema(description = "현재 레벨 이름")
-        String currentLevelName,
-        @Schema(description = "지금까지 달린 거리")
-        String currentKm,
-        @Schema(description = "다음 레벨 이름")
-        String nextLevelName,
-        @Schema(description = "다음 레벨까지 남은 거리")
-        String nextLevelKm
+        long currentLevel,
+        int currentExpMeter,
+        long nextLevel,
+        int nextLevelStartExpMeter,
+        int nextLevelEndExpMeter
 ) {
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponseV1.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/member/dto/response/MyProfileResponseV1.java
@@ -1,0 +1,29 @@
+package com.dnd.runus.presentation.v1.member.dto.response;
+
+import com.dnd.runus.domain.level.Level;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyProfileResponseV1(
+    @Schema(description = "현재 프로필 이미지")
+    String profileImageUrl,
+    @Schema(description = "현재 레벨 이름")
+    String currentLevelName,
+    @Schema(description = "지금까지 달린 거리")
+    String currentKm,
+    @Schema(description = "다음 레벨 이름")
+    String nextLevelName,
+    @Schema(description = "다음 레벨까지 남은 거리")
+    String nextLevelKm
+) {
+
+    public static MyProfileResponseV1 from(MyProfileResponse myProfileResponse) {
+        return new MyProfileResponseV1(
+            myProfileResponse.profileImageUrl(),
+            Level.formatLevelName(myProfileResponse.currentLevel()),
+            Level.formatExp(myProfileResponse.currentExpMeter()),
+            Level.formatLevelName(myProfileResponse.nextLevel()),
+            Level.formatExp(myProfileResponse.nextLevelEndExpMeter()
+                - myProfileResponse.currentExpMeter())
+        );
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v2/member/MemberProfileControllerV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/member/MemberProfileControllerV2.java
@@ -1,0 +1,32 @@
+package com.dnd.runus.presentation.v2.member;
+
+import com.dnd.runus.application.member.MemberService;
+import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
+import com.dnd.runus.presentation.v2.member.dto.response.MyProfileResponseV2;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v2/members/profiles")
+public class MemberProfileControllerV2 {
+    private final MemberService memberService;
+
+    @GetMapping("me")
+    @ResponseStatus(HttpStatus.OK)
+    public MyProfileResponseV2 getMyProfile(@MemberId long memberId) {
+        MyProfileResponse myProfile = memberService.getMyProfile(memberId);
+
+        // 퍼센테이지
+        double leftNextLevelKm = myProfile.nextLevelEndExpMeter() - myProfile.currentExpMeter();
+        double divisor = myProfile.nextLevelEndExpMeter() - myProfile.nextLevelStartExpMeter();
+        double percentage = 1 - (leftNextLevelKm / divisor);
+
+        return MyProfileResponseV2.of(myProfile, percentage);
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v2/member/dto/response/MyProfileResponseV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/member/dto/response/MyProfileResponseV2.java
@@ -1,0 +1,36 @@
+package com.dnd.runus.presentation.v2.member.dto.response;
+
+
+import com.dnd.runus.domain.level.Level;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyProfileResponseV2 (
+    @Schema(description = "현재 프로필 이미지")
+    String profileImageUrl,
+    @Schema(description = "현재 레벨 이름")
+    String currentLevelName,
+    @Schema(description = "지금까지 달린 거리")
+    String currentKm,
+    @Schema(description = "다음 레벨 이름")
+    String nextLevelName,
+    @Schema(description = "다음 레벨까지 남은 거리")
+    String nextLevelKm,
+    @Schema(description = "퍼센테이지값", example = "0.728")
+    double percentage
+
+) {
+
+    public static MyProfileResponseV2 of(MyProfileResponse myProfileResponse, double percentage) {
+        return new MyProfileResponseV2(
+            myProfileResponse.profileImageUrl(),
+            Level.formatLevelName(myProfileResponse.currentLevel()),
+            Level.formatExp(myProfileResponse.currentExpMeter()),
+            Level.formatLevelName(myProfileResponse.nextLevel()),
+            Level.formatExp(myProfileResponse.nextLevelEndExpMeter()
+                - myProfileResponse.currentExpMeter()),
+            percentage
+        );
+    }
+
+}

--- a/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/member/MemberServiceTest.java
@@ -22,7 +22,7 @@ class MemberServiceTest {
     @Mock
     private MemberLevelRepository memberLevelRepository;
 
-    @DisplayName("내 프로필 조회 성공 - 현재 레벨 1, 경험치 500일때, 0km로 표현 (소수점 버림)")
+    @DisplayName("내 프로필 조회 성공 - 현재 레벨 1, 경험치 500일때, 다음 레벨이 2여야함")
     @Test
     void getMyProfile_givenCurrentLevel1AndExp500_thenSuccess() {
         // given
@@ -35,26 +35,8 @@ class MemberServiceTest {
 
         // then
         assertEquals("imageUrl", myProfileResponse.profileImageUrl());
-        assertEquals("Level 1", myProfileResponse.currentLevelName());
-        assertEquals("0.5km", myProfileResponse.currentKm());
-        assertEquals("Level 2", myProfileResponse.nextLevelName());
-    }
-
-    @DisplayName("내 프로필 조회 성공 - 현재 레벨 2, 경험치 1500일때, 1km로 표현 (소수점 버림)")
-    @Test
-    void getMyProfile_givenCurrentLevel1AndExp1500_thenSuccess() {
-        // given
-        long memberId = 1L;
-        Level level = new Level(2, 1000, 2000, "imageUrl");
-        given(memberLevelRepository.findByMemberIdWithLevel(memberId)).willReturn(new MemberLevel.Current(level, 1500));
-
-        // when
-        MyProfileResponse myProfileResponse = memberService.getMyProfile(memberId);
-
-        // then
-        assertEquals("imageUrl", myProfileResponse.profileImageUrl());
-        assertEquals("Level 2", myProfileResponse.currentLevelName());
-        assertEquals("1.5km", myProfileResponse.currentKm());
-        assertEquals("Level 3", myProfileResponse.nextLevelName());
+        assertEquals(1, myProfileResponse.currentLevel());
+        assertEquals(500, myProfileResponse.currentExpMeter());
+        assertEquals(2, myProfileResponse.nextLevel());
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #295

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `/api/v2/members/profiles`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 응답 버전 별 공통으로 값을 가공할 수 있게 `MyProfileResponse`의 필드 값을 변경합니다.
- MemberService의 `getMyProfile`메서드가  `MyProfileResponse`를 리턴하도록 합니다.
- 기존의  `MyProfileResponse`을  `MyProfileResponseV1`으로 변경합니다.
- `MyProfileResponseV1`에서 `MyProfileResponse`값을 변환할 수 있게 합니다.
- 퍼센테이지 값을 추가한 `MyProfileResponseV2`를 생성하고 `/api/v2/members/profiles` api를 추가합니다.
## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 해당 구조를 어떻게 변경할지는 백엔드 스크럼 회의에서 정하고 도메인 별로 리팩터링 작업 들어가면  될 것 같아요!
- 우선 임시로 구성했습니다.
- 리팩터링 코드랑, 구현 코드랑 별도로 PR를 올려야했었는데, 해당 작업이 목요일까지 완료하기로 예정되어서 같이 올렸어요! 다음부터는 나눠서 올리겠습니다🙏 