### PR TITLE
Fix: 지구한바퀴 코스 저장 시, 달성 가능한 코스 id 조회 오류 수정

### DIFF
--- a/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
+++ b/src/main/java/com/dnd/runus/infrastructure/persistence/jooq/scale/JooqScaleRepository.java
@@ -35,7 +35,10 @@ public class JooqScaleRepository {
                 .fields("id", "cumulative_sum")
                 .as(select(
                                 SCALE.ID,
-                                sum(SCALE.SIZE_METER).over().orderBy(SCALE.ID).cast(int.class))
+                                sum(SCALE.SIZE_METER)
+                                        .over()
+                                        .orderBy(SCALE.INDEX)
+                                        .cast(int.class))
                         .from(SCALE));
 
         return dsl.with(totalDistance)

--- a/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
+++ b/src/test/java/com/dnd/runus/infrastructure/persistence/domain/scale/ScaleRepositoryImplTest.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,9 +51,10 @@ public class ScaleRepositoryImplTest {
     @Autowired
     private ScaleAchievementRepository scaleAchievementRepository;
 
-    private Long scale1Id;
-    private Long scale2Id;
-    private Long scale3Id;
+    private Scale scale1;
+    private Scale scale2;
+    private Scale scale3;
+    private Scale scale4;
 
     @BeforeEach
     void setUp() {
@@ -60,9 +62,9 @@ public class ScaleRepositoryImplTest {
         em.persist(ScaleEntity.from(new Scale(0, "scale1", 1_000_000, 1, "서울(한국)", "도쿄(일본)"))); // 누적 달성 거리 : 1_000_000
         em.persist(ScaleEntity.from(new Scale(0, "scale2", 2_100_000, 2, "도쿄(일본)", "베이징(중국)"))); // 누적 달성 거리 : 3_100_000
         em.persist(
-                ScaleEntity.from(new Scale(0, "scale3", 1_000_000, 3, "베이징(중국)", "타이베이(대만)"))); // 누적 달성 거리 : 4_100_000
+                ScaleEntity.from(new Scale(0, "scale3", 1_000_000, 4, "베이징(중국)", "타이베이(대만)"))); // 누적 달성 거리 : 4_100_000
         em.persist(
-                ScaleEntity.from(new Scale(0, "scale4", 1_000_000, 4, "베이징(중국)", "타이베이(대만)"))); // 누적 달성 거리 : 5_100_000
+                ScaleEntity.from(new Scale(0, "scale4", 1_000_000, 3, "베이징(중국)", "타이베이(대만)"))); // 누적 달성 거리 : 5_100_000
         em.flush();
 
         CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
@@ -70,12 +72,16 @@ public class ScaleRepositoryImplTest {
         Root<ScaleEntity> from = query.from(ScaleEntity.class);
         query.select(from).orderBy(criteriaBuilder.asc(from.get("index")));
 
-        List<Long> idList =
-                em.createQuery(query).getResultStream().map(ScaleEntity::getId).toList();
+        List<Scale> scales = em.createQuery(query)
+                .getResultStream()
+                .sorted(Comparator.comparing(ScaleEntity::getIndex))
+                .map(ScaleEntity::toDomain)
+                .toList();
 
-        scale1Id = idList.get(0);
-        scale2Id = idList.get(1);
-        scale3Id = idList.get(2);
+        scale1 = scales.get(0); // total sum : 1_000_000
+        scale2 = scales.get(1); // total sum : 3_100_000
+        scale4 = scales.get(2); // total sum : 4_100_000
+        scale3 = scales.get(3); // total sum : 5_100_000
     }
 
     @DisplayName("scale_achievement에 기록이 없는 경우 성취 가능한 scale_id를 반환한다.")
@@ -107,8 +113,8 @@ public class ScaleRepositoryImplTest {
         // then
         assertNotNull(achievableScaleIds);
         assertThat(achievableScaleIds.size()).isEqualTo(2);
-        assertTrue(achievableScaleIds.contains(scale1Id));
-        assertTrue(achievableScaleIds.contains(scale2Id));
+        assertTrue(achievableScaleIds.contains(scale1.scaleId()));
+        assertTrue(achievableScaleIds.contains(scale2.scaleId()));
     }
 
     @DisplayName("scale_achievement에 기록이 존재 할 경우, 성취 가능한 scale_id를 반환한다.")
@@ -132,9 +138,42 @@ public class ScaleRepositoryImplTest {
                 RunningEmoji.SOSO));
         // scale1 기록 달성(달성 거리 1_000_000 달성), 현재 누적 거리 : 1_100_000
         scaleAchievementRepository.saveAll(
-                List.of(new ScaleAchievement(savedMember, new Scale(scale1Id), OffsetDateTime.now())));
+                List.of(new ScaleAchievement(savedMember, new Scale(scale1.scaleId()), OffsetDateTime.now())));
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 2; i++) {
+            RunningRecord runningRecord = new RunningRecord(
+                    0,
+                    savedMember,
+                    1_100_000,
+                    Duration.ofHours(12).plusMinutes(23).plusSeconds(56),
+                    1,
+                    new Pace(5, 11),
+                    ZonedDateTime.now(),
+                    ZonedDateTime.now().plusHours(1),
+                    List.of(new CoordinatePoint(1, 2, 3), new CoordinatePoint(4, 5, 6)),
+                    "start location",
+                    "end location",
+                    RunningEmoji.SOSO);
+            runningRecordRepository.save(runningRecord);
+        } // 현재 누넉 거리 : 3_300_000
+
+        // when
+        List<Long> achievableScaleIds = scaleRepository.findAchievableScaleIds(savedMember.memberId());
+
+        // then
+        assertNotNull(achievableScaleIds);
+        assertThat(achievableScaleIds.size()).isEqualTo(1);
+        assertTrue(achievableScaleIds.contains(scale2.scaleId()));
+    }
+
+    @DisplayName("scaled의 id와 index값의 순서가 달를 경우, 성취 가능한 scale_id를 올바르게 반환한다.")
+    @Test
+    void findAchievableScaleIds_diffIDAndIndex() {
+        // given
+        Member savedMember = memberRepository.save(
+                new Member(1L, MemberRole.USER, "nickname", OffsetDateTime.now(), OffsetDateTime.now()));
+
+        for (int i = 0; i < 4; i++) {
             RunningRecord runningRecord = new RunningRecord(
                     0,
                     savedMember,
@@ -156,8 +195,9 @@ public class ScaleRepositoryImplTest {
 
         // then
         assertNotNull(achievableScaleIds);
-        assertThat(achievableScaleIds.size()).isEqualTo(2);
-        assertTrue(achievableScaleIds.contains(scale2Id));
-        assertTrue(achievableScaleIds.contains(scale3Id));
+        assertThat(achievableScaleIds.size()).isEqualTo(3);
+        assertTrue(achievableScaleIds.contains(scale1.scaleId()));
+        assertTrue(achievableScaleIds.contains(scale2.scaleId()));
+        assertTrue(achievableScaleIds.contains(scale4.scaleId()));
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #330 

## 🚀 구현한 API

<!-- 구현한 API를 적어주세요. -->
<!-- 예시: GET /api/v1/users -->

- X

## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 달성 가능한 코스 id 조회 시, 누적합 기준이 id로 되어있습니다.
- 해당 버그 수정을 위해 누적합 기준을 index로 변경합니다.
- id 값과 index 순서가 다른 두 scale 데이터(ex) sale1:{id:1, index:2}, sclae2:{id:2, index:1}) 관련 테스트 코드를 추가합니다.

## 🔍 리뷰 요청/참고 사항

<!-- 리뷰어에게 요청하고 싶은 내용이나 참고할 사항을 적어주세요. -->

- 
