### PR TITLE
Fix: 챌린지 목표값이 기본 목표값으로 리턴하는 오류 수정(비교값으로 리턴되어야됨)

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/v1/challenge/dto/response/ChallengesResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/challenge/dto/response/ChallengesResponse.java
@@ -49,8 +49,8 @@ public record ChallengesResponse(
             challenge.formatExpectedTime(),
             challenge.imageUrl(),
             condition.goalMetricType(),
-            condition.goalMetricType().equals(GoalMetricType.DISTANCE) ? calMeterToKm(condition.goalValue()) : null,
-            condition.goalMetricType().equals(GoalMetricType.TIME) ? condition.goalValue() : null
+            condition.goalMetricType().equals(GoalMetricType.DISTANCE) ? calMeterToKm(condition.comparisonValue()) : null,
+            condition.goalMetricType().equals(GoalMetricType.TIME) ? condition.comparisonValue() : null
         );
     }
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- X

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

-  챌린지 조회 시 목표값이 기본 목표값으로 리턴되는 버그를 수정합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
