### PR TITLE
Fix: oauth 로그인 시 id token에 이메일 필드가 없는 경우 에러 타입 변경

### DIFF
--- a/src/main/java/com/dnd/runus/application/oauth/OauthService.java
+++ b/src/main/java/com/dnd/runus/application/oauth/OauthService.java
@@ -91,7 +91,8 @@ public class OauthService {
         String email = (String) claim.get("email");
         if (StringUtils.isBlank(email)) {
             log.warn("Failed to get email from idToken! type: {}, claim: {}", socialType, claim);
-            throw new AuthException(ErrorType.FAILED_AUTHENTICATION, "Failed to get email from idToken");
+            throw new AuthException(
+                    ErrorType.EMAIL_NOT_FOUND_IN_ID_TOKEN, socialType + ": subject: " + claim.getSubject());
         }
         return email;
     }

--- a/src/main/java/com/dnd/runus/application/oauth/SocialProfileService.java
+++ b/src/main/java/com/dnd/runus/application/oauth/SocialProfileService.java
@@ -1,12 +1,12 @@
 package com.dnd.runus.application.oauth;
 
+import com.dnd.runus.auth.exception.AuthException;
 import com.dnd.runus.domain.member.Member;
 import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.member.SocialProfile;
 import com.dnd.runus.domain.member.SocialProfileRepository;
 import com.dnd.runus.global.constant.MemberRole;
 import com.dnd.runus.global.constant.SocialType;
-import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.type.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,7 +32,7 @@ public class SocialProfileService {
         SocialProfile socialProfile = socialProfileRepository
                 .findBySocialTypeAndOauthId(socialType, oauthId)
                 .orElseThrow(() ->
-                        new BusinessException(ErrorType.SOCIAL_MEMBER_NOT_FOUND, socialType + ", oauthId: " + oauthId));
+                        new AuthException(ErrorType.SOCIAL_MEMBER_NOT_FOUND, socialType + ", oauthId: " + oauthId));
 
         updateEmailIfChanged(socialProfile, email);
         return socialProfile;

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -33,6 +33,7 @@ public enum ErrorType {
 
     // OauthErrorType
     SOCIAL_MEMBER_NOT_FOUND(NOT_FOUND, DEBUG, "OAUTH_001", "찾을 수 없는 소셜 회원입니다"),
+    EMAIL_NOT_FOUND_IN_ID_TOKEN(BAD_REQUEST, DEBUG, "OAUTH_002", "ID 토큰 필드에 이메일이 없습니다"),
 
     // DatabaseErrorType
     ENTITY_NOT_FOUND(NOT_FOUND, DEBUG, "DB_001", "해당 엔티티를 찾을 수 없습니다"),

--- a/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/oauth/OauthController.java
@@ -40,6 +40,7 @@ public class OauthController {
     @ApiErrorType({
         ErrorType.UNSUPPORTED_SOCIAL_TYPE,
         ErrorType.SOCIAL_MEMBER_NOT_FOUND,
+        ErrorType.EMAIL_NOT_FOUND_IN_ID_TOKEN,
         ErrorType.FAILED_AUTHENTICATION,
         ErrorType.UNSUPPORTED_JWT_TOKEN
     })


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #306 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- x

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- id token에 이메일 필드가 없는 경우, `FAILED_AUTHENTICATION`에서 `EMAIL_NOT_FOUND_IN_ID_TOKEN`을 반환하도록 수정합니다.
- BusinessException 대신 AuthException을 사용하도록 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
