### PR TITLE
Fix: 목표 달성, 챌린지 성공 Title 문구 변경

### DIFF
--- a/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
+++ b/src/main/java/com/dnd/runus/domain/goalAchievement/GoalAchievement.java
@@ -28,7 +28,7 @@ public record GoalAchievement(
     }
 
     public String getTitle() {
-        String returnTitle = (this.isAchieved ? " 달성" : " 달성 실패");
+        String returnTitle = (this.isAchieved ? " 달성 성공!" : " 달성 실패");
         if (goalMetricType == DISTANCE) {
             return KILO_METER_FORMATTER.format(achievementValue / METERS_IN_A_KILOMETER) + returnTitle;
         }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordAddResultResponse.java
@@ -40,7 +40,7 @@ public record RunningRecordAddResultResponse(
         return buildResponse(runningRecord,
                 new ChallengeDto(
                         achievement.challenge().challengeId(),
-                        achievement.challenge().name(),
+                        achievement.isSuccess() ? achievement.challenge().name() + " 성공!" : achievement.challenge().name() + " 실패",
                         achievement.description(),
                         achievement.challenge().imageUrl(),
                         achievement.isSuccess()

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
@@ -40,7 +40,7 @@ public record RunningRecordQueryResponse(
         return buildResponse(runningRecord,
                 new ChallengeDto(
                         achievement.challenge().challengeId(),
-                        achievement.challenge().name(),
+                        achievement.isSuccess() ? achievement.challenge().name() + " 성공!" : achievement.challenge().name() + " 실패",
                         achievement.description(),
                         achievement.challenge().imageUrl(),
                         achievement.isSuccess()

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -179,7 +179,7 @@ class RunningRecordServiceTest {
         assertEquals(runningRecordId, result.runningRecordId());
         assertEquals(runningRecord.emoji(), result.emotion());
         assertEquals(
-                challengeAchievementStatus.challenge().name(),
+                challengeAchievementStatus.challenge().name() + " 성공!",
                 result.challenge().title());
         assertEquals(RunningAchievementMode.CHALLENGE, result.achievementMode());
     }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #304 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 목표달성과 챌린지 title이 성공 시 `성공!`, 실패 시 `실패` 문구를 기존 title에 붙여줍니다.
- 목표 달성은 `GoalAchievement`의 `getTitle` 함수를 수정합니다.
- 챌린지 같은 경우 러닝 기록을 추가하고 리턴하는 `RunningRecordAddResultResponse`와 러닝 상세 기록을 리턴하는 `RunningRecordQueryResponse`에서 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

