### PR TITLE
Feat: Challenge 테이블에 isActive 컬럼 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/Challenge.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/Challenge.java
@@ -3,10 +3,16 @@ package com.dnd.runus.domain.challenge;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_HOUR;
 import static com.dnd.runus.global.constant.MetricsConversionFactor.SECONDS_PER_MINUTE;
 
-public record Challenge(long challengeId, String name, int expectedTime, String imageUrl, ChallengeType challengeType) {
+public record Challenge(
+        long challengeId,
+        String name,
+        int expectedTime,
+        String imageUrl,
+        boolean isActive,
+        ChallengeType challengeType) {
 
-    public Challenge(long challengeId, String name, String imageUrl, ChallengeType challengeType) {
-        this(challengeId, name, 0, imageUrl, challengeType);
+    public Challenge(long challengeId, String name, String imageUrl, boolean isActive, ChallengeType challengeType) {
+        this(challengeId, name, 0, imageUrl, isActive, challengeType);
     }
 
     public boolean isDefeatYesterdayChallenge() {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeAchievementRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeAchievementRepository.java
@@ -23,6 +23,7 @@ public class JooqChallengeAchievementRepository {
                         CHALLENGE.NAME,
                         CHALLENGE.EXPECTED_TIME,
                         CHALLENGE.IMAGE_URL,
+                        CHALLENGE.IS_ACTIVE,
                         CHALLENGE.CHALLENGE_TYPE)
                 .from(CHALLENGE_ACHIEVEMENT)
                 .join(CHALLENGE)
@@ -35,6 +36,7 @@ public class JooqChallengeAchievementRepository {
                                 record.get(CHALLENGE.NAME, String.class),
                                 record.get(CHALLENGE.EXPECTED_TIME, Integer.class),
                                 record.get(CHALLENGE.IMAGE_URL, String.class),
+                                record.get(CHALLENGE.IS_ACTIVE, Boolean.class),
                                 ChallengeType.valueOf(record.get(CHALLENGE.CHALLENGE_TYPE, String.class))),
                         record.get(CHALLENGE_ACHIEVEMENT.SUCCESS_STATUS)));
     }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeRepository.java
@@ -31,6 +31,7 @@ public class JooqChallengeRepository {
                         CHALLENGE.NAME,
                         CHALLENGE.EXPECTED_TIME,
                         CHALLENGE.IMAGE_URL,
+                        CHALLENGE.IS_ACTIVE,
                         CHALLENGE.CHALLENGE_TYPE)
                 .from(CHALLENGE)
                 .where(CHALLENGE.CHALLENGE_TYPE.ne(ChallengeType.DEFEAT_YESTERDAY.toString()))
@@ -41,7 +42,9 @@ public class JooqChallengeRepository {
         return dsl.select(
                         CHALLENGE.ID,
                         CHALLENGE.NAME,
+                        CHALLENGE.EXPECTED_TIME,
                         CHALLENGE.IMAGE_URL,
+                        CHALLENGE.IS_ACTIVE,
                         CHALLENGE.CHALLENGE_TYPE,
                         multiset(select(
                                                 CHALLENGE_GOAL_CONDITION.GOAL_TYPE,
@@ -68,6 +71,7 @@ public class JooqChallengeRepository {
                     record.get(CHALLENGE.NAME, String.class),
                     record.get(CHALLENGE.EXPECTED_TIME, int.class),
                     record.get(CHALLENGE.IMAGE_URL, String.class),
+                    record.get(CHALLENGE.IS_ACTIVE, Boolean.class),
                     record.get(CHALLENGE.CHALLENGE_TYPE, ChallengeType.class));
         }
     }
@@ -87,7 +91,9 @@ public class JooqChallengeRepository {
                     new Challenge(
                             record.get(CHALLENGE.ID, long.class),
                             record.get(CHALLENGE.NAME, String.class),
+                            record.get(CHALLENGE.EXPECTED_TIME, int.class),
                             record.get(CHALLENGE.IMAGE_URL, String.class),
+                            record.get(CHALLENGE.IS_ACTIVE, Boolean.class),
                             record.get(CHALLENGE.CHALLENGE_TYPE, ChallengeType.class)),
                     challengeConditions);
         }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeEntity.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/entity/ChallengeEntity.java
@@ -37,17 +37,21 @@ public class ChallengeEntity {
     @NotNull
     private String imageUrl;
 
+    @NotNull
+    private Boolean isActive;
+
     public static ChallengeEntity from(Challenge challenge) {
         return ChallengeEntity.builder()
                 .id(challenge.challengeId() == 0 ? null : challenge.challengeId())
                 .name(challenge.name())
                 .expectedTime(challenge.expectedTime())
+                .isActive(challenge.isActive())
                 .challengeType(challenge.challengeType())
                 .imageUrl(challenge.imageUrl())
                 .build();
     }
 
     public Challenge toDomain() {
-        return new Challenge(id, name, expectedTime, imageUrl, challengeType);
+        return new Challenge(id, name, expectedTime, imageUrl, isActive, challengeType);
     }
 }

--- a/src/main/resources/db/migration/V5.0.14__add_challenge_is_active.sql
+++ b/src/main/resources/db/migration/V5.0.14__add_challenge_is_active.sql
@@ -1,0 +1,5 @@
+ALTER TABLE challenge
+    ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE challenge
+SET is_active = TRUE;

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -54,12 +54,12 @@ class ChallengeServiceTest {
 
         given(challengeRepository.findAllChallenges())
                 .willReturn(List.of(
-                        new Challenge(1L, "어제보다 1km더 뛰기", "imageUrl", ChallengeType.DEFEAT_YESTERDAY),
-                        new Challenge(2L, "어제보다 5분 더 뛰기", "imageUrl", ChallengeType.DEFEAT_YESTERDAY),
-                        new Challenge(3L, "어제보다 평균 페이스 10초 빠르게", "imageUrl", ChallengeType.DEFEAT_YESTERDAY),
-                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", ChallengeType.TODAY),
-                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", ChallengeType.TODAY),
-                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", ChallengeType.DISTANCE_IN_TIME)));
+                        new Challenge(1L, "어제보다 1km더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+                        new Challenge(2L, "어제보다 5분 더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+                        new Challenge(3L, "어제보다 평균 페이스 10초 빠르게", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
+                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
+                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
 
         // when
         List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
@@ -78,9 +78,9 @@ class ChallengeServiceTest {
 
         given(challengeRepository.findAllIsNotDefeatYesterday())
                 .willReturn(List.of(
-                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", ChallengeType.TODAY),
-                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", ChallengeType.TODAY),
-                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", ChallengeType.DISTANCE_IN_TIME)));
+                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
+                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
+                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
         // when
         List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
 

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -165,8 +165,8 @@ class RunningRecordServiceTest {
                 "end location",
                 RunningEmoji.VERY_GOOD);
 
-        ChallengeAchievement.Status challengeAchievementStatus =
-                new ChallengeAchievement.Status(1L, new Challenge(1L, "challenge", "image", ChallengeType.TODAY), true);
+        ChallengeAchievement.Status challengeAchievementStatus = new ChallengeAchievement.Status(
+                1L, new Challenge(1L, "challenge", "image", true, ChallengeType.TODAY), true);
 
         given(runningRecordRepository.findById(runningRecordId)).willReturn(Optional.of(runningRecord));
         given(challengeAchievementRepository.findByRunningRecordId(runningRecordId))
@@ -204,7 +204,7 @@ class RunningRecordServiceTest {
         RunningRecord expected = createRunningRecord(request, member);
 
         ChallengeWithCondition challengeWithCondition = new ChallengeWithCondition(
-                new Challenge(1L, "challenge", "image", ChallengeType.TODAY),
+                new Challenge(1L, "challenge", "image", true, ChallengeType.TODAY),
                 List.of(new ChallengeCondition(
                         GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 10_000)));
         ChallengeAchievement challengeAchievement =

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementPercentageRepositoryImplTest.java
@@ -75,7 +75,7 @@ class ChallengeAchievementPercentageRepositoryImplTest {
                     RunningEmoji.SOSO)));
         }
 
-        Challenge challenge = new Challenge(1, "name", 60, "imageUrl", ChallengeType.DEFEAT_YESTERDAY);
+        Challenge challenge = new Challenge(1, "name", 60, "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY);
 
         savedChallengeAchievements = new ArrayList<>();
         for (int i = 0; i < 2; i++) {

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeAchievementRepositoryImplTest.java
@@ -72,7 +72,7 @@ public class ChallengeAchievementRepositoryImplTest {
         for (int i = 0; i < 2; i++) {
             savedRunningRecords.add(runningRecordRepository.save(runningRecord));
         }
-        challenge = new Challenge(0, "name", 60, "imageUrl", ChallengeType.DEFEAT_YESTERDAY);
+        challenge = new Challenge(0, "name", 60, "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY);
     }
 
     @DisplayName("ChallengeAchievement 저장시, 성공여부가 true인지 확인")


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #310 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Challenge 테이블에 isActive(현재 사용하는 챌린지인지 나타내는 컬럼)을 추가합니다.
- 기존의 데이터는 isActive를 true로 set하고, 추후 데이터를 변경합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
