### PR TITLE
Refactor: 챌린지 조회 시 챌린지 목표 값까지 같이 리턴할 수 있게 수정

### DIFF
--- a/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
+++ b/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
@@ -2,18 +2,8 @@ package com.dnd.runus.application.challenge;
 
 import com.dnd.runus.domain.challenge.ChallengeRepository;
 import com.dnd.runus.domain.running.RunningRecordRepository;
-import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-import java.util.stream.Collectors;
-
-import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 
 @Service
 @RequiredArgsConstructor
@@ -22,29 +12,4 @@ public class ChallengeService {
     private final ChallengeRepository challengeRepository;
 
     private final RunningRecordRepository runningRecordRepository;
-
-    public List<ChallengesResponse> getChallenges(long memberId) {
-        OffsetDateTime todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
-                .atStartOfDay(SERVER_TIMEZONE_ID)
-                .toOffsetDateTime();
-        OffsetDateTime yesterday = todayMidnight.minusDays(1);
-
-        List<ChallengesResponse> challengesResponses;
-        // 어제 기록이 없으면
-        if (!runningRecordRepository.hasByMemberIdAndStartAtBetween(memberId, yesterday, todayMidnight)) {
-            challengesResponses = challengeRepository.findAllIsNotDefeatYesterday().stream()
-                    .map(ChallengesResponse::from)
-                    .collect(Collectors.toList());
-        } else {
-            challengesResponses = challengeRepository.findAllChallenges().stream()
-                    .map(ChallengesResponse::from)
-                    .collect(Collectors.toList());
-        }
-
-        // 랜덤으로 2개 리턴
-        Random randomWithSeed = new Random(todayMidnight.toEpochSecond());
-        Collections.shuffle(challengesResponses, randomWithSeed);
-
-        return challengesResponses.subList(0, 2);
-    }
 }

--- a/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
+++ b/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 
@@ -37,31 +36,25 @@ public class ChallengeService {
         List<ChallengeWithCondition> allChallengesWithConditions =
                 new ArrayList<>(challengeRepository.findAllActiveChallengesWithConditions());
 
-        // 어제 기록이 없으면
+        // 어제 기록이 없으면 어제 기록과 관련된 챌린지 삭제
         if (runningRecords.isEmpty()) {
-            allChallengesWithConditions = allChallengesWithConditions.stream()
+            allChallengesWithConditions.removeIf(
+                    challengeWithCondition -> challengeWithCondition.challenge().isDefeatYesterdayChallenge());
+        } else {
+            // 어제의 기록과 관련된 챌린지면, 챌린지 비교할 값(성공 유무를 위한 목표 값) 재등록
+            allChallengesWithConditions.stream()
                     .filter(challengeWithCondition ->
-                            !challengeWithCondition.challenge().isDefeatYesterdayChallenge())
-                    .collect(Collectors.toList());
+                            challengeWithCondition.challenge().isDefeatYesterdayChallenge())
+                    .forEach(challengeWithCondition -> challengeWithCondition
+                            .conditions()
+                            .forEach(condition -> condition.registerComparisonValue(
+                                    condition.goalMetricType().getActualValue(runningRecords.getFirst()))));
         }
 
         // 랜덤으로 2개 리턴
         Random randomWithSeed = new Random(todayMidnight.toEpochSecond());
         Collections.shuffle(allChallengesWithConditions, randomWithSeed);
-        List<ChallengeWithCondition> randomChallengeWithConditions = allChallengesWithConditions.subList(0, 2);
 
-        if (!runningRecords.isEmpty()) {
-            for (ChallengeWithCondition challenge : randomChallengeWithConditions) {
-                if (challenge.challenge().isDefeatYesterdayChallenge()) {
-                    // 어제의 기록과 관련된 챌린지면, 챌린지 비교할 값(성공 유무를 위한 목표 값) 재등록
-                    challenge
-                            .conditions()
-                            .forEach(condition -> condition.registerComparisonValue(
-                                    condition.goalMetricType().getActualValue(runningRecords.getFirst())));
-                }
-            }
-        }
-
-        return randomChallengeWithConditions;
+        return allChallengesWithConditions.subList(0, 2);
     }
 }

--- a/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
+++ b/src/main/java/com/dnd/runus/application/challenge/ChallengeService.java
@@ -1,9 +1,21 @@
 package com.dnd.runus.application.challenge;
 
 import com.dnd.runus.domain.challenge.ChallengeRepository;
+import com.dnd.runus.domain.challenge.ChallengeWithCondition;
+import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
 
 @Service
 @RequiredArgsConstructor
