### PR TITLE
Fix: oauth 로그인 시 회원을 찾지 못한 경우에 반환하는 에러 타입을 변경

### DIFF
--- a/src/main/java/com/dnd/runus/application/oauth/SocialProfileService.java
+++ b/src/main/java/com/dnd/runus/application/oauth/SocialProfileService.java
@@ -6,7 +6,8 @@ import com.dnd.runus.domain.member.SocialProfile;
 import com.dnd.runus.domain.member.SocialProfileRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.SocialType;
-import com.dnd.runus.global.exception.NotFoundException;
+import com.dnd.runus.global.exception.BusinessException;
+import com.dnd.runus.global.exception.type.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +31,8 @@ public class SocialProfileService {
     public SocialProfile findOrThrow(SocialType socialType, String oauthId, String email) {
         SocialProfile socialProfile = socialProfileRepository
                 .findBySocialTypeAndOauthId(socialType, oauthId)
-                .orElseThrow(() -> new NotFoundException(SocialProfile.class, oauthId));
+                .orElseThrow(() ->
+                        new BusinessException(ErrorType.SOCIAL_MEMBER_NOT_FOUND, socialType + ", oauthId: " + oauthId));
 
         updateEmailIfChanged(socialProfile, email);
         return socialProfile;

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -32,7 +32,7 @@ public enum ErrorType {
     INVALID_CREDENTIALS(UNAUTHORIZED, DEBUG, "AUTH_008", "해당 사용자의 정보가 없거나 일치하지 않아 처리할 수 없습니다"),
 
     // OauthErrorType
-    USER_NOT_FOUND(NOT_FOUND, DEBUG, "OAUTH_001", "존재하지 않은 사용자 입니다"),
+    SOCIAL_MEMBER_NOT_FOUND(NOT_FOUND, DEBUG, "OAUTH_001", "찾을 수 없는 소셜 회원입니다"),
 
     // DatabaseErrorType
     ENTITY_NOT_FOUND(NOT_FOUND, DEBUG, "DB_001", "해당 엔티티를 찾을 수 없습니다"),

--- a/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
@@ -39,7 +39,7 @@ public class OauthController {
                     """)
     @ApiErrorType({
         ErrorType.UNSUPPORTED_SOCIAL_TYPE,
-        ErrorType.USER_NOT_FOUND,
+        ErrorType.SOCIAL_MEMBER_NOT_FOUND,
         ErrorType.FAILED_AUTHENTICATION,
         ErrorType.UNSUPPORTED_JWT_TOKEN
     })

--- a/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/oauth/OauthServiceTest.java
@@ -108,7 +108,7 @@ class OauthServiceTest {
         }
 
         @Test
-        @DisplayName("sign-in 시 socialProfile이 없다면 에러 타입이 USER_NOT_FOUND인 BusinessException 에러 발생")
+        @DisplayName("sign-in 시 socialProfile이 없다면 에러 타입이 SOCIAL_MEMBER_NOT_FOUND인 BusinessException 에러 발생")
         void socialProfile_not_exist_then_signIn_fail() {
             // given
             SignInRequest request = new SignInRequest(socialType, idToken);
@@ -117,11 +117,11 @@ class OauthServiceTest {
             given(claims.getSubject()).willReturn(oauthId);
             given(claims.get("email")).willReturn(email);
             given(socialProfileService.findOrThrow(socialType, oauthId, email))
-                    .willThrow(new BusinessException(ErrorType.USER_NOT_FOUND));
+                    .willThrow(new BusinessException(ErrorType.SOCIAL_MEMBER_NOT_FOUND));
 
             // when, then
             BusinessException exception = assertThrows(BusinessException.class, () -> oauthService.signIn(request));
-            assertEquals(ErrorType.USER_NOT_FOUND, exception.getType());
+            assertEquals(ErrorType.SOCIAL_MEMBER_NOT_FOUND, exception.getType());
         }
 
         @Test


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #306 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- oauth sign in 과정에서 해당 소셜 로그인 멤버를 찾지 못한 경우, 반환하는 에러 코드를 `OAUTH_001`로 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
