### PR TITLE
Feat: 이번달 러닝 서머리 V2 API 추가

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordServiceV2.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordServiceV2.java
@@ -1,0 +1,84 @@
+package com.dnd.runus.application.running;
+
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.domain.scale.ScaleAchievementLog;
+import com.dnd.runus.domain.scale.ScaleAchievementRepository;
+import com.dnd.runus.presentation.v2.running.dto.response.RunningRecordMonthlySummaryResponseV2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DecimalFormat;
+import java.util.List;
+
+import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
+
+@Service
+public class RunningRecordServiceV2 {
+
+    private final RunningRecordRepository runningRecordRepository;
+    private final ScaleAchievementRepository scaleAchievementRepository;
+
+    private static final DecimalFormat KILO_METER_UNDER_1_POINT_FORMATTER = new DecimalFormat("#,###.#km");
+
+    public RunningRecordServiceV2(
+            RunningRecordRepository runningRecordRepository, ScaleAchievementRepository scaleAchievementRepository) {
+        this.runningRecordRepository = runningRecordRepository;
+        this.scaleAchievementRepository = scaleAchievementRepository;
+    }
+
+    // todo 지구 한바퀴 작업 후 리팩터링 예정
+    @Transactional(readOnly = true)
+    public RunningRecordMonthlySummaryResponseV2.PercentageBoxWithMessage getPercentageValues(long memberId) {
+        // 지구한바퀴 코스 조회
+        List<ScaleAchievementLog> scaleAchievementLogs = scaleAchievementRepository.findScaleAchievementLogs(memberId);
+        ScaleAchievementLog currentCourseLog = scaleAchievementLogs.stream()
+                .filter(log -> log.achievedDate() == null)
+                .findFirst()
+                .orElse(null);
+
+        // todo 정해지면 하드코드 수정
+        if (currentCourseLog == null) {
+            return RunningRecordMonthlySummaryResponseV2.PercentageBoxWithMessage.builder()
+                    .message("축하합니다! 지구 한바퀴 완주하셨네요!")
+                    .percentageBox(RunningRecordMonthlySummaryResponseV2.PercentageBox.builder()
+                            .startName("한국")
+                            .endName("지구 한바퀴")
+                            .percentage(100)
+                            .build())
+                    .build();
+        }
+
+        // 사용자가 달린 전체 거리 확인
+        int totalRunningDistanceMeter = runningRecordRepository.findTotalDistanceMeterByMemberId(memberId);
+        // 성취한 코스의 전체 합 거리
+        int achievedCourseMeterSum = scaleAchievementLogs.stream()
+                .filter(log -> log.achievedDate() != null)
+                .mapToInt(log -> log.scale().sizeMeter())
+                .sum();
+
+        // 현재 코스에서 사용자가 성취한 거리 합
+        double currentCourseAchievedKmSum =
+                (totalRunningDistanceMeter - achievedCourseMeterSum) / METERS_IN_A_KILOMETER;
+        // 현재 코스 완주를 위해 필요한 키로미터 값
+        double courseSizeKm = currentCourseLog.scale().sizeMeter() / METERS_IN_A_KILOMETER;
+
+        double percentage = calPercentage(courseSizeKm, currentCourseAchievedKmSum);
+
+        return RunningRecordMonthlySummaryResponseV2.PercentageBoxWithMessage.builder()
+                .message(String.format(
+                        "%s까지 %s 남았어요!",
+                        currentCourseLog.scale().endName(),
+                        KILO_METER_UNDER_1_POINT_FORMATTER.format(courseSizeKm - currentCourseAchievedKmSum)))
+                .percentageBox(RunningRecordMonthlySummaryResponseV2.PercentageBox.builder()
+                        .startName(currentCourseLog.scale().startName())
+                        .endName(currentCourseLog.scale().endName())
+                        .percentage(percentage)
+                        .build())
+                .build();
+    }
+
+    private double calPercentage(double totalRangeValue, double currentValue) {
+        if (totalRangeValue <= 0) return 0;
+        return currentValue / totalRangeValue;
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -1,9 +1,12 @@
 package com.dnd.runus.presentation.v1.running;
 
+import com.dnd.runus.application.member.MemberService;
 import com.dnd.runus.application.running.RunningRecordService;
+import com.dnd.runus.domain.level.Level;
 import com.dnd.runus.global.exception.type.ApiErrorType;
 import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.member.dto.response.MyProfileResponse;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequest;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
 import com.dnd.runus.presentation.v1.running.dto.response.*;
@@ -23,6 +26,7 @@ import java.util.List;
 @RequestMapping("/api/v1/running-records")
 public class RunningRecordController {
     private final RunningRecordService runningRecordService;
+    private final MemberService memberService;
 
     @GetMapping("/{runningRecordId}")
     @Operation(summary = "러닝 기록 상세 조회", description = "RunngingRecord id로 러닝 상세 기록을 조회합니다.")
@@ -76,8 +80,17 @@ public class RunningRecordController {
             """)
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("monthly-summary")
-    public RunningRecordMonthlySummaryResponse getMonthlyRunningSummary(@MemberId long memberId) {
-        return runningRecordService.getMonthlyRunningSummery(memberId);
+    public RunningRecordMonthlySummaryResponseV1 getMonthlyRunningSummary(@MemberId long memberId) {
+        RunningRecordMonthlySummaryResponse monthlyRunningSummery =
+                runningRecordService.getMonthlyRunningSummery(memberId);
+
+        MyProfileResponse myProfile = memberService.getMyProfile(memberId);
+
+        return new RunningRecordMonthlySummaryResponseV1(
+                monthlyRunningSummery.month(),
+                monthlyRunningSummery.monthlyTotalMeter(),
+                Level.formatLevelName(myProfile.nextLevel()),
+                Level.formatExp(myProfile.nextLevelEndExpMeter() - myProfile.currentExpMeter()));
     }
 
     @Operation(

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponse.java
@@ -1,24 +1,13 @@
 package com.dnd.runus.presentation.v1.running.dto.response;
 
-import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.text.DecimalFormat;
+import lombok.Builder;
 
+//todo API 버저닝 관련 구조 정해지면 패키지 변경 예쩡
+@Builder
 public record RunningRecordMonthlySummaryResponse(
-        @Schema(description = "이번 달", example = "8월")
-        String month,
-        @Schema(description = "이번 달에 달린 키로 수", example = "2.55km")
-        String monthlyKm,
-        @Schema(description = "다음 레벨", example = "Level 2")
-        String nextLevelName,
-        @Schema(description = "다음 레벨까지 남은 키로 수", example = "2.55km")
-        String nextLevelKm
+    int month,
+    int monthlyTotalMeter
 ) {
-    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.##km");
-
-    public RunningRecordMonthlySummaryResponse(int monthValue, int monthlyTotalMeter, String nextLevelName, String nextLevelKm) {
-        this(monthValue + "월", KILO_METER_FORMATTER.format(monthlyTotalMeter / METERS_IN_A_KILOMETER), nextLevelName, nextLevelKm);
-    }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponseV1.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordMonthlySummaryResponseV1.java
@@ -1,0 +1,23 @@
+package com.dnd.runus.presentation.v1.running.dto.response;
+
+import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.text.DecimalFormat;
+
+public record RunningRecordMonthlySummaryResponseV1(
+        @Schema(description = "이번 달", example = "8월")
+        String month,
+        @Schema(description = "이번 달에 달린 키로 수", example = "2.55km")
+        String monthlyKm,
+        @Schema(description = "다음 레벨", example = "Level 2")
+        String nextLevelName,
+        @Schema(description = "다음 레벨까지 남은 키로 수", example = "2.55km")
+        String nextLevelKm
+) {
+    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("0.##km");
+
+    public RunningRecordMonthlySummaryResponseV1(int monthValue, int monthlyTotalMeter, String nextLevelName, String nextLevelKm) {
+        this(monthValue + "월", KILO_METER_FORMATTER.format(monthlyTotalMeter / METERS_IN_A_KILOMETER), nextLevelName, nextLevelKm);
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
@@ -1,0 +1,36 @@
+package com.dnd.runus.presentation.v2.running;
+
+import com.dnd.runus.application.running.RunningRecordService;
+import com.dnd.runus.application.running.RunningRecordServiceV2;
+import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.running.dto.response.RunningRecordMonthlySummaryResponse;
+import com.dnd.runus.presentation.v2.running.dto.response.RunningRecordMonthlySummaryResponseV2;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/running-records")
+public class RunningRecordControllerV2 {
+    private final RunningRecordServiceV2 runningRecordService2;
+    private final RunningRecordService runningRecordService;
+
+    @Operation(summary = "이번 달 러닝 기록 조회(홈화면) V2", description = """
+    홈화면의 이번 달 러닝 기록을 조회 합니다.<br>
+    """)
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("monthly-summary")
+    public RunningRecordMonthlySummaryResponseV2 getMonthlyRunningSummary(@MemberId long memberId) {
+        RunningRecordMonthlySummaryResponse monthlyRunningSummery =
+                runningRecordService.getMonthlyRunningSummery(memberId);
+        return new RunningRecordMonthlySummaryResponseV2(
+                monthlyRunningSummery.month(),
+                monthlyRunningSummery.monthlyTotalMeter(),
+                runningRecordService2.getPercentageValues(memberId));
+    }
+}

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/response/RunningRecordMonthlySummaryResponseV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/response/RunningRecordMonthlySummaryResponseV2.java
@@ -1,0 +1,59 @@
+package com.dnd.runus.presentation.v2.running.dto.response;
+
+
+import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.text.DecimalFormat;
+import lombok.Builder;
+
+
+public record RunningRecordMonthlySummaryResponseV2(
+    @Schema(description = "이번 달", example = "8월")
+    String month,
+    @Schema(description = "이번 달에 달린 키로 수", example = "2.55km")
+    String monthlyKm,
+    @Schema(description = "서브 메세지", example = "대전까지 00km 남았어요!")
+    String message,
+    @Schema(description = "퍼센테이지 시작 위치 이름", example = "인천")
+    String startName,
+    @Schema(description = "퍼센테이지 종료 위치 이름", example = "대전")
+    String endName,
+    @Schema(description = "퍼센테이지값", example = "0.728")
+    double percentage
+) {
+
+    private static final DecimalFormat KILO_METER_FORMATTER = new DecimalFormat("#,###.##km");
+
+    public RunningRecordMonthlySummaryResponseV2(
+        int monthValue,
+        int monthlyTotalMeter,
+        PercentageBoxWithMessage percentageBoxWithMessage) {
+        this(
+            monthValue + "월",
+            KILO_METER_FORMATTER.format(monthlyTotalMeter / METERS_IN_A_KILOMETER),
+            percentageBoxWithMessage.message,
+            percentageBoxWithMessage.percentageBox.startName,
+            percentageBoxWithMessage.percentageBox.endName,
+            percentageBoxWithMessage.percentageBox.percentage
+        );
+    }
+
+    @Schema(name = "RunningRecordMonthlySummaryResponseV2 PercentageBox",
+        description = "이번달 러닝 서머리 퍼센테이지 관련 값")
+    @Builder
+    public record PercentageBox(
+        String startName,
+        String endName,
+        double percentage
+    ) {
+    }
+
+    @Builder
+    public record PercentageBoxWithMessage(
+        String message,
+        RunningRecordMonthlySummaryResponseV2.PercentageBox percentageBox
+    ) {
+    }
+
+}

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -8,10 +8,7 @@ import com.dnd.runus.domain.common.Coordinate;
 import com.dnd.runus.domain.common.Pace;
 import com.dnd.runus.domain.goalAchievement.GoalAchievement;
 import com.dnd.runus.domain.goalAchievement.GoalAchievementRepository;
-import com.dnd.runus.domain.level.Level;
 import com.dnd.runus.domain.member.Member;
-import com.dnd.runus.domain.member.MemberLevel;
-import com.dnd.runus.domain.member.MemberLevelRepository;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.DailyRunningRecordSummary;
 import com.dnd.runus.domain.running.RunningRecord;
@@ -61,9 +58,6 @@ class RunningRecordServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private MemberLevelRepository memberLevelRepository;
-
-    @Mock
     private ChallengeRepository challengeRepository;
 
     @Mock
@@ -85,7 +79,6 @@ class RunningRecordServiceTest {
         runningRecordService = new RunningRecordService(
                 runningRecordRepository,
                 memberRepository,
-                memberLevelRepository,
                 challengeRepository,
                 challengeAchievementRepository,
                 percentageValuesRepository,
@@ -416,7 +409,7 @@ class RunningRecordServiceTest {
     }
 
     @Test
-    @DisplayName("이번 달, 달린 키로 수, 러닝 레벨을 조회한다.")
+    @DisplayName("이번 달, 달린 키로수를 조회한다.")
     void getMonthlyRunningSummery() {
         // given
         long memberId = 1;
@@ -430,19 +423,14 @@ class RunningRecordServiceTest {
             given(runningRecordRepository.findTotalDistanceMeterByMemberIdWithRangeDate(eq(memberId), any(), any()))
                     .willReturn(45_780);
 
-            given(memberLevelRepository.findByMemberIdWithLevel(memberId))
-                    .willReturn(new MemberLevel.Current(new Level(1, 0, 50_000, "image"), 45_780));
-
             // when
             RunningRecordMonthlySummaryResponse monthlyRunningSummery =
                     runningRecordService.getMonthlyRunningSummery(memberId);
 
             // then
             assertNotNull(monthlyRunningSummery);
-            assertThat(monthlyRunningSummery.month()).isEqualTo("1월");
-            assertThat(monthlyRunningSummery.monthlyKm()).isEqualTo("45.78km");
-            assertThat(monthlyRunningSummery.nextLevelName()).isEqualTo("Level 2");
-            assertThat(monthlyRunningSummery.nextLevelKm()).isEqualTo("4.22km");
+            assertThat(monthlyRunningSummery.month()).isEqualTo(1);
+            assertThat(monthlyRunningSummery.monthlyTotalMeter()).isEqualTo(45_780);
         }
     }
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #294 
- #301 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- GET `api/v2/running-records/monthly-summary`

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 리팩터링 관련
    - V1, V2 공통 리스펀스 DTO RunningRecordMonthlySummaryResponse로 지정합니다. 
    - 공통으로 필요하는 month, monthlyTotalMeter 값을 서비스단의 `getMonthlyRunningSummery`함수에서 리턴하도록 변경합니다.
    - V1에서 추가로 필요한 다음 레벨 값과 다음 레벨까지 남은 거리수를 구하기 위해 `MemberService`의 `getMyProfile` 메서드로 가져옵니다.
    - 컨트롤러에서 위의 두개의 값을 가공해 RunningRecordMonthlySummaryResponseV1으로 리턴하도록 변경합니다.
- V2 추가
    -  현재 사용자가 달리고 있는 지구 한 바퀴 코스를 조회하고, 코스에 대한 퍼센티지 값들을 계산해서 리턴하는 `getPercentageValues` 메서드를 `RunningRecordServiceV2.java`에 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 패키지 위치나, DTO명은 임시로 지정했어요. 버전 관련해서 구조를 어떻게 변경할지 결정되어 리팩터링 작업 들어가면 그 때 다시 변경하도록 하겠습니다.