@@ -12,4 +24,44 @@ public class ChallengeService {
     private final ChallengeRepository challengeRepository;
 
     private final RunningRecordRepository runningRecordRepository;
+
+    public List<ChallengeWithCondition> getChallenges(long memberId) {
+        OffsetDateTime todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
+                .atStartOfDay(SERVER_TIMEZONE_ID)
+                .toOffsetDateTime();
+        OffsetDateTime yesterday = todayMidnight.minusDays(1);
+
+        List<RunningRecord> runningRecords =
+                runningRecordRepository.findByMemberIdAndStartAtBetween(memberId, yesterday, todayMidnight);
+
+        List<ChallengeWithCondition> allChallengesWithConditions =
+                new ArrayList<>(challengeRepository.findAllActiveChallengesWithConditions());
+
+        // 어제 기록이 없으면
+        if (runningRecords.isEmpty()) {
+            allChallengesWithConditions = allChallengesWithConditions.stream()
+                    .filter(challengeWithCondition ->
+                            !challengeWithCondition.challenge().isDefeatYesterdayChallenge())
+                    .collect(Collectors.toList());
+        }
+
+        // 랜덤으로 2개 리턴
+        Random randomWithSeed = new Random(todayMidnight.toEpochSecond());
+        Collections.shuffle(allChallengesWithConditions, randomWithSeed);
+        List<ChallengeWithCondition> randomChallengeWithConditions = allChallengesWithConditions.subList(0, 2);
+
+        if (!runningRecords.isEmpty()) {
+            for (ChallengeWithCondition challenge : randomChallengeWithConditions) {
+                if (challenge.challenge().isDefeatYesterdayChallenge()) {
+                    // 어제의 기록과 관련된 챌린지면, 챌린지 비교할 값(성공 유무를 위한 목표 값) 재등록
+                    challenge
+                            .conditions()
+                            .forEach(condition -> condition.registerComparisonValue(
+                                    condition.goalMetricType().getActualValue(runningRecords.getFirst())));
+                }
+            }
+        }
+
+        return randomChallengeWithConditions;
+    }
 }

