### PR TITLE
Feat: 챌린지 및 목표 응답 DTO 통합

### DIFF
--- a/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
+++ b/src/main/java/com/dnd/runus/application/running/RunningRecordService.java
@@ -21,7 +21,9 @@ import com.dnd.runus.domain.member.MemberRepository;
 import com.dnd.runus.domain.running.DailyRunningRecordSummary;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.domain.running.RunningRecordRepository;
+import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.NotFoundException;
+import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v1.running.dto.WeeklyRunningRatingDto;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordRequestV1;
 import com.dnd.runus.presentation.v1.running.dto.request.RunningRecordWeeklySummaryType;
@@ -228,6 +230,9 @@ public class RunningRecordService {
                         .findById(request.challengeValues().challengeId())
                         .orElseThrow(() -> new NotFoundException(
                                 Challenge.class, request.challengeValues().challengeId()));
+                if (!challenge.isActive()) {
+                    throw new BusinessException(ErrorType.CHALLENGE_NOT_ACTIVE);
+                }
 
                 ChallengeAchievement challengeAchievement =
                         challengeAchievementRepository.save(new ChallengeAchievement(

--- a/src/main/java/com/dnd/runus/application/running/dto/RunningResultDto.java
+++ b/src/main/java/com/dnd/runus/application/running/dto/RunningResultDto.java
@@ -9,33 +9,38 @@ public record RunningResultDto(
     RunningRecord runningRecord,
     com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode runningAchievementMode,
     ChallengeAchievement challengeAchievement,
-    GoalAchievement goalAchievement
+    GoalAchievement goalAchievement,
+    Double percentage
 ) {
     public static RunningResultDto from(RunningRecord runningRecord) {
         return new RunningResultDto(
             runningRecord,
             com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.NORMAL,
             null,
+            null,
             null
         );
     }
 
     public static RunningResultDto of(RunningRecord runningRecord,
-        ChallengeAchievement challengeAchievement) {
+        ChallengeAchievement challengeAchievement, Double percentage) {
         return new RunningResultDto(
             runningRecord,
             com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE,
             challengeAchievement,
-            null
+            null,
+            percentage
         );
     }
 
-    public static RunningResultDto of(RunningRecord runningRecord, GoalAchievement goalAchievement) {
+    public static RunningResultDto of(RunningRecord runningRecord,
+        GoalAchievement goalAchievement, Double percentage) {
         return new RunningResultDto(
             runningRecord,
             com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.GOAL,
             null,
-            goalAchievement
+            goalAchievement,
+            percentage
         );
     }
 }

--- a/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
+++ b/src/main/java/com/dnd/runus/global/exception/type/ErrorType.java
@@ -50,6 +50,9 @@ public enum ErrorType {
     GOAL_VALUES_REQUIRED_IN_GOAL_MODE(BAD_REQUEST, DEBUG, "RUNNING_005", "개인 목표 모드에서, 개인 목표 달성값은 필수 잆니다."),
     CHALLENGE_VALUES_REQUIRED_IN_CHALLENGE_MODE(BAD_REQUEST, DEBUG, "RUNNING_006", "챌린지 모드에서, 챌린지 달성값은 필수 입니다."),
 
+    // ChallengeErrorType
+    CHALLENGE_NOT_ACTIVE(CONFLICT, DEBUG, "CHALLENGE_001", "해당 챌린지는 현재 활성화된 챌린지가 아닙니다."),
+
     // WeatherErrorType
     WEATHER_API_ERROR(SERVICE_UNAVAILABLE, WARN, "WEATHER_001", "날씨 API 호출 중 오류가 발생했습니다"),
     ;

--- a/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/RunningRecordController.java
@@ -31,7 +31,7 @@ public class RunningRecordController {
     @GetMapping("/{runningRecordId}")
     @Operation(summary = "러닝 기록 상세 조회", description = "RunngingRecord id로 러닝 상세 기록을 조회합니다.")
     public RunningRecordQueryResponse getRunningRecord(@MemberId long memberId, @PathVariable long runningRecordId) {
-        return runningRecordService.getRunningRecord(memberId, runningRecordId);
+        return RunningRecordQueryResponse.from(runningRecordService.getRunningRecord(memberId, runningRecordId));
     }
 
     @GetMapping("monthly-dates")

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/ChallengeDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/ChallengeDto.java
@@ -1,21 +1,31 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
+import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record ChallengeDto(
-        @Schema(description = "챌린지 ID")
-        long challengeId,
-        @NotBlank
-        @Schema(description = "챌린지 이름", example = "오늘 30분 동안 뛰기")
-        String title,
-        @NotBlank
-        @Schema(description = "챌린지 결과 문구", example = "성공했어요!")
-        String subTitle,
-        @NotBlank
-        @Schema(description = "챌린지 아이콘 이미지 URL")
-        String iconUrl,
-        @Schema(description = "챌린지 성공 여부")
-        boolean isSuccess
+    @Schema(description = "챌린지 ID")
+    long challengeId,
+    @NotBlank
+    @Schema(description = "챌린지 이름", example = "오늘 30분 동안 뛰기")
+    String title,
+    @NotBlank
+    @Schema(description = "챌린지 결과 문구", example = "성공했어요!")
+    String subTitle,
+    @NotBlank
+    @Schema(description = "챌린지 아이콘 이미지 URL")
+    String iconUrl,
+    @Schema(description = "챌린지 성공 여부")
+    boolean isSuccess
 ) {
+    public static ChallengeDto from(ChallengeAchievement achievement) {
+        return new ChallengeDto(
+            achievement.challenge().challengeId(),
+            achievement.challenge().name(),
+            achievement.description(),
+            achievement.challenge().imageUrl(),
+            achievement.isSuccess()
+        );
+    }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/GoalResultDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/GoalResultDto.java
@@ -1,17 +1,26 @@
 package com.dnd.runus.presentation.v1.running.dto;
 
+import com.dnd.runus.domain.goalAchievement.GoalAchievement;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record GoalResultDto(
-        @Schema(description = "설정된 목표 제목", example = "2.5km 달성")
-        String title,
-        @Schema(description = "설정된 목표 결과 문구", example = "성공했어요!")
-        String subTitle,
-        @NotBlank
-        @Schema(description = "챌린지 아이콘 이미지 URL")
-        String iconUrl,
-        @Schema(description = "설정된 목표 성공 여부")
-        boolean isSuccess
+    @Schema(description = "설정된 목표 제목", example = "2.5km 달성")
+    String title,
+    @Schema(description = "설정된 목표 결과 문구", example = "성공했어요!")
+    String subTitle,
+    @NotBlank
+    @Schema(description = "챌린지 아이콘 이미지 URL")
+    String iconUrl,
+    @Schema(description = "설정된 목표 성공 여부")
+    boolean isSuccess
 ) {
+    public static GoalResultDto from(GoalAchievement achievement) {
+        return new GoalResultDto(
+            achievement.getTitle(),
+            achievement.getDescription(),
+            achievement.getIconUrl(),
+            achievement.isAchieved()
+        );
+    }
 }

--- a/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
+++ b/src/main/java/com/dnd/runus/presentation/v1/running/dto/response/RunningRecordQueryResponse.java
@@ -1,7 +1,6 @@
 package com.dnd.runus.presentation.v1.running.dto.response;
 
-import com.dnd.runus.domain.challenge.achievement.ChallengeAchievement;
-import com.dnd.runus.domain.goalAchievement.GoalAchievement;
+import com.dnd.runus.application.running.dto.RunningResultDto;
 import com.dnd.runus.domain.running.RunningRecord;
 import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.presentation.v1.running.dto.ChallengeDto;
@@ -32,45 +31,18 @@ public record RunningRecordQueryResponse(
         @NotNull
         RunningRecordMetricsDto runningData
 ) {
-    public static RunningRecordQueryResponse from(RunningRecord runningRecord) {
-        return buildResponse(runningRecord, null, null, RunningAchievementMode.NORMAL);
-    }
 
-    public static RunningRecordQueryResponse of(RunningRecord runningRecord, ChallengeAchievement achievement) {
-        return buildResponse(runningRecord,
-                new ChallengeDto(
-                        achievement.challenge().challengeId(),
-                        achievement.challenge().name(),
-                        achievement.description(),
-                        achievement.challenge().imageUrl(),
-                        achievement.isSuccess()
-                ),
-                null,
-                RunningAchievementMode.CHALLENGE
+    public static RunningRecordQueryResponse from(RunningResultDto runningResult) {
+        return buildResponse(
+            runningResult.runningRecord(),
+            runningResult.challengeAchievement() == null ? null
+                : ChallengeDto.from(runningResult.challengeAchievement()),
+            runningResult.goalAchievement() == null ? null
+                : GoalResultDto.from(runningResult.goalAchievement()),
+            runningResult.runningAchievementMode()
         );
     }
 
-    public static RunningRecordQueryResponse of(RunningRecord runningRecord, GoalAchievement achievement) {
-        return buildResponse(runningRecord,
-                null,
-                new GoalResultDto(
-                        achievement.getTitle(),
-                        achievement.getDescription(),
-                        achievement.getIconUrl(),
-                        achievement.isAchieved()
-                ),
-                RunningAchievementMode.GOAL
-        );
-    }
-
-    public static RunningRecordQueryResponse of(RunningRecord runningRecord, ChallengeAchievement challengeAchievement, GoalAchievement goalAchievement) {
-        if (challengeAchievement != null) {
-            return of(runningRecord, challengeAchievement);
-        } else if (goalAchievement != null) {
-            return of(runningRecord, goalAchievement);
-        }
-        return from(runningRecord);
-    }
 
     private static RunningRecordQueryResponse buildResponse(RunningRecord runningRecord, ChallengeDto challenge, GoalResultDto goal, RunningAchievementMode achievementMode) {
         return new RunningRecordQueryResponse(
@@ -89,4 +61,5 @@ public record RunningRecordQueryResponse(
                 )
         );
     }
+
 }

--- a/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class RunningRecordControllerV2 {
     private final RunningRecordServiceV2 runningRecordService2;
     private final RunningRecordService runningRecordService;
+
+    @GetMapping("/{runningRecordId}")
+    @Operation(summary = "러닝 기록 상세 조회", description = "RunngingRecord id로 러닝 상세 기록을 조회합니다.")
+    public RunningRecordResultResponseV2 getRunningRecord(@MemberId long memberId, @PathVariable long runningRecordId) {
+        return RunningRecordResultResponseV2.from(runningRecordService.getRunningRecord(memberId, runningRecordId));
+    }
 
     @Operation(summary = "이번 달 러닝 기록 조회(홈화면) V2", description = """
     홈화면의 이번 달 러닝 기록을 조회 합니다.<br>

--- a/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
@@ -58,7 +58,8 @@ public class RunningRecordControllerV2 {
         ErrorType.CHALLENGE_VALUES_REQUIRED_IN_CHALLENGE_MODE,
         ErrorType.GOAL_VALUES_REQUIRED_IN_GOAL_MODE,
         ErrorType.GOAL_TIME_AND_DISTANCE_BOTH_EXIST,
-        ErrorType.ROUTE_MUST_HAVE_AT_LEAST_TWO_COORDINATES
+        ErrorType.ROUTE_MUST_HAVE_AT_LEAST_TWO_COORDINATES,
+        ErrorType.CHALLENGE_NOT_ACTIVE
     })
     @PostMapping
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
@@ -54,9 +54,9 @@ public class RunningRecordControllerV2 {
                     """
             러닝 기록을 추가합니다.<br>
             러닝 기록은 시작 시간, 종료 시간, 러닝 평가(emotion), 러닝 데이터 등으로 구성됩니다. <br>
-            챌린지 모드가 normal : challengeValues, goalValues 둘다 null <br>
-            챌린지 모드가 challenge : challengeValues 필수 값 <br>
-            챌린지 모드가 goal : goalValues 필수 값 <br>
+            normal : challengeValues, goalValues 둘다 null <br>
+            challenge : challengeValues 필수 값 <br>
+            goal : goalValues 필수 값 <br>
             러닝 데이터는 위치, 거리, 시간, 칼로리, 평균 페이스, 러닝 경로로 구성됩니다. <br>
             러닝 기록 추가에 성공하면 러닝 기록 ID, 기록 정보를 반환합니다. <br>
             """)

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/AchievementResultDto.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/AchievementResultDto.java
@@ -1,0 +1,23 @@
+package com.dnd.runus.presentation.v2.running.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.lang.Nullable;
+
+/**
+ * 챌린지, 목표 달성 결과 통합 DTO
+ */
+public record AchievementResultDto(
+    @Schema(description = "챌린지 이름 또는 설정된 목표 제목", examples = {"오늘 30분 동안 뛰기", "2.5km 달성"})
+    String title,
+    @Schema(description = "결과 문구", examples = {"정말 대단해요! 잘하셨어요", "아쉬워요. 내일 다시 도전해보세요!"})
+    String subTitle,
+    @Schema(description = "아이콘 이미지 URL")
+    String iconUrl,
+    @Schema(description = "성공 여부")
+    boolean isSuccess,
+    @Nullable
+    @Schema(description = "퍼센테이지 값, V2 이전에 퍼센테이지를 나타낼 수 없는 챌린지일 경우 null값을 리턴합니다.")
+    Double percentage
+) {
+
+}

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/RouteDtoV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/RouteDtoV2.java
@@ -14,7 +14,7 @@ public record RouteDtoV2(
 ) {
     public record Point(double longitude, double latitude) {
         public static Point from(CoordinatePoint point) {
-            return new Point(point.longitude(), point.longitude());
+            return new Point(point.longitude(), point.latitude());
         }
     }
 }

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/request/RunningRecordRequestV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/request/RunningRecordRequestV2.java
@@ -31,7 +31,8 @@ public record RunningRecordRequestV2(
         com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode achievementMode,
         @Schema(description = "챌린지 데이터, 챌린지를 하지 않은 경우 null이나 필드 없이 보내주세요")
         ChallengeAchievedDto challengeValues,
-        @Schema(description = "목표 데이터, 목표를 설정하지 않은 경우 null이나 필드 없이 보내주세요")
+        @Schema(description = "목표 데이터, 목표를 설정하지 않은 경우 null이나 필드 없이 보내주세요. "
+            + "goalDistance(거리) 또는 goalTime(시간)값 둘 중 하나는 null이어야 합니다.")
         GoalAchievedDto goalValues,
         @NotNull
         RunningRecordMetrics runningData

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/request/RunningRecordRequestV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/request/RunningRecordRequestV2.java
@@ -52,7 +52,8 @@ public record RunningRecordRequestV2(
             if(goalValues == null) {
                 throw new BusinessException(ErrorType.GOAL_VALUES_REQUIRED_IN_GOAL_MODE);
             }
-            if (goalValues.goalDistance() == null && goalValues.goalTime() == null) {
+            if ((goalValues.goalDistance() == null && goalValues.goalTime() == null)
+                || (goalValues.goalDistance() != null && goalValues.goalTime() != null)) {
                 throw new BusinessException(ErrorType.GOAL_TIME_AND_DISTANCE_BOTH_EXIST);
             }
         }

--- a/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
+++ b/src/test/java/com/dnd/runus/application/running/RunningRecordServiceTest.java
@@ -47,6 +47,7 @@ import java.util.stream.Stream;
 import static com.dnd.runus.global.constant.TimeConstant.SERVER_TIMEZONE;
 import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -531,10 +532,25 @@ class RunningRecordServiceTest {
     @DisplayName("러닝 결과 저장 V2")
     class RunningRecordAddV2 {
 
+        private RunningRecordRequestV2.RunningRecordMetrics runningRecordMetrics;
+
+        @BeforeEach
+        void beforeEach() {
+            runningRecordMetrics = new RunningRecordRequestV2.RunningRecordMetrics(
+                    Duration.ofSeconds(600),
+                    1000,
+                    500.0,
+                    List.of(
+                            new RouteDtoV2(new RouteDtoV2.Point(0, 0), new RouteDtoV2.Point(1, 1)),
+                            new RouteDtoV2(new RouteDtoV2.Point(2, 2), new RouteDtoV2.Point(3, 3)),
+                            new RouteDtoV2(new RouteDtoV2.Point(4, 4), new RouteDtoV2.Point(5, 5))));
+        }
+
         @Test
         @DisplayName("러닝 결과 저장 : 루트가 순서대로 들어갔는지 확인")
         void addRunningRecordV2_CheckRoute() {
             // given
+            Member member = new Member(MemberRole.USER, "nickname1");
             RunningRecordRequestV2 request = new RunningRecordRequestV2(
                     LocalDateTime.of(2021, 1, 1, 12, 10, 30),
                     LocalDateTime.of(2021, 1, 1, 13, 12, 10),
@@ -544,16 +560,251 @@ class RunningRecordServiceTest {
                     com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.NORMAL,
                     null,
                     null,
-                    new RunningRecordRequestV2.RunningRecordMetrics(
-                            Duration.ofSeconds(10_100),
-                            10_000,
-                            500.0,
-                            List.of(
-                                    new RouteDtoV2(new RouteDtoV2.Point(0, 0), new RouteDtoV2.Point(1, 1)),
-                                    new RouteDtoV2(new RouteDtoV2.Point(2, 2), new RouteDtoV2.Point(3, 3)),
-                                    new RouteDtoV2(new RouteDtoV2.Point(4, 4), new RouteDtoV2.Point(5, 5)))));
+                    runningRecordMetrics);
 
-            List<CoordinatePoint> route = request.runningData().route().stream()
+            RunningRecord expectedRecord = createRecordFrom(member, request);
+
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.save(expectedRecord)).willReturn(expectedRecord);
+
+            // when
+            RunningResultDto response = runningRecordService.addRunningRecordV2(member.memberId(), request);
+
+            // then
+            assertEquals(
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.NORMAL,
+                    response.runningAchievementMode());
+            assertNull(response.challengeAchievement());
+            assertNull(response.goalAchievement());
+            assertNull(response.percentage());
+
+            RunningRecord resultRunning = response.runningRecord();
+            for (int i = 0; i < resultRunning.route().size(); i++) {
+                assertEquals(i, resultRunning.route().get(i).longitude());
+                assertEquals(i, resultRunning.route().get(i).latitude());
+            }
+        }
+
+        @Test
+        @DisplayName("러닝 모드가가 챌린지(어제보다 ~) : 기준이 되는 러닝 기록의 어제 러닝 기록이 없으면 NotFoundException를 발생한다.")
+        void addRunningRecordV2_ChallengeMode_DefeatYesterday_RunningRecordNotFoundError() {
+            // given
+            Member member = new Member(MemberRole.USER, "nickname1");
+            Challenge challenge =
+                    new Challenge(1L, "어제보다 1km 더 달리기", 360, "image url", true, ChallengeType.DEFEAT_YESTERDAY);
+            RunningRecordRequestV2 request = new RunningRecordRequestV2(
+                    LocalDateTime.of(2021, 1, 1, 12, 10, 30),
+                    LocalDateTime.of(2021, 1, 1, 13, 12, 10),
+                    "start location",
+                    "end location",
+                    RunningEmoji.VERY_GOOD,
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE,
+                    new RunningRecordRequestV2.ChallengeAchievedDto(challenge.challengeId(), true),
+                    null,
+                    runningRecordMetrics);
+            RunningRecord expectedRecord = createRecordFrom(member, request);
+            ChallengeAchievement expectedChallengeAchievement = new ChallengeAchievement(
+                    challenge, expectedRecord, request.challengeValues().isSuccess());
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.save(expectedRecord)).willReturn(expectedRecord);
+            given(challengeRepository.findById(request.challengeValues().challengeId()))
+                    .willReturn(Optional.of(challenge));
+            given(challengeAchievementRepository.save(expectedChallengeAchievement))
+                    .willReturn(expectedChallengeAchievement);
+            given(challengeRepository.findChallengeWithConditionsByChallengeId(challenge.challengeId()))
+                    .willReturn(Optional.of(new ChallengeWithCondition(
+                            challenge,
+                            List.of(new ChallengeCondition(
+                                    GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 1000)))));
+            OffsetDateTime runningDate = expectedRecord
+                    .startAt()
+                    .toLocalDate()
+                    .atStartOfDay(expectedRecord.startAt().getZone())
+                    .toOffsetDateTime();
+            given(runningRecordRepository.findByMemberIdAndStartAtBetween(
+                            member.memberId(), runningDate.minusDays(1), runningDate))
+                    .willReturn(List.of());
+
+            // when, then
+            assertThrows(
+                    NotFoundException.class, () -> runningRecordService.addRunningRecordV2(member.memberId(), request));
+        }
+
+        @Test
+        @DisplayName("러닝 모드가 챌린지(어제보다 ~km더 뛰기) : 챌린지 관련 값이 정상적으로 저장되었는지 확인한다.")
+        void addRunningRecordV2_ChallengeMode_DefeatYesterday_Distance() {
+            // given
+            Member member = new Member(MemberRole.USER, "nickname1");
+            Challenge challenge =
+                    new Challenge(1L, "어제보다 1km 더 달리기", 360, "image url", true, ChallengeType.DEFEAT_YESTERDAY);
+            RunningRecordRequestV2 request = new RunningRecordRequestV2(
+                    LocalDateTime.of(2021, 1, 1, 12, 10, 30),
+                    LocalDateTime.of(2021, 1, 1, 13, 12, 10),
+                    "start location",
+                    "end location",
+                    RunningEmoji.VERY_GOOD,
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE,
+                    new RunningRecordRequestV2.ChallengeAchievedDto(challenge.challengeId(), false),
+                    null,
+                    runningRecordMetrics);
+            RunningRecord expectedRecord = createRecordFrom(member, request);
+            ChallengeAchievement expectedChallengeAchievement = new ChallengeAchievement(
+                    challenge, expectedRecord, request.challengeValues().isSuccess());
+            OffsetDateTime runningDate = expectedRecord
+                    .startAt()
+                    .toLocalDate()
+                    .atStartOfDay(expectedRecord.startAt().getZone())
+                    .toOffsetDateTime();
+            RunningRecord yesterdayRunning = RunningRecord.builder()
+                    .member(member)
+                    .startAt(expectedRecord.startAt().minusDays(1))
+                    .endAt(expectedRecord.endAt().minusDays(1))
+                    .emoji(expectedRecord.emoji())
+                    .startLocation(expectedRecord.startLocation())
+                    .endLocation(expectedRecord.endLocation())
+                    .distanceMeter(expectedRecord.distanceMeter())
+                    .duration(expectedRecord.duration())
+                    .calorie(expectedRecord.calorie())
+                    .averagePace(expectedRecord.averagePace())
+                    .route(expectedRecord.route())
+                    .build();
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.save(expectedRecord)).willReturn(expectedRecord);
+            given(challengeRepository.findById(request.challengeValues().challengeId()))
+                    .willReturn(Optional.of(challenge));
+            given(challengeAchievementRepository.save(expectedChallengeAchievement))
+                    .willReturn(expectedChallengeAchievement);
+            given(challengeRepository.findChallengeWithConditionsByChallengeId(challenge.challengeId()))
+                    .willReturn(Optional.of(new ChallengeWithCondition(
+                            challenge,
+                            List.of(new ChallengeCondition(
+                                    GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 1000)))));
+            given(runningRecordRepository.findByMemberIdAndStartAtBetween(
+                            member.memberId(), runningDate.minusDays(1), runningDate))
+                    .willReturn(List.of(yesterdayRunning));
+
+            // when
+            RunningResultDto result = runningRecordService.addRunningRecordV2(member.memberId(), request);
+
+            // then
+            assertEquals(
+                    result.runningAchievementMode(),
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE);
+            assertNotNull(result.challengeAchievement());
+            assertNotNull(result.percentage());
+            assertEquals(0.5, result.percentage());
+        }
+
+        @Test
+        @DisplayName("러닝 모드가가 챌린지(어제보다 ~분 더 뛰기) : 챌린지 관련 값이 정상적으로 저장되었는지 확인한다.")
+        void addRunningRecordV2_ChallengeMode_DefeatYesterday_Time() {
+            // given
+            Member member = new Member(MemberRole.USER, "nickname1");
+            Challenge challenge =
+                    new Challenge(1L, "어제보다 30분 더 달리기", 360, "image url", true, ChallengeType.DEFEAT_YESTERDAY);
+            RunningRecordRequestV2 request = new RunningRecordRequestV2(
+                    LocalDateTime.of(2021, 1, 1, 12, 10, 30),
+                    LocalDateTime.of(2021, 1, 1, 13, 12, 10),
+                    "start location",
+                    "end location",
+                    RunningEmoji.VERY_GOOD,
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE,
+                    new RunningRecordRequestV2.ChallengeAchievedDto(challenge.challengeId(), false),
+                    null,
+                    runningRecordMetrics);
+            RunningRecord expectedRecord = createRecordFrom(member, request);
+            ChallengeAchievement expectedChallengeAchievement = new ChallengeAchievement(
+                    challenge, expectedRecord, request.challengeValues().isSuccess());
+            OffsetDateTime runningDate = expectedRecord
+                    .startAt()
+                    .toLocalDate()
+                    .atStartOfDay(expectedRecord.startAt().getZone())
+                    .toOffsetDateTime();
+            RunningRecord yesterdayRunning = RunningRecord.builder()
+                    .member(member)
+                    .startAt(expectedRecord.startAt().minusDays(1))
+                    .endAt(expectedRecord.endAt().minusDays(1))
+                    .emoji(expectedRecord.emoji())
+                    .startLocation(expectedRecord.startLocation())
+                    .endLocation(expectedRecord.endLocation())
+                    .distanceMeter(expectedRecord.distanceMeter())
+                    .duration(expectedRecord.duration())
+                    .calorie(expectedRecord.calorie())
+                    .averagePace(expectedRecord.averagePace())
+                    .route(expectedRecord.route())
+                    .build();
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.save(expectedRecord)).willReturn(expectedRecord);
+            given(challengeRepository.findById(request.challengeValues().challengeId()))
+                    .willReturn(Optional.of(challenge));
+            given(challengeAchievementRepository.save(expectedChallengeAchievement))
+                    .willReturn(expectedChallengeAchievement);
+            given(challengeRepository.findChallengeWithConditionsByChallengeId(challenge.challengeId()))
+                    .willReturn(Optional.of(new ChallengeWithCondition(
+                            challenge,
+                            List.of(new ChallengeCondition(
+                                    GoalMetricType.TIME, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 1800)))));
+            given(runningRecordRepository.findByMemberIdAndStartAtBetween(
+                            member.memberId(), runningDate.minusDays(1), runningDate))
+                    .willReturn(List.of(yesterdayRunning));
+
+            // when
+            RunningResultDto result = runningRecordService.addRunningRecordV2(member.memberId(), request);
+
+            // then
+            assertEquals(
+                    result.runningAchievementMode(),
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE);
+            assertNotNull(result.challengeAchievement());
+            assertNotNull(result.percentage());
+            assertEquals(0.25, result.percentage());
+        }
+
+        @Test
+        @DisplayName("러닝 모드가가 챌린지이고 챌린지가 성공일 경우 퍼센티이지 값은 1를 리턴한다.")
+        void addRunningRecordV2_ChallengeMode_CheckPercentage() {
+            // given
+            Member member = new Member(MemberRole.USER, "nickname1");
+            Challenge challenge = new Challenge(1L, "500m 달리기", 360, "image url", true, ChallengeType.TODAY);
+            RunningRecordRequestV2 request = new RunningRecordRequestV2(
+                    LocalDateTime.of(2021, 1, 1, 12, 10, 30),
+                    LocalDateTime.of(2021, 1, 1, 13, 12, 10),
+                    "start location",
+                    "end location",
+                    RunningEmoji.VERY_GOOD,
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE,
+                    new RunningRecordRequestV2.ChallengeAchievedDto(challenge.challengeId(), true),
+                    null,
+                    runningRecordMetrics);
+            RunningRecord expectedRecord = createRecordFrom(member, request);
+            ChallengeAchievement expectedChallengeAchievement = new ChallengeAchievement(
+                    challenge, expectedRecord, request.challengeValues().isSuccess());
+            given(memberRepository.findById(member.memberId())).willReturn(Optional.of(member));
+            given(runningRecordRepository.save(expectedRecord)).willReturn(expectedRecord);
+            given(challengeRepository.findById(request.challengeValues().challengeId()))
+                    .willReturn(Optional.of(challenge));
+            given(challengeAchievementRepository.save(expectedChallengeAchievement))
+                    .willReturn(expectedChallengeAchievement);
+            given(challengeRepository.findChallengeWithConditionsByChallengeId(challenge.challengeId()))
+                    .willReturn(Optional.of(new ChallengeWithCondition(
+                            challenge,
+                            List.of(new ChallengeCondition(
+                                    GoalMetricType.DISTANCE, ComparisonType.GREATER_THAN_OR_EQUAL_TO, 500)))));
+
+            // when
+            RunningResultDto result = runningRecordService.addRunningRecordV2(member.memberId(), request);
+
+            // then
+            assertEquals(
+                    result.runningAchievementMode(),
+                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.CHALLENGE);
+            assertNotNull(result.challengeAchievement());
+            assertNotNull(result.percentage());
+            assertEquals(1, result.percentage());
+        }
+
+        private RunningRecord createRecordFrom(Member member, RunningRecordRequestV2 request) {
+            List<CoordinatePoint> coordinatePoints = request.runningData().route().stream()
                     .flatMap(point -> Stream.of(
                             new CoordinatePoint(
                                     point.start().longitude(), point.start().latitude()),
@@ -561,9 +812,7 @@ class RunningRecordServiceTest {
                                     point.end().longitude(), point.end().latitude())))
                     .collect(Collectors.toList());
 
-            Member member = new Member(MemberRole.USER, "nickname1");
-
-            RunningRecord expectedRecord = RunningRecord.builder()
+            return RunningRecord.builder()
                     .member(member)
                     .startAt(request.startAt().atZone(defaultZoneOffset))
                     .endAt(request.endAt().atZone(defaultZoneOffset))
@@ -576,27 +825,8 @@ class RunningRecordServiceTest {
                     .averagePace(Pace.from(
                             request.runningData().distanceMeter(),
                             request.runningData().runningTime()))
-                    .route(route)
+                    .route(coordinatePoints)
                     .build();
-
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(runningRecordRepository.save(expectedRecord)).willReturn(expectedRecord);
-
-            // when
-            RunningResultDto response = runningRecordService.addRunningRecordV2(1L, request);
-
-            // then
-            assertEquals(
-                    com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.NORMAL,
-                    response.runningAchievementMode());
-            assertNull(response.challengeAchievement());
-            assertNull(response.goalAchievement());
-
-            RunningRecord resultRunning = response.runningRecord();
-            for (int i = 0; i < resultRunning.route().size(); i++) {
-                assertEquals(i, resultRunning.route().get(i).longitude());
-                assertEquals(i, resultRunning.route().get(i).latitude());
-            }
         }
     }
 }

--- a/src/test/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2Test.java
+++ b/src/test/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2Test.java
@@ -122,8 +122,7 @@ class RunningRecordControllerV2Test extends ControllerTestHelper {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.emotion").value("very-good"))
                 .andExpect(jsonPath("$.data.achievementMode").value("normal"))
-                .andExpect(jsonPath("$.data.challenge").doesNotExist())
-                .andExpect(jsonPath("$.data.goal").doesNotExist())
+                .andExpect(jsonPath("$.data.achievementResult").doesNotExist())
                 .andExpect(jsonPath("$.data.runningData.averagePace").value("5’30”"))
                 .andExpect(
                         jsonPath("$.data.runningData.route[0].start.longitude").value("1.0"))

--- a/src/test/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2Test.java
+++ b/src/test/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2Test.java
@@ -110,6 +110,7 @@ class RunningRecordControllerV2Test extends ControllerTestHelper {
                         createRunningRecordFrom(request),
                         com.dnd.runus.presentation.v1.running.dto.request.RunningAchievementMode.NORMAL,
                         null,
+                        null,
                         null));
 
         // when


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #317 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

-  X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 러닝 결과의 챌린지 및 목표 달성 관련해서 응답 형식을 통합했습니다.
- percentage값은 사용자가 퍼센티이지를 나타내지 못하는 기록을 조회 할 경우를 null를 리턴하도록 구성했습니다.
- RunningRecordServcie.java의 `calChallengeAchievementPercentage` 는 이후 러닝 기록 조회 시 재 사용할 예정입니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 오늘 안에 챌린지 및 목표 DTO 통합이 완료 되어야 되어서 러닝 결과 조회 V2 API도 같은 PR에 올리게 되었습니다.
- 코드 리뷰하기에 시간이 부족하면, 오늘 먼저 머지 진행하고, 금요일 스크럼에서 이야기 나누는 건 어떠세요?
