### PR TITLE
Feat: Challenge findById 리파지토리 추가

### DIFF
--- a/src/main/java/com/dnd/runus/domain/challenge/ChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/domain/challenge/ChallengeRepository.java
@@ -7,4 +7,6 @@ public interface ChallengeRepository {
     List<ChallengeWithCondition> findAllActiveChallengesWithConditions();
 
     Optional<ChallengeWithCondition> findChallengeWithConditionsByChallengeId(long challengeId);
+
+    Optional<Challenge> findById(long challengeId);
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/domain/challenge/ChallengeRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.dnd.runus.infrastructure.persistence.domain.challenge;
 
+import com.dnd.runus.domain.challenge.Challenge;
 import com.dnd.runus.domain.challenge.ChallengeRepository;
 import com.dnd.runus.domain.challenge.ChallengeWithCondition;
 import com.dnd.runus.infrastructure.persistence.jooq.challenge.JooqChallengeRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.JpaChallengeRepository;
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +17,7 @@ import java.util.Optional;
 public class ChallengeRepositoryImpl implements ChallengeRepository {
 
     private final JooqChallengeRepository jooqChallengeRepository;
+    private final JpaChallengeRepository jpaChallengeRepository;
 
     @Override
     public List<ChallengeWithCondition> findAllActiveChallengesWithConditions() {
@@ -23,5 +27,10 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
     @Override
     public Optional<ChallengeWithCondition> findChallengeWithConditionsByChallengeId(long challengeId) {
         return Optional.ofNullable(jooqChallengeRepository.findChallengeWithConditionsBy(challengeId));
+    }
+
+    @Override
+    public Optional<Challenge> findById(long challengeId) {
+        return jpaChallengeRepository.findById(challengeId).map(ChallengeEntity::toDomain);
     }
 }

--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jpa/challenge/JpaChallengeRepository.java
@@ -1,0 +1,6 @@
+package com.dnd.runus.infrastructure.persistence.jpa.challenge;
+
+import com.dnd.runus.infrastructure.persistence.jpa.challenge.entity.ChallengeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaChallengeRepository extends JpaRepository<ChallengeEntity, Long> {}


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #319 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 러닝 데이터 저장 시, 챌린지 모드일 경우, 해당 챌린지가 존재하는지 확인하는 확인할 수 있게 findById 리파지토리 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
