### PR TITLE
Fix: 러닝 경로가 빈 리스트일 경우 좌표를 0,0,0인 지점을 저장하게 수정

### DIFF
--- a/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/RunningRecordControllerV2.java
@@ -65,7 +65,6 @@ public class RunningRecordControllerV2 {
         ErrorType.CHALLENGE_VALUES_REQUIRED_IN_CHALLENGE_MODE,
         ErrorType.GOAL_VALUES_REQUIRED_IN_GOAL_MODE,
         ErrorType.GOAL_TIME_AND_DISTANCE_BOTH_EXIST,
-        ErrorType.ROUTE_MUST_HAVE_AT_LEAST_TWO_COORDINATES,
         ErrorType.CHALLENGE_NOT_ACTIVE
     })
     @PostMapping

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/RouteDtoV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/RouteDtoV2.java
@@ -2,6 +2,7 @@ package com.dnd.runus.presentation.v2.running.dto;
 
 
 import com.dnd.runus.domain.common.CoordinatePoint;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * 클라이언트와의 러닝 경로 요청/응답 형식
@@ -9,7 +10,9 @@ import com.dnd.runus.domain.common.CoordinatePoint;
  * @param end 종료 위치
  */
 public record RouteDtoV2(
+    @NotNull
     Point start,
+    @NotNull
     Point end
 ) {
     public record Point(double longitude, double latitude) {

--- a/src/main/java/com/dnd/runus/presentation/v2/running/dto/request/RunningRecordRequestV2.java
+++ b/src/main/java/com/dnd/runus/presentation/v2/running/dto/request/RunningRecordRequestV2.java
@@ -5,6 +5,7 @@ import com.dnd.runus.global.constant.RunningEmoji;
 import com.dnd.runus.global.exception.BusinessException;
 import com.dnd.runus.global.exception.type.ErrorType;
 import com.dnd.runus.presentation.v2.running.dto.RouteDtoV2;
+import com.dnd.runus.presentation.v2.running.dto.RouteDtoV2.Point;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -58,11 +59,6 @@ public record RunningRecordRequestV2(
                 throw new BusinessException(ErrorType.GOAL_TIME_AND_DISTANCE_BOTH_EXIST);
             }
         }
-
-        //러닝 경로 유요성 확인
-        if(runningData.route() == null || runningData.route().size() < 2) {
-            throw new BusinessException(ErrorType.ROUTE_MUST_HAVE_AT_LEAST_TWO_COORDINATES);
-        }
     }
 
     public record ChallengeAchievedDto(
@@ -96,5 +92,14 @@ public record RunningRecordRequestV2(
         @Schema(description = "러닝 경로, 최소, 경로는 최소 2개의 좌표를 가져야합니다.")
         List<RouteDtoV2> route
     ) {
+        public RunningRecordMetrics{
+            //러닝 경로 유요성 확인, 기본으로 null Point 좌표가 들어가게
+            if (route == null || route.isEmpty()) {
+                Point nullIsLandPoint = new Point(0, 0);
+                route = List.of(
+                    new RouteDtoV2(nullIsLandPoint, nullIsLandPoint)
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #327 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 러닝 경로가 null이거나 빈 리스트 이면 (0,0,0)인 지점을 start, end값으로 기본 설정합니다.
- start, end 지점은 null이면 안됩니다.(List<CoordinatePoint> 가 짝수야함.)

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 해당 PR 프런트에서 테스트하기 위해서 임시로 설정했습니다.
- 회의 때 최소 경로 수가 정해 지면, 빈리스트 체크 대신 최소 경로 수보다 작으면  (0,0,0)으로 저장하게 변경합니다.
