### PR TITLE
Feat: 챌린지 목록 조회 리파지토리 추가(업데이트를 위한 조건 값까지 함께 조회)

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/ChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/ChallengeRepository.java
@@ -8,5 +8,7 @@ public interface ChallengeRepository {
 
     List<Challenge> findAllIsNotDefeatYesterday();
 
+    List<ChallengeWithCondition> findAllActiveChallengesWithConditions();
+
     Optional<ChallengeWithCondition> findChallengeWithConditionsByChallengeId(long challengeId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeRepositoryImpl.java
@@ -32,6 +32,11 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
     }
 
     @Override
+    public List<ChallengeWithCondition> findAllActiveChallengesWithConditions() {
+        return jooqChallengeRepository.findAllActiveChallengesWithConditions();
+    }
+
+    @Override
     public Optional<ChallengeWithCondition> findChallengeWithConditionsByChallengeId(long challengeId) {
         return Optional.ofNullable(jooqChallengeRepository.findChallengeWithConditionsBy(challengeId));
     }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #310 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 챌린지 목록을 조회하는 findAllActiveChallengesWithConditions() 함수를 추가합니다.
- 챌린지 성공 여부를 프런트에서 하기 위해 challenge 값 + 챌린지 성공 유무 확인 조건 값을 같이 조회합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