--- a/src/main/java/com/dnd/runus/domain/challenge/ChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/ChallengeRepository.java
@@ -4,10 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeRepository {
-    List<Challenge> findAllChallenges();
-
-    List<Challenge> findAllIsNotDefeatYesterday();
-
     List<ChallengeWithCondition> findAllActiveChallengesWithConditions();
 
     Optional<ChallengeWithCondition> findChallengeWithConditionsByChallengeId(long challengeId);

--- a/src/main/java/com/dnd/runus/domain/challenge/GoalMetricType.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/GoalMetricType.java
@@ -1,6 +1,8 @@
 package com.dnd.runus.domain.challenge;
 
 import com.dnd.runus.domain.running.RunningRecord;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -29,5 +31,15 @@ public enum GoalMetricType {
             case DISTANCE -> record.distanceMeter();
             case PACE -> record.averagePace().toSeconds();
         };
+    }
+
+    @JsonCreator
+    public GoalMetricType fromString(String value) {
+        return GoalMetricType.valueOf(value.toUpperCase());
+    }
+
+    @JsonValue
+    public String toJson() {
+        return this.name().toLowerCase();
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeRepositoryImpl.java
@@ -1,11 +1,8 @@
 package com.dnd.runus.infrastructure.persistence.domain.challenge;
 
-import com.dnd.runus.domain.challenge.Challenge;
 import com.dnd.runus.domain.challenge.ChallengeRepository;
 import com.dnd.runus.domain.challenge.ChallengeWithCondition;
 import com.dnd.runus.infrastructure.persistence.jooq.challenge.JooqChallengeRepository;
-import com.dnd.runus.infrastructure.persistence.jpa.challenge.JpaChallengeRepository;
-import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,19 +14,6 @@ import java.util.Optional;
 public class ChallengeRepositoryImpl implements ChallengeRepository {
 
     private final JooqChallengeRepository jooqChallengeRepository;
-    private final JpaChallengeRepository jpaChallengeRepository;
-
-    @Override
-    public List<Challenge> findAllChallenges() {
-        return jpaChallengeRepository.findAll().stream()
-                .map(ChallengeEntity::toDomain)
-                .toList();
-    }
-
-    @Override
-    public List<Challenge> findAllIsNotDefeatYesterday() {
-        return jooqChallengeRepository.findAllIsNotDefeatYesterday();
-    }
 
     @Override
     public List<ChallengeWithCondition> findAllActiveChallengesWithConditions() {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/challenge/JooqChallengeRepository.java
@@ -25,19 +25,6 @@ public class JooqChallengeRepository {
 
     private final DSLContext dsl;
 
-    public List<Challenge> findAllIsNotDefeatYesterday() {
-        return dsl.select(
-                        CHALLENGE.ID,
-                        CHALLENGE.NAME,
-                        CHALLENGE.EXPECTED_TIME,
-                        CHALLENGE.IMAGE_URL,
-                        CHALLENGE.IS_ACTIVE,
-                        CHALLENGE.CHALLENGE_TYPE)
-                .from(CHALLENGE)
-                .where(CHALLENGE.CHALLENGE_TYPE.ne(ChallengeType.DEFEAT_YESTERDAY.toString()))
-                .fetch(new ChallengeMapper());
-    }
-
     public ChallengeWithCondition findChallengeWithConditionsBy(long challengeId) {
         return dsl.select(
                         CHALLENGE.ID,
@@ -84,20 +71,6 @@ public class JooqChallengeRepository {
                 .from(CHALLENGE)
                 .where(CHALLENGE.IS_ACTIVE.eq(true))
                 .fetch(new ChallengeWithConditionMapper());
-    }
-
-    private static class ChallengeMapper implements RecordMapper<Record, Challenge> {
-
-        @Override
-        public Challenge map(Record record) {
-            return new Challenge(
-                    record.get(CHALLENGE.ID, long.class),
-                    record.get(CHALLENGE.NAME, String.class),
-                    record.get(CHALLENGE.EXPECTED_TIME, int.class),
-                    record.get(CHALLENGE.IMAGE_URL, String.class),
-                    record.get(CHALLENGE.IS_ACTIVE, Boolean.class),
-                    record.get(CHALLENGE.CHALLENGE_TYPE, ChallengeType.class));
-        }
     }
 
     private static class ChallengeWithConditionMapper implements RecordMapper<Record, ChallengeWithCondition> {

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeRepository.java
@@ -1,6 +1,0 @@
-package com.dnd.runus.infrastructure.persistence.jpa.challenge;
-
-import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface JpaChallengeRepository extends JpaRepository<ChallengeEntity, Long> {}

--- a/src/main/java/com/dnd/runus/presentation/v1/challenge/ChallengeController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/challenge/ChallengeController.java
@@ -1,19 +1,10 @@
 package com.dnd.runus.presentation.v1.challenge;
 
 import com.dnd.runus.application.challenge.ChallengeService;
-import com.dnd.runus.presentation.annotation.MemberId;
-import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengesResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "오늘의 챌린지")
 @RestController
@@ -21,21 +12,22 @@ import java.util.List;
 @RequestMapping("/api/v1/challenges")
 public class ChallengeController {
 
-    @Autowired
     private final ChallengeService challengeService;
 
-    @Operation(
-            summary = "오늘의 챌린지 리스트 조회",
-            description =
-                    """
-            ## 오늘의 챌린지 리스트를 조회합니다.
-            - 챌린지가 페이스와 관련된 경우 응답의 예상 소요 시간은 0으로 리턴됩니다.
-            - 사용자가 어제의 러닝 기록이 없는 경우 : 어제의 기록과 관련된 챌린지는 제외하고 반환합니다.
-            - 사용자가 어제의 러닝 기록이 있는 경우 : 모든 챌린지를 반환합니다.
-            """)
-    @GetMapping
-    @ResponseStatus(HttpStatus.OK)
-    public List<ChallengesResponse> getChallenges(@MemberId long memberId) {
-        return challengeService.getChallenges(memberId);
-    }
+    //    @Operation(
+    //            summary = "오늘의 챌린지 리스트 조회",
+    //            description =
+    //                    """
+    //            ## 오늘의 챌린지 리스트를 조회합니다.
+    //            - 챌린지가 페이스와 관련된 경우 응답의 예상 소요 시간은 0으로 리턴됩니다.
+    //            - 사용자가 어제의 러닝 기록이 없는 경우 : 어제의 기록과 관련된 챌린지는 제외하고 반환합니다.
+    //            - 사용자가 어제의 러닝 기록이 있는 경우 : 모든 챌린지를 반환합니다., 챌린지 목표 값은 (어제 사용자 기록 + 목표값) 으로 반환됩니다.
+    //            """)
+    //    @GetMapping
+    //    @ResponseStatus(HttpStatus.OK)
+    //    public List<ChallengesResponse> getChallenges(@MemberId long memberId) {
+    //        return challengeService.getChallenges(memberId).stream()
+    //                .map(ChallengesResponse::from)
+    //                .toList();
+    //    }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/challenge/ChallengeController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/challenge/ChallengeController.java
@@ -1,10 +1,18 @@
 package com.dnd.runus.presentation.v1.challenge;
 
 import com.dnd.runus.application.challenge.ChallengeService;
+import com.dnd.runus.presentation.annotation.MemberId;
+import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengesResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "오늘의 챌린지")
 @RestController
@@ -14,20 +22,20 @@ public class ChallengeController {
 
     private final ChallengeService challengeService;
 
-    //    @Operation(
-    //            summary = "오늘의 챌린지 리스트 조회",
-    //            description =
-    //                    """
-    //            ## 오늘의 챌린지 리스트를 조회합니다.
-    //            - 챌린지가 페이스와 관련된 경우 응답의 예상 소요 시간은 0으로 리턴됩니다.
-    //            - 사용자가 어제의 러닝 기록이 없는 경우 : 어제의 기록과 관련된 챌린지는 제외하고 반환합니다.
-    //            - 사용자가 어제의 러닝 기록이 있는 경우 : 모든 챌린지를 반환합니다., 챌린지 목표 값은 (어제 사용자 기록 + 목표값) 으로 반환됩니다.
-    //            """)
-    //    @GetMapping
-    //    @ResponseStatus(HttpStatus.OK)
-    //    public List<ChallengesResponse> getChallenges(@MemberId long memberId) {
-    //        return challengeService.getChallenges(memberId).stream()
-    //                .map(ChallengesResponse::from)
-    //                .toList();
-    //    }
+    @Operation(
+            summary = "오늘의 챌린지 리스트 조회",
+            description =
+                    """
+                ## 오늘의 챌린지 리스트를 조회합니다.
+                - 챌린지가 페이스와 관련된 경우 응답의 예상 소요 시간은 0으로 리턴됩니다.
+                - 사용자가 어제의 러닝 기록이 없는 경우 : 어제의 기록과 관련된 챌린지는 제외하고 반환합니다.
+                - 사용자가 어제의 러닝 기록이 있는 경우 : 모든 챌린지를 반환합니다., 챌린지 목표 값은 (어제 사용자 기록 + 목표값) 으로 반환됩니다.
+                """)
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<ChallengesResponse> getChallenges(@MemberId long memberId) {
+        return challengeService.getChallenges(memberId).stream()
+                .map(ChallengesResponse::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/challenge/dto/response/ChallengesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/challenge/dto/response/ChallengesResponse.java
@@ -27,7 +27,7 @@ public record ChallengesResponse(
     @Schema(description = "챌린지 이미지 URL")
     @NotNull
     String icon,
-    @Schema(description = "챌린지 타입 : distance, time", example = "")
+    @Schema(description = "챌린지 타입 : distance, time", example = "distance")
     GoalMetricType type,
     @Nullable
     @Schema(description = "챌린지 목표 거리(단위:km)", example = "5.0")

--- a/src/main/java/com/dnd/runus/presentation/v1/challenge/dto/response/ChallengesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/challenge/dto/response/ChallengesResponse.java
@@ -1,8 +1,15 @@
 package com.dnd.runus.presentation.v1.challenge.dto.response;
 
 
+import static com.dnd.runus.global.constant.MetricsConversionFactor.METERS_IN_A_KILOMETER;
+
 import com.dnd.runus.domain.challenge.Challenge;
+import com.dnd.runus.domain.challenge.ChallengeCondition;
+import com.dnd.runus.domain.challenge.ChallengeWithCondition;
+import com.dnd.runus.domain.challenge.GoalMetricType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 public record ChallengesResponse(
@@ -19,14 +26,35 @@ public record ChallengesResponse(
     String expectedTime,
     @Schema(description = "챌린지 이미지 URL")
     @NotNull
-    String icon
+    String icon,
+    @Schema(description = "챌린지 타입 : distance, time", example = "")
+    GoalMetricType type,
+    @Nullable
+    @Schema(description = "챌린지 목표 거리(단위:km)", example = "5.0")
+    Double goalDistance,
+    @Nullable
+    @Schema(description = "챌린지 목표 시간(단위:초)")
+    Integer goalTime
 ) {
-    public static ChallengesResponse from(Challenge challenge) {
+    public static ChallengesResponse from(ChallengeWithCondition challengeWithCondition) {
+        Challenge challenge = challengeWithCondition.challenge();
+        List<ChallengeCondition> conditions = challengeWithCondition.conditions();
+
+        //현재는 복합 챌린지(페이스 + 거리 +..)가 없어 getFirst로 가져옵니다.
+        //추후 페이스 관련 챌린지가 추가 되면 변경될 수 있습니다.
+        ChallengeCondition condition = conditions.getFirst();
         return new ChallengesResponse(
             challenge.challengeId(),
             challenge.name(),
             challenge.formatExpectedTime(),
-            challenge.imageUrl()
+            challenge.imageUrl(),
+            condition.goalMetricType(),
+            condition.goalMetricType().equals(GoalMetricType.DISTANCE) ? calMeterToKm(condition.goalValue()) : null,
+            condition.goalMetricType().equals(GoalMetricType.TIME) ? condition.goalValue() : null
         );
+    }
+
+    private static double calMeterToKm(int meter) {
+        return meter / METERS_IN_A_KILOMETER;
     }
 }

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -1,74 +1,183 @@
 package com.dnd.runus.application.challenge;
 
 import com.dnd.runus.domain.challenge.*;
+import com.dnd.runus.domain.common.Coordinate;
+import com.dnd.runus.domain.common.Pace;
+import com.dnd.runus.domain.member.Member;
+import com.dnd.runus.domain.running.RunningRecord;
+import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.global.constant.MemberRole;
+import com.dnd.runus.global.constant.RunningEmoji;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ChallengeServiceTest {
 
-    //    @Mock
-    //    private RunningRecordRepository runningRecordRepository;
-    //
-    //    @Mock
-    //    private ChallengeRepository challengeRepository;
-    //
-    //    @InjectMocks
-    //    private ChallengeService challengeService;
-    //
-    //    private OffsetDateTime todayMidnight;
-    //    private Member member;
-    //
-    //    @BeforeEach
-    //    void setUp() {
-    //        todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
-    //                .atStartOfDay(SERVER_TIMEZONE_ID)
-    //                .toOffsetDateTime();
-    //        member = new Member(MemberRole.USER, "nickname");
-    //    }
-    //
-    //    @DisplayName("어제 기록이 있는경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
-    //    @Test
-    //    void getChallengesWithYesterdayRecords() {
-    //        // given
-    //        given(runningRecordRepository.hasByMemberIdAndStartAtBetween(
-    //                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
-    //                .willReturn(true);
-    //
-    //        given(challengeRepository.findAllChallenges())
-    //                .willReturn(List.of(
-    //                        new Challenge(1L, "어제보다 1km더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
-    //                        new Challenge(2L, "어제보다 5분 더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
-    //                        new Challenge(3L, "어제보다 평균 페이스 10초 빠르게", "imageUrl", true,
-    // ChallengeType.DEFEAT_YESTERDAY),
-    //                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
-    //                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
-    //                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
-    //
-    //        // when
-    //        List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
-    //
-    //        // then
-    //        assertThat(challenges.size()).isEqualTo(2);
-    //    }
-    //
-    //    @DisplayName("어제 기록이 없는 경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
-    //    @Test
-    //    void getChallengesWithoutYesterdayRecords() {
-    //        // given
-    //        given(runningRecordRepository.hasByMemberIdAndStartAtBetween(
-    //                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
-    //                .willReturn(false);
-    //
-    //        given(challengeRepository.findAllIsNotDefeatYesterday())
-    //                .willReturn(List.of(
-    //                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
-    //                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
-    //                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
-    //        // when
-    //        List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
-    //
-    //        // then
-    //        assertThat(challenges.size()).isEqualTo(2);
-    //    }
+    @Mock
+    private RunningRecordRepository runningRecordRepository;
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @InjectMocks
+    private ChallengeService challengeService;
+
+    private OffsetDateTime todayMidnight;
+    private Member member;
+
+    private ChallengeWithCondition challengeWithCondition1;
+    private ChallengeWithCondition challengeWithCondition2;
+    private ChallengeWithCondition challengeWithCondition3;
+    private ChallengeWithCondition challengeWithCondition4;
+
+    @BeforeEach
+    void setUp() {
+        todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
+                .atStartOfDay(SERVER_TIMEZONE_ID)
+                .toOffsetDateTime();
+        member = new Member(MemberRole.USER, "nickname");
+
+        challengeWithCondition1 = new ChallengeWithCondition(
+                new Challenge(1L, "어제보다 1km더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+                List.of(new ChallengeCondition(
+                        GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 1_000)));
+
+        challengeWithCondition2 = new ChallengeWithCondition(
+                new Challenge(2L, "어제보다 5분 더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+                List.of(new ChallengeCondition(GoalMetricType.TIME, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 300)));
+
+        challengeWithCondition3 = new ChallengeWithCondition(
+                new Challenge(3L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
+                List.of(new ChallengeCondition(
+                        GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 5_000)));
+
+        challengeWithCondition4 = new ChallengeWithCondition(
+                new Challenge(4L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
+                List.of(new ChallengeCondition(GoalMetricType.TIME, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 1_800)));
+    }
+
+    @DisplayName("챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
+    @Test
+    void getChallenges_size_is_2() {
+        // given
+        given(challengeRepository.findAllActiveChallengesWithConditions())
+                .willReturn(List.of(
+                        challengeWithCondition1,
+                        challengeWithCondition2,
+                        challengeWithCondition3,
+                        challengeWithCondition4));
+
+        // when
+        List<ChallengeWithCondition> challenges = challengeService.getChallenges(member.memberId());
+
+        // then
+        assertThat(challenges.size()).isEqualTo(2);
+    }
+
+    @DisplayName("어제 기록이 있는경우 챌린지 리스트 조회 : 목표 값(comparisonValue)이 어제 기록 + 챌린지 목표 값이여햐함.")
+    @Test
+    void getChallengesWithYesterdayRecords_checkGoalValue() {
+        // given
+        ZonedDateTime startDate = ZonedDateTime.now().minusDays(1);
+
+        List<RunningRecord> runningRecords = List.of(
+                new RunningRecord(
+                        1L,
+                        member,
+                        3_000,
+                        Duration.ofMinutes(21),
+                        100,
+                        new Pace(7, 0),
+                        startDate,
+                        startDate.plusMinutes(21),
+                        List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                        "start location",
+                        "end location",
+                        RunningEmoji.SOSO),
+                new RunningRecord(
+                        2L,
+                        member,
+                        4_000,
+                        Duration.ofMinutes(28),
+                        100,
+                        new Pace(7, 0),
+                        startDate.plusMinutes(5),
+                        startDate.plusMinutes(5).plusMinutes(28),
+                        List.of(new Coordinate(1, 2, 3), new Coordinate(4, 5, 6)),
+                        "start location",
+                        "end location",
+                        RunningEmoji.SOSO));
+        given(runningRecordRepository.findByMemberIdAndStartAtBetween(
+                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
+                .willReturn(runningRecords);
+
+        given(challengeRepository.findAllActiveChallengesWithConditions())
+                .willReturn(List.of(challengeWithCondition1, challengeWithCondition2));
+
+        // when
+        List<ChallengeWithCondition> challenges = challengeService.getChallenges(member.memberId());
+
+        // then
+        assertThat(challenges.size()).isEqualTo(2);
+
+        ChallengeWithCondition challenge1 = challenges.stream()
+                .filter(challenge -> challenge.challenge().challengeId()
+                        == challengeWithCondition1.challenge().challengeId())
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(challenge1);
+        assertEquals(4_000, challenge1.conditions().getFirst().comparisonValue());
+
+        ChallengeWithCondition challenge2 = challenges.stream()
+                .filter(challenge -> challenge.challenge().challengeId()
+                        == challengeWithCondition2.challenge().challengeId())
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(challenge2);
+        assertEquals((21 * 60) + 300, challenge2.conditions().getFirst().comparisonValue());
+    }
+
+    @DisplayName("어제 기록이 없는 경우 챌린지 리스트 조회 : 어제 기록과 관련되 첼린지가 있으면 안됨")
+    @Test
+    void getChallengesWithoutYesterdayRecords() {
+        // given
+        given(runningRecordRepository.findByMemberIdAndStartAtBetween(
+                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
+                .willReturn(List.of());
+
+        given(challengeRepository.findAllActiveChallengesWithConditions())
+                .willReturn(List.of(
+                        challengeWithCondition1,
+                        challengeWithCondition2,
+                        challengeWithCondition3,
+                        challengeWithCondition4));
+        // when
+        List<ChallengeWithCondition> challenges = challengeService.getChallenges(member.memberId());
+
+        // then
+        assertThat(challenges.size()).isEqualTo(2);
+        assertThat(challenges)
+                .noneMatch(challengeWithCondition ->
+                        challengeWithCondition.challenge().isDefeatYesterdayChallenge());
+    }
 }

--- a/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/challenge/ChallengeServiceTest.java
@@ -1,90 +1,74 @@
 package com.dnd.runus.application.challenge;
 
 import com.dnd.runus.domain.challenge.*;
-import com.dnd.runus.domain.member.Member;
-import com.dnd.runus.domain.running.RunningRecordRepository;
-import com.dnd.runus.global.constant.MemberRole;
-import com.dnd.runus.presentation.v1.challenge.dto.response.ChallengesResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.util.List;
-
-import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE_ID;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ChallengeServiceTest {
 
-    @Mock
-    private RunningRecordRepository runningRecordRepository;
-
-    @Mock
-    private ChallengeRepository challengeRepository;
-
-    @InjectMocks
-    private ChallengeService challengeService;
-
-    private OffsetDateTime todayMidnight;
-    private Member member;
-
-    @BeforeEach
-    void setUp() {
-        todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
-                .atStartOfDay(SERVER_TIMEZONE_ID)
-                .toOffsetDateTime();
-        member = new Member(MemberRole.USER, "nickname");
-    }
-
-    @DisplayName("어제 기록이 있는경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
-    @Test
-    void getChallengesWithYesterdayRecords() {
-        // given
-        given(runningRecordRepository.hasByMemberIdAndStartAtBetween(
-                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
-                .willReturn(true);
-
-        given(challengeRepository.findAllChallenges())
-                .willReturn(List.of(
-                        new Challenge(1L, "어제보다 1km더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
-                        new Challenge(2L, "어제보다 5분 더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
-                        new Challenge(3L, "어제보다 평균 페이스 10초 빠르게", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
-                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
-                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
-                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
-
-        // when
-        List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
-
-        // then
-        assertThat(challenges.size()).isEqualTo(2);
-    }
-
-    @DisplayName("어제 기록이 없는 경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
-    @Test
-    void getChallengesWithoutYesterdayRecords() {
-        // given
-        given(runningRecordRepository.hasByMemberIdAndStartAtBetween(
-                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
-                .willReturn(false);
-
-        given(challengeRepository.findAllIsNotDefeatYesterday())
-                .willReturn(List.of(
-                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
-                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
-                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
-        // when
-        List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
-
-        // then
-        assertThat(challenges.size()).isEqualTo(2);
-    }
+    //    @Mock
+    //    private RunningRecordRepository runningRecordRepository;
+    //
+    //    @Mock
+    //    private ChallengeRepository challengeRepository;
+    //
+    //    @InjectMocks
+    //    private ChallengeService challengeService;
+    //
+    //    private OffsetDateTime todayMidnight;
+    //    private Member member;
+    //
+    //    @BeforeEach
+    //    void setUp() {
+    //        todayMidnight = LocalDate.now(SERVER_TIMEZONE_ID)
+    //                .atStartOfDay(SERVER_TIMEZONE_ID)
+    //                .toOffsetDateTime();
+    //        member = new Member(MemberRole.USER, "nickname");
+    //    }
+    //
+    //    @DisplayName("어제 기록이 있는경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
+    //    @Test
+    //    void getChallengesWithYesterdayRecords() {
+    //        // given
+    //        given(runningRecordRepository.hasByMemberIdAndStartAtBetween(
+    //                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
+    //                .willReturn(true);
+    //
+    //        given(challengeRepository.findAllChallenges())
+    //                .willReturn(List.of(
+    //                        new Challenge(1L, "어제보다 1km더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+    //                        new Challenge(2L, "어제보다 5분 더 뛰기", "imageUrl", true, ChallengeType.DEFEAT_YESTERDAY),
+    //                        new Challenge(3L, "어제보다 평균 페이스 10초 빠르게", "imageUrl", true,
+    // ChallengeType.DEFEAT_YESTERDAY),
+    //                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
+    //                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
+    //                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
+    //
+    //        // when
+    //        List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
+    //
+    //        // then
+    //        assertThat(challenges.size()).isEqualTo(2);
+    //    }
+    //
+    //    @DisplayName("어제 기록이 없는 경우 챌린지 리스트 조회 : 챌린지 리스트 크기가 2이어야함")
+    //    @Test
+    //    void getChallengesWithoutYesterdayRecords() {
+    //        // given
+    //        given(runningRecordRepository.hasByMemberIdAndStartAtBetween(
+    //                        member.memberId(), todayMidnight.minusDays(1), todayMidnight))
+    //                .willReturn(false);
+    //
+    //        given(challengeRepository.findAllIsNotDefeatYesterday())
+    //                .willReturn(List.of(
+    //                        new Challenge(4L, "오늘 5km 뛰기", "imageUrl", true, ChallengeType.TODAY),
+    //                        new Challenge(5L, "오늘 30분 뛰기", "imageUrl", true, ChallengeType.TODAY),
+    //                        new Challenge(6L, "1km 6분안에 뛰기", "imageUrl", true, ChallengeType.DISTANCE_IN_TIME)));
+    //        // when
+    //        List<ChallengesResponse> challenges = challengeService.getChallenges(member.memberId());
+    //
+    //        // then
+    //        assertThat(challenges.size()).isEqualTo(2);
+    //    }
 }

--- a/src/test/java/com/dnd/runus/presentation/v1/challenge/ChallengeControllerTest.java
+++ b/src/test/java/com/dnd/runus/presentation/v1/challenge/ChallengeControllerTest.java
@@ -1,0 +1,84 @@
+package com.dnd.runus.presentation.v1.challenge;
+
+import com.dnd.runus.application.challenge.ChallengeService;
+import com.dnd.runus.domain.challenge.Challenge;
+import com.dnd.runus.domain.challenge.ChallengeCondition;
+import com.dnd.runus.domain.challenge.ChallengeType;
+import com.dnd.runus.domain.challenge.ChallengeWithCondition;
+import com.dnd.runus.domain.challenge.ComparisonType;
+import com.dnd.runus.domain.challenge.GoalMetricType;
+import com.dnd.runus.presentation.config.ControllerTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WithMockUser
+@WebMvcTest(ChallengeController.class)
+class ChallengeControllerTest extends ControllerTestHelper {
+
+    @Autowired
+    private ChallengeController challengecontroller;
+
+    @MockBean
+    private ChallengeService challengeService;
+
+    private long memberId;
+
+    private ChallengeWithCondition challenge1;
+    private ChallengeWithCondition challenge2;
+
+    @BeforeEach
+    void setUp() {
+        setUpMockMvc(challengecontroller);
+
+        challenge1 = new ChallengeWithCondition(
+                new Challenge(1L, "3km 달리기", 21 * 60, "imageUrl", true, ChallengeType.TODAY),
+                List.of(new ChallengeCondition(
+                        GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 3000)));
+
+        challenge2 = new ChallengeWithCondition(
+                new Challenge(2L, "1시간 30분 달리기", 90 * 60, "imageUrl", true, ChallengeType.TODAY),
+                List.of(new ChallengeCondition(GoalMetricType.TIME, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 90 * 60)));
+
+        memberId = 1;
+    }
+
+    @DisplayName("오늘의 챌린지 조회 응답 형식 확인: 반환 문구, 단위 등을 확인합니다.)")
+    @Test
+    void getChallenges() throws Exception {
+        // given
+        given(challengeService.getChallenges(memberId)).willReturn(List.of(challenge1, challenge2));
+
+        // when
+        ResultActions result = mvc.perform(get("/api/v1/challenges").param("memberId", String.valueOf(memberId)));
+
+        // then
+        result.andExpect(jsonPath("$.data[0].challengeId")
+                        .value(challenge1.challenge().challengeId()))
+                .andExpect(
+                        jsonPath("$.data[0].title").value(challenge1.challenge().name()))
+                .andExpect(jsonPath("$.data[0].expectedTime").value("21분"))
+                .andExpect(jsonPath("$.data[0].type").value("distance"))
+                .andExpect(jsonPath("$.data[0].goalDistance").value(3.0))
+                .andExpect(jsonPath("$.data[0].goalTime").doesNotExist())
+                .andExpect(jsonPath("$.data[1].challengeId")
+                        .value(challenge2.challenge().challengeId()))
+                .andExpect(
+                        jsonPath("$.data[1].title").value(challenge2.challenge().name()))
+                .andExpect(jsonPath("$.data[1].expectedTime").value("1시간 30분"))
+                .andExpect(jsonPath("$.data[1].type").value("time"))
+                .andExpect(jsonPath("$.data[1].goalDistance").doesNotExist())
+                .andExpect(jsonPath("$.data[1].goalTime").value(5400));
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #310 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

-  /api/v1/challenges

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Response에 큰 변동 사항이 없어 기존 v1 API를 유지하고, 기존 ReponseDTO에 목표 값과 챌린지 타입 필드를 추가합니다.
- 기존의 service단의 getChallenges 메서드를 다음과 같이 수정합니다.
    - AS-IS: 사용자의 어제의 러닝 기록이 있을 경우, `어제의~` 와 관련된 챌린지도 같이 조회해서 랜덤으로 2개 리턴
    - TO-BE
        - 사용자가 어제의 러닝 기록이 없을 경우, `어제의~` 와 관련된 챌린지를 제외
        - 필터링한 챌린지에서 랜덤으로 2개 추출
        - 랜덤 2개의 챌린지 중 `어제의~` 와 관련된 챌린지가 포합되었을 경우, 사용자의 어제의 러닝기록(첫번째로 조회되는)을 이용해서 챌린지 목표값 리턴할 수 있게 함


## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 머지는 12시에서 새벽사이에 진행 할 예정입니다.
- DB에 페이스 관련 챌린지의 isActive 값을 false로 변경 완료했습니다.